### PR TITLE
Add command line flag --user-plugin

### DIFF
--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -741,6 +741,13 @@ Show list of all available plugins and exit. Defaults to off."""
 
 parser.add_option_group(plugin_group)
 
+plugin_group.add_option(
+    "--user-plugin",
+    action  = "append",
+    dest    = "user_plugins",
+    default = [],
+    help    = "The file name of user plugin. Can be given multiple times. Default empty."
+)
 
 def parseOptions():
     # First, isolate the first non-option arguments.

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -444,6 +444,13 @@ def getPluginsDisabled():
     return tuple(set(options.plugins_disabled))
 
 
+def getUserPlugins():
+    if not options:
+        return ()
+
+    return tuple(set(options.user_plugins))
+
+
 def shallDetectMissingPlugins():
     return options is not None and options.detect_missing_plugins
 

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -239,7 +239,7 @@ def isObjectAUserPluginBaseClass(obj):
 
 
 def importFilePy3NewWay(filename):
-    import importlib.util
+    import importlib.util   # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
     spec = importlib.util.spec_from_file_location(filename, filename)
     user_plugin_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(user_plugin_module)
@@ -247,8 +247,8 @@ def importFilePy3NewWay(filename):
 
 
 def importFilePy3OldWay(filename):
-    from importlib.machinery import SourceFileLoader
-    return SourceFileLoader(filename, filename).load_module()
+    from importlib.machinery import SourceFileLoader  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
+    return SourceFileLoader(filename, filename).load_module(filename)   # pylint: disable=deprecated-method
 
 
 def importFilePy2(filename):

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -30,6 +30,7 @@ The base class in PluginBase will serve as documentation of available.
 from __future__ import print_function
 
 import os
+from logging import info
 import sys
 
 from nuitka import Options
@@ -274,9 +275,10 @@ def importUserPlugins():
             if not isObjectAUserPluginBaseClass(obj):
                 continue
 
-            plugin_name = getattr(obj, 'plugin_name', None)
+            plugin_name = getattr(obj, "plugin_name", None)
             if plugin_name and plugin_name not in Options.getPluginsDisabled():
                 active_plugin_list.append(obj())
+                info("User plugin '%s' loaded." % plugin_filename)
 
 
 def initPlugins():

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -248,7 +248,7 @@ def importFilePy3NewWay(filename):
 
 def importFilePy3OldWay(filename):
     from importlib.machinery import SourceFileLoader  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
-    return SourceFileLoader(filename, filename).load_module(filename)   # pylint: disable=deprecated-method
+    return SourceFileLoader(filename, filename).load_module(filename)   # pylint: disable=I0021,deprecated-method
 
 
 def importFilePy2(filename):


### PR DESCRIPTION
### What does this PR do?
This PR adds a new command line flag --user-plugin.
This command line flag is used to load user plugins that are not in the Nuitka source code.

### Why was it initiated? Any relevant Issues?
Right now, all plugin source files have to be in the source code of Nuitka.
Adding the flag would allow Nuitka users to write their own plugins.
And the source code of the plugin can be put anywhere.
It's even possible to write per project user plugin.
All UserPluginBase subclasses in the specified file will be imported, unless it's explicitly disabled with flag --plugin-disable

The flag can be used multiple times.

Usage example:
python -m nuitka --module package_test --include-package=package_test --user-plugin my-plugin.py

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
