### PR TITLE
Fixed doc logo size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Changelog.pdf
 Changelog.html
 doc/*.1
 doc/man-*.html
+doxygen-warnings.log

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1231,7 +1231,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = doc/custom.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/doc/custom.css
+++ b/doc/custom.css
@@ -1,0 +1,25 @@
+/**********************************************************************
+ Copyright 2019, Kay Hayen, mailto:kay.hayen@gmail.com,
+                 Batakrishna Sahu, mailto:Batakrishna.Sahu@suiit.ac.in
+
+ Part of "Nuitka", an optimizing Python compiler that is compatible and
+ integrates with CPython, but also works on its own.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License. *
+************************************************************************/
+
+/* Override logo */
+#projectlogo img {
+    max-width: 50px;
+    padding: 5px;
+}


### PR DESCRIPTION
This PR fixes the following

![alt text](https://i.imgur.com/1caxPOq.png "Logo Man Page Nuitka")


- [x] Reduces the size of the Logo in the Docs
- [x] Added doxygen log file to the gitignore  

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?

### Why was it initiated? Any relevant Issues?

### PR Checklist
- [X] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [ ] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
