### PR TITLE
Disable forced Clang compiler mode on FreeBSD/PowerPC

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -138,9 +138,9 @@ uninstalled_python = getBoolOption("uninstalled_python", False)
 # Unstriped mode: Do not remove debug symbols.
 unstripped_mode = getBoolOption("unstripped_mode", False)
 
-# Clang compiler mode, forced on MacOS X and FreeBSD (excluding PowerPC), optional on Linux.
+# Clang compiler mode, forced on macOS and FreeBSD (excluding PowerPC), optional on Linux.
 clang_mode = getBoolOption("clang_mode", False)
-if macosx_target or ("freebsd" in sys.platform and platform.machine() != "powerpc"):
+if macosx_target or ("freebsd" in sys.platform and os.uname()[4] != "powerpc"):
     clang_mode = True
 
 # MinGW compiler mode, optional and interesting to Windows only.

--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -138,9 +138,9 @@ uninstalled_python = getBoolOption("uninstalled_python", False)
 # Unstriped mode: Do not remove debug symbols.
 unstripped_mode = getBoolOption("unstripped_mode", False)
 
-# Clang compiler mode, forced on macOS X and FreeBSD, optional on Linux.
+# Clang compiler mode, forced on MacOS X and FreeBSD (excluding PowerPC), optional on Linux.
 clang_mode = getBoolOption("clang_mode", False)
-if macosx_target or "freebsd" in sys.platform:
+if macosx_target or ("freebsd" in sys.platform and platform.machine() != "powerpc"):
     clang_mode = True
 
 # MinGW compiler mode, optional and interesting to Windows only.


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?

Disable forced Clang compiler mode on FreeBSD/PowerPC

### Why was it initiated? Any relevant Issues?

We (FreeBSD) still use GCC on PowerPC architecture.
This is a [local patch](https://svnweb.freebsd.org/ports/head/devel/nuitka/files/patch-nuitka_build_SingleExe.scons) from FreeBSD ports repository.

### PR Checklist
- [ ] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [ ] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
