### PR TITLE
Use README.rst instead of README.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include LICENSE.txt
+include LICENSE.rst
 include MANIFEST.in
-include README.txt README.pdf
+include README.rst README.pdf
 include Changelog.rst Changelog.pdf
 include Developer_Manual.rst Developer_Manual.pdf
 include doc/*.1

--- a/README.rst
+++ b/README.rst
@@ -736,7 +736,7 @@ This document is written in REST. That is an ASCII format which is readable as
 ASCII, but used to generate PDF or HTML documents.
 
 You will find the current source under:
-http://nuitka.net/gitweb/?p=Nuitka.git;a=blob_plain;f=README.txt
+http://nuitka.net/gitweb/?p=Nuitka.git;a=blob_plain;f=README.rst
 
 And the current PDF under:
 http://nuitka.net/doc/README.pdf

--- a/debian/docs
+++ b/debian/docs
@@ -1,5 +1,5 @@
 README.pdf
-README.txt
+README.rst
 Developer_Manual.pdf
 Developer_Manual.txt
 changelog

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ override_dh_auto_install:
 	python setup.py install --root=debian/nuitka --install-layout=deb --install-lib=/usr/share/nuitka --install-scripts=/usr/share/nuitka/bin
 
 override_dh_auto_build:
-	rst2pdf README.txt
+	rst2pdf README.rst
 	rst2pdf Developer_Manual.rst
 	cp Changelog.rst changelog
 	cp Developer_Manual.rst Developer_Manual.txt

--- a/misc/make-doc.py
+++ b/misc/make-doc.py
@@ -41,7 +41,7 @@ if "logo" in sys.argv:
         assert 0 == os.system("convert -resize 114x114 misc/Logo/Nuitka-Logo-Symbol.svg ../nikola-site/files/apple-touch-icon-iphone4.png")
 
 
-for document in ( "README.txt", "Developer_Manual.rst", "Changelog.rst" ):
+for document in ( "README.rst", "Developer_Manual.rst", "Changelog.rst" ):
     args = []
 
     if document != "Changelog.rst":

--- a/misc/nuitka.spec
+++ b/misc/nuitka.spec
@@ -53,7 +53,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc README.txt Changelog.rst
+%doc README.rst Changelog.rst
 %{_bindir}/nuitka
 %{_bindir}/nuitka-run
 %{_bindir}/nuitka3


### PR DESCRIPTION
Using README.rst will let both Github and Bitbucket show pretty home page instead of raw rst content. (Just like the fork on my Github)
