### PR TITLE
Fix misc. typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@ https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md
       are Travis tests that cover the most important things however, and you are
       welcome to rely on those, but they might not cover enough.
 - [ ] Ideally new features or fixed regressions ought to be covered via new tests.
-- [ ] Ideally new or changed features have documention updates.
+- [ ] Ideally new or changed features have documentation updates.

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -497,7 +497,7 @@ and become possible, what will be 0.6.0 and the next release.
 
 Third, the improved generator performance will be removing a lot of cases,
 where Nuitka wasn't as fast, as its current state not using "C types" yet,
-should allow. It is now consistenly faster than CPython for everything
+should allow. It is now consistently faster than CPython for everything
 related to generators.
 
 Fourth, the fibers were a burden for the debugging and linking of Nuitka on
@@ -518,7 +518,7 @@ Nuitka Release 0.5.32
 
 This release contains substantial new optimization, bug fixes, and already the
 full support for Python 3.7. Among the fixes, the enhanced coroutine work for
-compatiblity with uncompiled ones is most important.
+compatibility with uncompiled ones is most important.
 
 Bug Fixes
 ---------
@@ -593,7 +593,7 @@ Cleanups
   if necessary. Also do not have code for importing a name in the header file
   anymore, not performance relevant.
 
-- Disable Python warnings when running scons. These are particularily given
+- Disable Python warnings when running scons. These are particularly given
   when using a Python debug binary, which is happening when Nuitka is run with
   ``--python-debug`` option and the inline copy of Scons is used.
 
@@ -693,7 +693,7 @@ Bug Fixes
   module variable for annotations used after that which is wrong.
 
 - Fix, some built-in type conversions are allowed to return derived types,
-  but Nuitka assumed the excact type, this affected ``bytes``, ``int``,
+  but Nuitka assumed the exact type, this affected ``bytes``, ``int``,
   ``long``, ``unicode``.
 
 - Standalone: Fix, the ``_socket`` module was insisted on to be found, but
@@ -1232,7 +1232,7 @@ Bug Fixes
 - Standalone: Added some newly discovered missing hidden dependencies of
   extension modules.
 
-- Compatiblity: The name mangling of private names (e.g. ``__var``) in classes
+- Compatibility: The name mangling of private names (e.g. ``__var``) in classes
   was applied to variable names, and function declarations, but not to classes
   yet.
 
@@ -1289,7 +1289,7 @@ New Features
 - Experimental support for running tests against compiled installation with
   ``nose`` and ``py.test``.
 
-- When specifiying what to recurse to, now patterns can be used, e.g. like
+- When specifying what to recurse to, now patterns can be used, e.g. like
   this ``--recurse-not-to=*.tests`` which will skip all tests in submodules
   from compilation.
 
@@ -1346,7 +1346,7 @@ Organizational
 --------------
 
 - Added support for Scons 3.0 and running Scons with Python3.5 or higher. The
-  option to specifiy the Python to use for scons has been renamed to reflect
+  option to specify the Python to use for scons has been renamed to reflect
   that it may also be a Python3 now. Only for Python3.2 to Python3.4 we now
   need another Python installation.
 
@@ -1419,15 +1419,15 @@ Bug Fixes
 - Python3.5: For ``async def`` functions parameter variables could fail to
   properly work with in-place assignments to them. Fixed in 0.5.26.4 already.
 
-- Compatability: Decorators that overload type checks didn't pass the checks
+- Compatibility: Decorators that overload type checks didn't pass the checks
   for compiled types. Now ``isinstance`` and as a result ``inspect`` module
   work fine for them.
 
-- Compatiblity: Fix, imports from ``__init__`` were crashing the compiler. You
+- Compatibility: Fix, imports from ``__init__`` were crashing the compiler. You
   are not supposed to do them, because they duplicate the package code, but
   they work.
 
-- Compatiblity: Fix, the ``super`` built-in on module level was crashing the
+- Compatibility: Fix, the ``super`` built-in on module level was crashing the
   compiler.
 
 - Standalone: For Linux, BSD and MacOS extension modules and shared libraries
@@ -1814,12 +1814,12 @@ Cleanups
 - Now always uses the ``__import__`` built-in node for all kinds of imports
   and directly optimizes and recursion into other modules based on that kind
   of node, instead of a static variant. This removes duplication and some
-  incompatability regarding defaults usage when doing the actual imports at
+  incompatibility regarding defaults usage when doing the actual imports at
   run time.
 
 - Split the expression node bases and mixin classes to a dedicated module,
   moving methods that only belong to expressions outside of the node base,
-  making for a cleaner class hierachy.
+  making for a cleaner class hierarchy.
 
 - Cleaned up the class structure of nodes, added base classes for typical
   compositions, e.g. expression with and without children, computation based
@@ -1832,7 +1832,7 @@ Cleanups
   times beyond program ends, requiring second attempts.
 
 - Code generation for existing supported types, ``PyObject *``, ``PyObject **``,
-  and ``struct Nuitka_CellObject *`` is now done via a C type class hierachy
+  and ``struct Nuitka_CellObject *`` is now done via a C type class hierarchy
   instead of ``elif`` sequences.
 
 - Closure taking is now always done immediately correctly and references are
@@ -2212,7 +2212,7 @@ Tests
 - Enhanced constructs that test generator expressions to more clearly show the
   actual construct cost.
 
-- Added construct tests for the ``sum`` built-in on verious types of ``int``
+- Added construct tests for the ``sum`` built-in on various types of ``int``
   containers, making sure we can do all of those really fast.
 
 Summary
@@ -2371,7 +2371,7 @@ variable versions of certain known shapes seems feasible now.
 
 Then there is also the move towards pure C. This will make the backend
 compilation lighter, but due to using C11, we will not suffer any loss of
-convinience compared to "C-ish". The plan is to use continue to use C++ for
+convenience compared to "C-ish". The plan is to use continue to use C++ for
 compilation for compilers not capable of supporting C11.
 
 The amount of static analysis done in Nuitka is now going to quickly expand,
@@ -2418,7 +2418,7 @@ Bug Fixes
 
 - Standalone: Do not include system specific C libraries in the distribution
   created. This would lead to problems for some configurations on Linux in
-  cases the glibc is no longer compatible with newer oder older kernels.
+  cases the glibc is no longer compatible with newer or older kernels.
   Fixed in 0.5.22.2 already.
 
 - The ``--recurse-directory`` option didn't check with decision mechanisms
@@ -2472,7 +2472,7 @@ Cleanups
 Summary
 -------
 
-This release is the result of a couple of months work, and somwhat means that
+This release is the result of a couple of months work, and somewhat means that
 proper re-loading of cached results is becoming in sight. The reloading of
 modules still fails for some things, and more changes will be needed, but with
 that out of the way, Nuitka's footprint is about to drop and making it then
@@ -2495,12 +2495,12 @@ Bug Fixes
 - Windows: Support for newer MinGW64 was broken by a workaround for older
   MinGW64 versions.
 
-- Compatibility: Added support for the (inofficial) C-Python API
+- Compatibility: Added support for the (unofficial) C-Python API
   ``Py_GetArgcArgv`` that was causing ``prctl`` module to fail loading on ARM
   platforms.
 
 - Compatibility: The proper error message template for complex call arguments
-  is now detected as compile time. There are changes comming, that are already
+  is now detected as compile time. There are changes coming, that are already
   in some pre-releases of CPython.
 
 - Standalone: Wasn't properly ignoring ``Tools`` and other directories in the
@@ -3169,7 +3169,7 @@ Bug Fixes
   `Issue#219 <http://bugs.nuitka.net/issue219>`__.
 
 - Fix, when running under ``wine``, the check for scons binary was fooled by
-  existance of ``/usr/bin/scons``. `Issue#251
+  existence of ``/usr/bin/scons``. `Issue#251
   <http://bugs.nuitka.net/issue251>`__.
 
 New Features
@@ -3548,7 +3548,7 @@ Tests
 - Made the compile library test robust against modules that raise a syntax
   error, checking that Nuitka does the same.
 
-- Refined more tests to be directly execuable with Python3, this is an ongoing
+- Refined more tests to be directly executable with Python3, this is an ongoing
   effort.
 
 Summary
@@ -3789,7 +3789,7 @@ Bug Fixes
       # Inside "x.y" module:
       import x.y.exceptions
 
-- Similarily, the importing of modules with the same name as standard library
+- Similarly, the importing of modules with the same name as standard library
   modules could go wrong. This corrects `Issue#184
   <http://bugs.nuitka.net/issue184>`__.
 
@@ -3955,7 +3955,7 @@ Bug Fixes
 - Fix, generator objects didn't release weak references to them properly. Fixed
   in 0.5.10.2 already.
 
-- Compatiblity: The ``__closure__`` attributes of functions was so far not
+- Compatibility: The ``__closure__`` attributes of functions was so far not
   supported, and rarely missing. Recent changes made it easy to expose, so now
   it was added. This corrects `Issue#45 <http://bugs.nuitka.net/issue45>`__.
 
@@ -6473,7 +6473,7 @@ Bug Fixes
   looks at the name ``exec`` had received. It was ``python`` in all cases, but
   now it depends on the running version, so it propagates.
 
-- Keyword only functions with default values were loosing references to
+- Keyword only functions with default values were losing references to
   defaults.
 
   .. code-block:: python
@@ -8182,7 +8182,7 @@ required to cover ``with`` statements as well. And assignments will become no
 more complex than unpacking from a temporary variable.
 
 For this release, there is only minimal progress on the Python3 front, despite
-the syntax support, which is only miniscule progress. The remaining tasks appear
+the syntax support, which is only minuscule progress. The remaining tasks appear
 all more or less difficult work that I don't want to touch now.
 
 There are still remaining steps, but we can foresee that a release may be done
@@ -9181,7 +9181,7 @@ Bug fixes
   built-in. Fixed in 0.3.12c already.
 
 - The code generated for the ``__import__`` built-in with constant values was
-  doing relative imports only. It needs to attempt relative and absolut
+  doing relative imports only. It needs to attempt relative and absolute
   imports. Fixed in 0.3.12c already.
 
 - The code of packages in "__init__.py" believed it was outside of the package,
@@ -9858,7 +9858,7 @@ Iteration
 - The next on iterator got our own code too, which has simpler code flow,
   because it avoids the double check in case of NULL returned.
 
-- The unpack check got simlar code to the next iterator, it also has simpler
+- The unpack check got similar code to the next iterator, it also has simpler
   code flow now and avoids double checks.
 
 Built-ins
@@ -10492,7 +10492,7 @@ Cleanups
   ``PyObjectTemporary`` in more places in the C++ code, or not using
   ``str.find`` where ``x in y`` is a better choice.
 
-- The node structure got cleaned up towards the direction that assigments always
+- The node structure got cleaned up towards the direction that assignments always
   have an assignment as a child. A function definition, or a class definition,
   are effectively assignments, and in order to not have to treat this as special
   cases everywhere, they need to have assignment targets as child nodes.

--- a/Developer_Manual.rst
+++ b/Developer_Manual.rst
@@ -459,7 +459,7 @@ You can run the "basic" tests like this:
 
 These tests normally give sufficient coverage to assume that a change is
 correct, if these "basic" tests pass. The most important constructs and
-built-ins are excercised.
+built-ins are exercised.
 
 To control the Python version used for testing, you can set the ``PYTHON``
 environment variable to e.g. ``python3.5`` (can also be full path), or simply
@@ -1030,7 +1030,7 @@ SSA form for Nuitka
 The SSA form is critical to how optimization works. The so called trace
 collections builds up traces. These are facts about how this works:
 
-   * Assignments draw from a counter unqiue for the variable, which becomes the
+   * Assignments draw from a counter unique for the variable, which becomes the
      variable version. This happens during tree building phase.
 
    * References are associated to the version of the variable active. This can be
@@ -2222,7 +2222,7 @@ performed, so it becomes:
 
    a = side_effects(f(), g(), 2)
 
-Modelling side effects explicitely has the advantage of recognizing them easily
+Modelling side effects explicitly has the advantage of recognizing them easily
 and allowing to drop the call to the tuple building and checking its length,
 only to release it.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ You can use all Python library modules or and all extension modules freely.
 It translates the Python into a C level program that then uses "libpython" to
 execute in the same way as CPython does. All optimization is aimed at avoiding
 overhead, where it's unnecessary. None is aimed at removing compatibility,
-although slight improvements will occassionally be done, where not every bug
+although slight improvements will occasionally be done, where not every bug
 of standard Python is emulated, e.g. more complete error messages are given,
 but there is a full compatibility mode to disable even that.
 
@@ -84,7 +84,7 @@ Requirements
 
      The created binaries have an ``.exe`` suffix on Windows. On other platforms
      they have no suffix for standalone mode, or ``.bin`` suffix, that you ar
-     free to remove or change, or specifiy with the ``-o`` option.
+     free to remove or change, or specify with the ``-o`` option.
 
      The suffix for acceleration mode is added just to be sure that the original
      script name and the binary name do not ever collide, so we can safely do
@@ -309,7 +309,7 @@ The fastest binaries of ``pystone.exe`` on Windows with 64 bits Python proved
 to be signicantly faster with MinGW64, roughly 20% better score. So it is
 recommended for use over MSVC. Using ``clang-cl.exe`` of Clang7 was faster
 than MSVC, but still significantly slower than MinGW64, and it will be harder
-to use, so it is not recommened.
+to use, so it is not recommended.
 
 On Linux for ``pystone.bin`` the binary produced by ``clang6`` was faster
 than ``gcc-6.3``, but not by a significant margin. Since gcc is more often

--- a/debian/source.lintian-overrides
+++ b/debian/source.lintian-overrides
@@ -1,5 +1,5 @@
 # The build dependency on python-dev stems from the running of tests which
-# will build extensions or programs that embedd CPython. Only the builder
+# will build extensions or programs that embed CPython. Only the builder
 # arch needs to be installed.
 nuitka source: build-depends-on-python-dev-with-no-arch-any
 

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -894,7 +894,7 @@ def main():
 # standalone mode usage of the created library will need it.
 
 # In the future, this will also contain type information for values
-# in the module, so IDEs will use this. Therfore please include it
+# in the module, so IDEs will use this. Therefore please include it
 # when you make software releases of the extension module that it
 # describes.
 

--- a/nuitka/build/include/nuitka/calling.h
+++ b/nuitka/build/include/nuitka/calling.h
@@ -81,7 +81,7 @@ NUITKA_MAY_BE_UNUSED static PyObject *CALL_FUNCTION_WITH_KEYARGS(PyObject *funct
 // Method call variant with no arguments provided at all.
 extern PyObject *CALL_METHOD_NO_ARGS(PyObject *source, PyObject *attribute);
 
-// Convinience wrapper for single argument calls to not require an array
+// Convenience wrapper for single argument calls to not require an array
 // of args. TODO: Maybe fully specialize this too.
 NUITKA_MAY_BE_UNUSED static inline PyObject *CALL_FUNCTION_WITH_SINGLE_ARG(PyObject *called, PyObject *arg) {
     PyObject *args[1] = {arg};

--- a/nuitka/build/static_src/CompiledFrameType.c
+++ b/nuitka/build/static_src/CompiledFrameType.c
@@ -487,7 +487,7 @@ PyTypeObject Nuitka_Frame_Type = {
 void _initCompiledFrameType(void) {
     PyType_Ready(&Nuitka_Frame_Type);
 
-    // These are to be used interchangably. Make sure that's true.
+    // These are to be used interchangeably. Make sure that's true.
     assert(offsetof(struct Nuitka_FrameObject, m_frame.f_localsplus) == offsetof(PyFrameObject, f_localsplus));
 }
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -518,7 +518,7 @@ int main(int argc, char **argv) {
     NUITKA_CANNOT_GET_HERE(main);
 }
 
-/* This is an inofficial API, not available on Windows, but on Linux and others
+/* This is an unofficial API, not available on Windows, but on Linux and others
  * it is exported, and has been used by some code.
  */
 #ifndef _WIN32

--- a/nuitka/codegen/FunctionCodes.py
+++ b/nuitka/codegen/FunctionCodes.py
@@ -91,10 +91,10 @@ def _getFunctionEntryPointIdentifier(function_identifier):
 def getFunctionQualnameObj(owner, context):
     """ Get code to pass to function alike object creation for qualname.
 
-        Qualname for funcions existed for Python3, generators only after
+        Qualname for functions existed for Python3, generators only after
         3.5 and coroutines and asyncgen for as long as they existed.
 
-        If indentical to the name, we do not pass it as a value, but
+        If identical to the name, we do not pass it as a value, but
         NULL instead.
     """
 
@@ -358,7 +358,7 @@ def getDirectFunctionCallCode(to_name, function_identifier, arg_names,
 
     suffix_args = []
 
-    # TODO: Does this still have to be a tripple, we are stopping to use
+    # TODO: Does this still have to be a triple, we are stopping to use
     # versions later in the game.
     for closure_variable, variable_trace in closure_variables:
         variable_declaration = getLocalVariableDeclaration(

--- a/nuitka/codegen/VariableCodes.py
+++ b/nuitka/codegen/VariableCodes.py
@@ -72,7 +72,7 @@ def generateAssignmentVariableCode(statement, emit, context):
         context        = context
     )
 
-    # Ownership of that reference must have been transfered.
+    # Ownership of that reference must have been transferred.
     assert not context.needsCleanup(tmp_name)
 
 

--- a/nuitka/nodes/ExpressionBases.py
+++ b/nuitka/nodes/ExpressionBases.py
@@ -1120,7 +1120,7 @@ class ExpressionChildHavingBase(ExpressionBase):
 
         attr_name = "subnode_" + name
 
-        # Determine old value, and inform it about loosing its parent.
+        # Determine old value, and inform it about losing its parent.
         old_value = getattr(self, attr_name)
 
         assert old_value is not value, value

--- a/nuitka/nodes/LocalsDictNodes.py
+++ b/nuitka/nodes/LocalsDictNodes.py
@@ -375,7 +375,7 @@ class StatementLocalsDictOperationSet(StatementChildHavingBase):
     def getLocalsDictScope(self):
         return self.locals_scope
 
-    # TODO: Child name inconsisten with accessor name.
+    # TODO: Child name inconsistent with accessor name.
     getAssignSource = StatementChildHavingBase.childGetter("value")
 
     def computeStatement(self, trace_collection):
@@ -400,7 +400,7 @@ class StatementLocalsDictOperationSet(StatementChildHavingBase):
                 assert False, (new_result, result)
 
             self.finalize()
-            return result, "new_statements", "Replaced dictionary assigment with temporary variable."
+            return result, "new_statements", "Replaced dictionary assignment with temporary variable."
 
         result, change_tags, change_desc = self.computeStatementSubExpressions(
             trace_collection = trace_collection

--- a/nuitka/nodes/NodeBases.py
+++ b/nuitka/nodes/NodeBases.py
@@ -578,7 +578,7 @@ class ChildrenHavingMixin(object):
 
         attr_name = "subnode_" + name
 
-        # Determine old value, and inform it about loosing its parent.
+        # Determine old value, and inform it about losing its parent.
         old_value = getattr(self, attr_name)
 
         assert old_value is not value, value
@@ -1012,7 +1012,7 @@ class StatementChildHavingBase(StatementBase):
 
         attr_name = "subnode_" + name
 
-        # Determine old value, and inform it about loosing its parent.
+        # Determine old value, and inform it about losing its parent.
         old_value = getattr(self, attr_name)
 
         assert old_value is not value, value

--- a/nuitka/nodes/NodeMetaClasses.py
+++ b/nuitka/nodes/NodeMetaClasses.py
@@ -31,7 +31,7 @@ def _checkBases(name, bases):
     # Avoid duplicate base classes.
     assert len(bases) == len(set(bases)), (name, bases)
 
-    # Insist on mixins being in proper place for inheritence.
+    # Insist on mixins being in proper place for inheritance.
     last_mixin = None
     for base in bases:
         base_name = base.__name__

--- a/nuitka/plugins/standard/PmwPlugin.py
+++ b/nuitka/plugins/standard/PmwPlugin.py
@@ -76,7 +76,7 @@ class NuitkaPluginPmw(NuitkaPluginBase):
                         return 1
             return 0
 
-        # This mimicks the scan the __init__.py does.
+        # This mimics the scan the __init__.py does.
         candidates = []
         for _fullpath, candidate in listDir(pmw_path):
             if _hasLoader(candidate):

--- a/nuitka/tools/testing/measure_construct_performance/__main__.py
+++ b/nuitka/tools/testing/measure_construct_performance/__main__.py
@@ -172,7 +172,7 @@ def main():
 
 
         # We want to compile under the same filename to minimize differences, and
-        # then copy te resulting files afterwards.
+        # then copy the resulting files afterwards.
         shutil.copyfile(test_case_1, os.path.basename(test_case))
 
         subprocess.check_call(nuitka_call)

--- a/nuitka/tree/InternalModule.py
+++ b/nuitka/tree/InternalModule.py
@@ -35,7 +35,7 @@ def once_decorator(func):
     Used for all internal function accesses to become a singleton.
 
     Note: This doesn't much specific anymore, but we are not having
-    this often enough to warrent re-use or generalization.
+    this often enough to warrant re-use or generalization.
 
     """
 

--- a/nuitka/tree/VariableClosure.py
+++ b/nuitka/tree/VariableClosure.py
@@ -178,7 +178,7 @@ class VariableClosureLookupVisitorPhase1(VisitorNoopMixin):
                 # Classes always assign to locals dictionary except for closure
                 # variables taken.
 
-                # TODO: This is loosing the "tolerant" annotation.
+                # TODO: This is losing the "tolerant" annotation.
                 new_node = StatementLocalsDictOperationDel(
                     locals_scope  = provider.getFunctionLocalsScope(),
                     variable_name = variable_name,

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -35,7 +35,7 @@ def areSamePaths(path1, path2):
     """ Are two paths the same.
 
     Same meaning here, that case differences ignored on platforms where
-    that is the norm, and with normalized, and turned absolut paths,
+    that is the norm, and with normalized, and turned absolute paths,
     there is no differences.
     """
 


### PR DESCRIPTION
Found via `codespell -q 3 --skip="./nuitka/build/inline_copy,./tests"`