### PR TITLE
Developer manual: Fix assignment order in example

### DIFF
--- a/Developer_Manual.rst
+++ b/Developer_Manual.rst
@@ -1461,16 +1461,16 @@ multiple simple assignments instead.
 .. code-block:: python
 
    _tmp = c
-   b = _tmp
    a = _tmp
+   b = _tmp
    del _tmp
 
 
 This is possible, because in Python, if one assignment fails, it can just be
 interrupted, so in fact, they are sequential, and all that is required is to not
-calculate ``c`` twice, which the temporary variable takes care of. Were ``a``
-a more complex expression, e.g. ``a.some_attribute`` that might raise an
-exception, ``b`` would still be assigned.
+calculate ``c`` twice, which the temporary variable takes care of. Were ``b``
+a more complex expression, e.g. ``b.some_attribute`` that might raise an
+exception, ``a`` would still be assigned.
 
 
 Unpacking Assignments


### PR DESCRIPTION
With multiple assignment targets, Python assigns left-to-right.
Fix the example in the documentation to be left-to-right instead of
right-to-left.

Note that Nuitka already handles this correctly as evidenced by running
the following example through nuitka-run:

	i = 0
	a = [0, 0]
	i = a[i] = 1
	print(a)

The example first assigns 1 to i and then 1 to a[1], resulting in the
correct output [0, 1], as opposed to [1, 0] which would be output in a
right-to-left-assigning language.