### PR TITLE
include new user plugins TkinterPlugin, NumpyPlugin

### DIFF
--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -54,6 +54,14 @@ from .standard.PySidePyQtPlugin import (  # isort:skip
     NuitkaPluginDetectorPyQtPySidePlugins,
     NuitkaPluginPyQtPySidePlugins
 )
+from .user.TkinterPlugin import (
+    TkinterPluginDetector,
+    TkinterPlugin
+)
+from .user.NumpyPlugin import (
+    NumpyPluginDetector,
+    NumpyPlugin
+)
 # The standard plug-ins have their list hard-coded here. User plug-ins will
 # be scanned later, TODO.
 
@@ -70,6 +78,8 @@ optional_plugin_classes = (
     (NuitkaPluginPyQtPySidePlugins, NuitkaPluginDetectorPyQtPySidePlugins),
     (NuitkaPluginPylintEclipseAnnotations, NuitkaPluginDetectorPylintEclipseAnnotations),
     (NuitkaPluginPmw, NuitkaPluginDetectorPmw),
+    (TkinterPlugin, TkinterPluginDetector),
+    (NumpyPlugin, NumpyPluginDetector),
 )
 
 plugin_name2plugin_classes = dict(

--- a/nuitka/plugins/user/NumpyPlugin.py
+++ b/nuitka/plugins/user/NumpyPlugin.py
@@ -26,19 +26,12 @@ because these are not detectable by dependency walkers.
 import os
 import shutil
 import sys
-import glob
 import pkgutil
 import re
 from logging import info
 
 from nuitka import Options
-from nuitka.plugins.PluginBase import UserPluginBase, pre_modules, post_modules
-from nuitka.utils import Execution, Utils
-from nuitka.utils.FileOperations import (
-    getFileList,
-    getSubDirectories,
-    removeDirectory
-)
+from nuitka.plugins.PluginBase import UserPluginBase, pre_modules
 
 #------------------------------------------------------------------------------
 # The following code is largely inspired by PyInstaller hook_numpy.core.py
@@ -120,7 +113,7 @@ def get_numpy_core_binaries():
         re_mkllib = re.compile(r'^(?:lib)?mkl\w+\.(?:dll|so|dylib)', re.IGNORECASE)
         dlls_mkl = [f for f in os.listdir(lib_dir) if re_mkllib.match(f)]
         if dlls_mkl:
-            print("MKL libraries found when importing numpy. Adding MKL to binaries")
+            info("MKL libraries found when importing numpy. Adding MKL to binaries")
             binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]
 
     return binaries

--- a/nuitka/plugins/user/NumpyPlugin.py
+++ b/nuitka/plugins/user/NumpyPlugin.py
@@ -31,7 +31,7 @@ import re
 from logging import info
 
 from nuitka import Options
-from nuitka.plugins.PluginBase import UserPluginBase, pre_modules
+from nuitka.plugins.PluginBase import UserPluginBase
 
 #------------------------------------------------------------------------------
 # The following code is largely inspired by PyInstaller hook_numpy.core.py
@@ -99,7 +99,7 @@ def get_numpy_core_binaries():
 
     # look for libraries in numpy package path
     # should already return MKLs in ordinary cases
-    pkg_base, pkg_dir = get_package_paths('numpy.core')
+    _, pkg_dir = get_package_paths('numpy.core')
     re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
     dlls_pkg = [f for f in os.listdir(pkg_dir) if re_anylib.match(f)]
     binaries += [(os.path.join(pkg_dir, f), '.') for f in dlls_pkg]

--- a/nuitka/plugins/user/NumpyPlugin.py
+++ b/nuitka/plugins/user/NumpyPlugin.py
@@ -1,0 +1,195 @@
+#     Copyright 2018, Kay Hayen, mailto:kay.hayen@gmail.com
+#
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+""" User plug-in to make tkinter scripts work well in standalone mode.
+
+To run properly, scripts need copies of the TCL / TK libraries as sub-folders
+of the script's dist folder.
+"""
+
+import os
+import shutil
+import sys
+import glob
+import pkgutil
+import re
+from logging import info
+
+from nuitka import Options
+from nuitka.plugins.PluginBase import NuitkaPluginBase, pre_modules, post_modules
+from nuitka.utils import Execution, Utils
+from nuitka.utils.FileOperations import (
+    getFileList,
+    getSubDirectories,
+    removeDirectory
+)
+
+#------------------------------------------------------------------------------
+# The following code is largely inspired by PyInstaller hook_numpy.core.py
+#------------------------------------------------------------------------------
+# START
+#------------------------------------------------------------------------------
+def remove_suffix(string, suffix):
+    """
+    This function removes the given suffix from a string, if the string
+    does indeed end with the prefix; otherwise, it returns the string
+    unmodified.
+    """
+    # Special case: if suffix is empty, string[:0] returns ''. So, test
+    # for a non-empty suffix.
+    if suffix and string.endswith(suffix):
+        return string[:-len(suffix)]
+    else:
+        return string
+
+def get_module_file_attribute(package):
+    """ Get the absolute path of the module with the passed name.
+    :arg str package: Fully-qualified name of this module.
+    :returns: (str) Absolute path of this module.
+    """
+    loader = pkgutil.find_loader(package)
+    attr = loader.get_filename(package)
+    if not attr:
+        raise ImportError
+    return attr
+
+def get_package_paths(package):
+    """
+    Given a package, return the path to packages stored on this machine
+    and also returns the path to this particular package. For example,
+    if pkg.subpkg lives in /abs/path/to/python/libs, then this function
+    returns (/abs/path/to/python/libs,
+             /abs/path/to/python/libs/pkg/subpkg).
+    """
+    file_attr = get_module_file_attribute(package)
+
+    # package.__file__ = /abs/path/to/package/subpackage/__init__.py.
+    # Search for Python files in /abs/path/to/package/subpackage.
+    # pkg_dir stores this path.
+    pkg_dir = os.path.dirname(file_attr)
+    # When found, remove /abs/path/to/ from the filename.
+    # pkg_base stores this path to be removed.
+    pkg_base = remove_suffix(pkg_dir, package.replace('.', os.sep))
+
+    return pkg_base, pkg_dir
+
+def get_numpy_core_binaries():
+    base_prefix = getattr(sys, 'real_prefix',
+                          getattr(sys, 'base_prefix', sys.prefix)
+                         )
+    base_prefix = os.path.abspath(base_prefix)
+    is_win = sys.platform == "win32"
+
+    binaries = []
+
+    # look for libraries in numpy package path
+    pkg_base, pkg_dir = get_package_paths('numpy.core')
+    re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
+    dlls_pkg = [f for f in os.listdir(pkg_dir) if re_anylib.match(f)]
+    binaries += [(os.path.join(pkg_dir, f), '.') for f in dlls_pkg]
+
+    # look for MKL libraries in pythons lib directory
+    if is_win:
+        lib_dir = os.path.join(base_prefix, "Library", "bin")
+    else:
+        lib_dir = os.path.join(base_prefix, "lib")
+    if os.path.isdir(lib_dir):
+        re_mkllib = re.compile(r'^(?:lib)?mkl\w+\.(?:dll|so|dylib)', re.IGNORECASE)
+        dlls_mkl = [f for f in os.listdir(lib_dir) if re_mkllib.match(f)]
+        if dlls_mkl:
+            print("MKL libraries found when importing numpy. Adding MKL to binaries")
+            binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]
+
+    return binaries
+#------------------------------------------------------------------------------
+# END PyInstaller inspired code
+#------------------------------------------------------------------------------
+
+class NumpyPlugin(NuitkaPluginBase):
+    """ This is for plugging in numpy support correctly.
+    """
+
+    plugin_name = "numpy-plugin"
+
+    def __init__(self):
+        self.bin_copied = False        # indicate binaries copied yet
+
+    @staticmethod
+    def createPreModuleLoadCode(module):
+        """Ensure that module '_dtype_ctypes' is not missing.
+        """
+        code = """from numpy.core import _dtype_ctypes
+        """
+        full_name = module.getFullName()
+        # select when to insert the code
+        if full_name == "numpy":
+            return code, None
+        return None, None
+
+    def onModuleDiscovered(self, module):
+        """Make sure our pre-module code is recorded.
+        """
+
+        full_name = module.getFullName()
+
+        pre_code, reason = self.createPreModuleLoadCode(module)
+        if pre_code:
+            if full_name is pre_modules:
+                sys.exit("Error, conflicting plug-ins for %s" % full_name)
+
+            pre_modules[full_name] = self._createTriggerLoadedModule(
+                module       = module,
+                trigger_name = "-preLoad",
+                code         = pre_code
+            )
+
+    def considerExtraDlls(self, dist_dir, module):
+        """Copy all binaries in 'numpy.core'.
+        """
+        if self.bin_copied is True:         # already done
+            return ()
+
+        info("Now copying binaries from 'numpy.core'.")
+
+        tar_dir  = os.path.join(dist_dir, "numpy", "core")
+
+        binaries = get_numpy_core_binaries()
+        bin_total = len(binaries)
+        mkl_count = 0
+        for f in binaries:
+            core_file = f[0].lower()
+            base_file = os.path.basename(core_file)
+            if base_file.startswith(("mkl", "tbb", "lib", "svml")):
+                mkl_count += 1
+            shutil.copy(core_file, tar_dir)
+        msg = "Done, copied %i 'numpy.core' binaries, thereof %i for MKL."
+        msg = msg % (bin_total, mkl_count)
+        info(msg)
+        self.bin_copied = True
+        return ()
+
+class NumpyPluginDetector(NuitkaPluginBase):
+    plugin_name = "numpy-plugin"
+
+    @staticmethod
+    def isRelevant():
+        return Options.isStandaloneMode()
+
+    def onModuleDiscovered(self, module):
+        full_name = module.getFullName().split(".")
+        if "numpy" in full_name:
+            self.warnUnusedPlugin("numpy support.")

--- a/nuitka/plugins/user/TkinterPlugin.py
+++ b/nuitka/plugins/user/TkinterPlugin.py
@@ -1,0 +1,146 @@
+#     Copyright 2018, Kay Hayen, mailto:kay.hayen@gmail.com
+#
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+""" User plug-in to make tkinter scripts work well in standalone mode.
+
+To run properly, scripts need copies of the TCL / TK libraries as sub-folders
+of the script's dist folder.
+"""
+
+import os
+import shutil
+import sys
+from logging import info
+
+from nuitka import Options
+from nuitka.plugins.PluginBase import NuitkaPluginBase, pre_modules, post_modules
+from nuitka.utils import Execution, Utils
+from nuitka.utils.FileOperations import (
+    getFileList,
+    getSubDirectories,
+    removeDirectory
+)
+
+class TkinterPlugin(NuitkaPluginBase):
+    """ This is for plugging in tkinter TCL / TK libraries and making sure
+    that tkinter requests are directed to them.
+    """
+
+    plugin_name = "tk-plugin"
+
+    def __init__(self):
+        self.tk_dirs = False           # indicate dirs already copied
+
+    @staticmethod
+    def createPreModuleLoadCode(module):
+        """Ensure that tkinter libs are being correctly pointed to
+        **before** a module starts executing.
+        """
+        if os.name != "nt":
+            return None, None
+        code = """import os
+if not os.environ.get("TCL_LIBRARY", None):
+    import sys
+    os.environ["TCL_LIBRARY"] = os.path.join(sys.path[0], "tcl")
+    os.environ["TK_LIBRARY"] = os.path.join(sys.path[0], "tk")
+"""
+        full_name = module.getFullName()
+        # only insert above code for tkinter modules
+        if not "tkinter" in full_name.lower():
+            return None, None
+        return code, None
+
+    def onModuleDiscovered(self, module):
+        """Make sure our pre-module code is recorded.
+        """
+
+        if os.name != "nt":
+            return None, None
+        full_name = module.getFullName()
+
+        pre_code, reason = self.createPreModuleLoadCode(module)
+        if pre_code:
+            if full_name is pre_modules:
+                sys.exit("Error, conflicting plug-ins for %s" % full_name)
+
+            pre_modules[full_name] = self._createTriggerLoadedModule(
+                module       = module,
+                trigger_name = "-preLoad",
+                code         = pre_code
+            )
+
+
+    def considerExtraDlls(self, dist_dir, module):
+        """Copy the TCL / TK directories to binary root directory (dist_dir).
+        We do not tell the caller to copy anything: we are doing it ourselves.
+        Therefore always return an empty tuple.
+
+        Note: this code will work for Windows systems only.
+        """
+        if self.tk_dirs is True:            # already done
+            return ()
+
+        if os.name != "nt":
+            info("tkinter plugin only supported under Windows")
+            self.tk_dirs = True
+            return ()
+
+        if str is bytes:                    # last tk/tcl qualifyers Py 2
+            tk_lq  = "tk8.5"
+            tcl_lq = "tcl8.5"
+        else:                               # last tk/tcl qualifyers Py 3+
+            tk_lq  = "tk8.6"
+            tcl_lq = "tcl8.6"
+
+        # check various locations of the dirs
+        sys_tcl = os.path.join(os.path.dirname(sys.executable), "tcl")
+        tk  = os.path.join(sys_tcl, tk_lq)
+        tcl = os.path.join(sys_tcl, tcl_lq)
+
+        # if this was not the right place, try this:
+        if not (os.path.exists(tk) and os.path.exists(tcl)):
+            tk = os.environ.get("TCL_LIBRARY", None)
+            tcl = os.environ.get("TCL_LIBRARY", None)
+            if not (tk and tcl):
+                info("could not find TK / TCL libraries")
+                sys.exit("aborting standalone generation.")
+
+        info("Starting copy of tkinter libraries.")
+        tar_tk  = os.path.join(dist_dir, "tk")
+        tar_tcl = os.path.join(dist_dir, "tcl")
+        shutil.copytree(tk, tar_tk)
+        shutil.copytree(tcl, tar_tcl)
+        # Definitely do not need the demos and delete them again.
+        # TODO: Anything else?
+        shutil.rmtree(os.path.join(tar_tk, "demos"), ignore_errors=True)
+        info("Finished copying tkinter libraries.")
+        self.tk_dirs = True
+        return ()
+
+
+
+class TkinterPluginDetector(NuitkaPluginBase):
+    plugin_name = "tk-plugin"
+
+    @staticmethod
+    def isRelevant():
+        return Options.isStandaloneMode() and os.name == "nt"
+
+    def onModuleDiscovered(self, module):
+        full_name = module.getFullName().split(".")
+        if full_name[0].lower() == "tkinter":
+            self.warnUnusedPlugin("tkinter support.")

--- a/nuitka/plugins/user/TkinterPlugin.py
+++ b/nuitka/plugins/user/TkinterPlugin.py
@@ -1,4 +1,4 @@
-#     Copyright 2018, Kay Hayen, mailto:kay.hayen@gmail.com
+#     Copyright 2019, Jorj McKie, mailto:lorj.x.mckie@outlook.de
 #
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and
 #     integrates with CPython, but also works on its own.
@@ -19,6 +19,8 @@
 
 To run properly, scripts need copies of the TCL / TK libraries as sub-folders
 of the script's dist folder.
+The script's tkinter requests must be re-directed to these library copies.
+For this, we set the appropriate os.environ keys to the new locations.
 """
 
 import os
@@ -27,7 +29,7 @@ import sys
 from logging import info
 
 from nuitka import Options
-from nuitka.plugins.PluginBase import NuitkaPluginBase, pre_modules, post_modules
+from nuitka.plugins.PluginBase import UserPluginBase, pre_modules, post_modules
 from nuitka.utils import Execution, Utils
 from nuitka.utils.FileOperations import (
     getFileList,
@@ -35,41 +37,45 @@ from nuitka.utils.FileOperations import (
     removeDirectory
 )
 
-class TkinterPlugin(NuitkaPluginBase):
-    """ This is for plugging in tkinter TCL / TK libraries and making sure
-    that tkinter requests are directed to them.
+class TkinterPlugin(UserPluginBase):
+    """ This is for copying tkinter's TCL/TK libraries and making sure
+    that requests are directed to these copies.
     """
 
     plugin_name = "tk-plugin"
 
     def __init__(self):
-        self.tk_dirs = False           # indicate dirs already copied
+        self.files_copied = False      # ensure one-time action
 
     @staticmethod
     def createPreModuleLoadCode(module):
-        """Ensure that tkinter libs are being correctly pointed to
-        **before** a module starts executing.
+        """Pointers to our tkinter libs must be set correctly before
+        a module tries to use them.
         """
-        if os.name != "nt":
+        if os.name != "nt":            # only relevant on Windows
             return None, None
+
+        full_name = module.getFullName()
+
+        # only insert code for tkinter related modules
+        if not "tkinter" in full_name.lower():
+            return None, None
+
         code = """import os
 if not os.environ.get("TCL_LIBRARY", None):
     import sys
     os.environ["TCL_LIBRARY"] = os.path.join(sys.path[0], "tcl")
     os.environ["TK_LIBRARY"] = os.path.join(sys.path[0], "tk")
 """
-        full_name = module.getFullName()
-        # only insert above code for tkinter modules
-        if not "tkinter" in full_name.lower():
-            return None, None
         return code, None
 
     def onModuleDiscovered(self, module):
         """Make sure our pre-module code is recorded.
         """
 
-        if os.name != "nt":
+        if os.name != "nt":            # only relevant on Windows
             return None, None
+
         full_name = module.getFullName()
 
         pre_code, reason = self.createPreModuleLoadCode(module)
@@ -83,7 +89,6 @@ if not os.environ.get("TCL_LIBRARY", None):
                 code         = pre_code
             )
 
-
     def considerExtraDlls(self, dist_dir, module):
         """Copy the TCL / TK directories to binary root directory (dist_dir).
         We do not tell the caller to copy anything: we are doing it ourselves.
@@ -91,13 +96,15 @@ if not os.environ.get("TCL_LIBRARY", None):
 
         Note: this code will work for Windows systems only.
         """
-        if self.tk_dirs is True:            # already done
+        if self.files_copied:
             return ()
 
         if os.name != "nt":
-            info("tkinter plugin only supported under Windows")
-            self.tk_dirs = True
+            info("tkinter plugin supported under Windows only")
+            self.files_copied = True
             return ()
+
+        self.files_copied = True
 
         if str is bytes:                    # last tk/tcl qualifyers Py 2
             tk_lq  = "tk8.5"
@@ -106,34 +113,34 @@ if not os.environ.get("TCL_LIBRARY", None):
             tk_lq  = "tk8.6"
             tcl_lq = "tcl8.6"
 
-        # check various locations of the dirs
+        # check possible locations of the dirs
         sys_tcl = os.path.join(os.path.dirname(sys.executable), "tcl")
         tk  = os.path.join(sys_tcl, tk_lq)
         tcl = os.path.join(sys_tcl, tcl_lq)
 
         # if this was not the right place, try this:
         if not (os.path.exists(tk) and os.path.exists(tcl)):
-            tk = os.environ.get("TCL_LIBRARY", None)
+            tk = os.environ.get("TK_LIBRARY", None)
             tcl = os.environ.get("TCL_LIBRARY", None)
             if not (tk and tcl):
-                info("could not find TK / TCL libraries")
+                info(" Could not find TK / TCL libraries")
                 sys.exit("aborting standalone generation.")
 
-        info("Starting copy of tkinter libraries.")
         tar_tk  = os.path.join(dist_dir, "tk")
         tar_tcl = os.path.join(dist_dir, "tcl")
+
+        info(" Now copying tkinter libraries.")
         shutil.copytree(tk, tar_tk)
         shutil.copytree(tcl, tar_tcl)
-        # Definitely do not need the demos and delete them again.
+
+        # Definitely don't need the demos, so remove them again.
         # TODO: Anything else?
         shutil.rmtree(os.path.join(tar_tk, "demos"), ignore_errors=True)
-        info("Finished copying tkinter libraries.")
-        self.tk_dirs = True
+
+        info(" Finished copying tkinter libraries.")
         return ()
 
-
-
-class TkinterPluginDetector(NuitkaPluginBase):
+class TkinterPluginDetector(UserPluginBase):
     plugin_name = "tk-plugin"
 
     @staticmethod

--- a/nuitka/plugins/user/TkinterPlugin.py
+++ b/nuitka/plugins/user/TkinterPlugin.py
@@ -29,13 +29,7 @@ import sys
 from logging import info
 
 from nuitka import Options
-from nuitka.plugins.PluginBase import UserPluginBase, pre_modules, post_modules
-from nuitka.utils import Execution, Utils
-from nuitka.utils.FileOperations import (
-    getFileList,
-    getSubDirectories,
-    removeDirectory
-)
+from nuitka.plugins.PluginBase import UserPluginBase, pre_modules
 
 class TkinterPlugin(UserPluginBase):
     """ This is for copying tkinter's TCL/TK libraries and making sure
@@ -78,7 +72,7 @@ if not os.environ.get("TCL_LIBRARY", None):
 
         full_name = module.getFullName()
 
-        pre_code, reason = self.createPreModuleLoadCode(module)
+        pre_code, _ = self.createPreModuleLoadCode(module)
         if pre_code:
             if full_name is pre_modules:
                 sys.exit("Error, conflicting plug-ins for %s" % full_name)


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?
Implements two new user plugins for full support of **standalone compiles** of scripts which make use of tkinter and/or numpy.

### Why was it initiated? Any relevant Issues?
The **tkinter** plugin is required on Windows only and aims to resolve issue #137. If the plugin is erroneously used on other platforms, it will disable itself and issue an information message.

The **numpy** plugin takes care of compiling numpy scripts successfully in standalone mode. At least on platforms Windows and Linux, numpy standalone compiles will not lead to a usable executable: you will see an exception about a missing ``_dtype_ctypes`` module. In addition, specifically for ``numpy+MKL`` (Math Kernel Library) installations, binaries will not be copied (correctly) to the script's ``dist`` folder, because they are not detectable by ``Dependency Walker`` and similar tools. The plugin will resolve this by copying relevant binaries from ``numpy/core`` to the ``dist/numpy/core`` folder.

### PR Checklist
- [x] Correct base branch selected? `develop` for new fetures and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
