### PR TITLE
Windows Qt window normal theme

### DIFF
--- a/nuitka/plugins/standard/PySidePyQtPlugin.py
+++ b/nuitka/plugins/standard/PySidePyQtPlugin.py
@@ -137,6 +137,7 @@ if os.path.exists(guess_path):
                 # Seems platforms is required on Windows.
                 if os.name == "nt":
                     plugin_options.add("platforms")
+                    plugin_options.add("styles") # Makes Qt window look much better, than before
 
             info(
                 "Copying Qt plug-ins '%s' to '%s'."


### PR DESCRIPTION
The default Qt window looks just awful. This fix adds a normal windows theme.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?
Adds Qt plugin, which makes window look way better
### Why was it initiated? Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [ ] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

### Before

![Before](https://user-images.githubusercontent.com/9751407/52746038-b1e96e80-2ff1-11e9-98af-7cba0cdf8356.png)

### After

![After](https://user-images.githubusercontent.com/9751407/52746080-c4fc3e80-2ff1-11e9-978c-781bd55c382c.png)
