### PR TITLE
Fix imports from the collections module

### DIFF
--- a/nuitka/__past__.py
+++ b/nuitka/__past__.py
@@ -94,6 +94,16 @@ except ImportError:
 
         return cls
 
+if str is bytes:
+    from collections import (  # pylint: disable=I0021,import-error,no-name-in-module
+        Iterable,  # @UnresolvedImport @UnusedImport
+        MutableSet,  # @UnresolvedImport @UnusedImport
+    )
+else:
+    from collections.abc import (  # pylint: disable=I0021,import-error,no-name-in-module
+        Iterable,  # @UnresolvedImport @Reimport pylint: disable=I0021,import-error
+        MutableSet,  # @UnresolvedImport @Reimport pylint: disable=I0021,import-error
+    )
 
 if str is bytes:
     intern = intern  # @ReservedAssignment pylint: disable=I0021,undefined-variable
@@ -109,3 +119,5 @@ assert type(xrange) is type, xrange
 assert total_ordering
 assert intern
 assert builtins
+assert Iterable
+assert MutableSet

--- a/nuitka/containers/odict.py
+++ b/nuitka/containers/odict.py
@@ -43,10 +43,11 @@ from nuitka.PythonVersions import python_version
 # pylint: disable=E0611,W0141
 
 try:
-    from collections import OrderedDict
-
     if python_version >= 360:
         OrderedDict = dict
+    else:
+        from collections import OrderedDict
+
 except ImportError:
 
     from itertools import izip, imap

--- a/nuitka/containers/oset.py
+++ b/nuitka/containers/oset.py
@@ -30,11 +30,10 @@ It was originally downloaded from http://code.activestate.com/recipes/576694/
 """
 
 # pylint: disable=W0221,redefined-builtin
+from nuitka.__past__ import MutableSet
 
-import collections
 
-
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]  # sentinel node for doubly linked list

--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -19,7 +19,6 @@
 
 """
 
-import collections
 import distutils.command.build  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
 import distutils.command.install  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
 import os
@@ -29,7 +28,7 @@ import sys
 
 import wheel.bdist_wheel  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
 
-from nuitka.__past__ import unicode  # pylint: disable=I0021,redefined-builtin
+from nuitka.__past__ import Iterable, unicode  # pylint: disable=I0021,redefined-builtin
 
 
 def setuptools_build_hook(dist, keyword, value):
@@ -127,7 +126,7 @@ class build(distutils.command.build.build):
                 _source, value = details
                 if value is None:
                     command.append(option)
-                elif isinstance(value, collections.Iterable) and not isinstance(
+                elif isinstance(value, Iterable) and not isinstance(
                     value, (unicode, bytes, str)
                 ):
                     for val in value:

--- a/tests/basics/Classes32.py
+++ b/tests/basics/Classes32.py
@@ -16,6 +16,11 @@
 #     limitations under the License.
 #
 
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
+
 print("Call order of Python3 metaclasses:")
 
 def a():
@@ -34,8 +39,6 @@ def b():
     print("Called", b)
 
     return B
-
-from collections import OrderedDict
 
 def displayable(dictionary):
     return sorted(dictionary.items())


### PR DESCRIPTION
### What does this PR do?

Fixes such warnings: `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`.

### Why was it initiated? Any relevant Issues?

Despite the fact that it will ease the Python 3.8 compliance, it will specially remove noisy warnings :)

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>