### PR TITLE
Fix non-normpath standard library paths not properly detected as standard library

### DIFF
--- a/nuitka/importing/StandardLibrary.py
+++ b/nuitka/importing/StandardLibrary.py
@@ -104,7 +104,7 @@ def getStandardLibraryPaths():
             stdlib_paths.add(os.path.dirname(_ctypes.__file__))
 
         getStandardLibraryPaths.result = [
-            os.path.normcase(stdlib_path) for stdlib_path in stdlib_paths
+            os.path.normcase(os.path.normpath(stdlib_path)) for stdlib_path in stdlib_paths
         ]
 
     return getStandardLibraryPaths.result
@@ -115,7 +115,7 @@ def isStandardLibraryPath(path):
 
     """
 
-    path = os.path.normcase(path)
+    path = os.path.normcase(os.path.normpath(path))
 
     # In virtualenv, the "site.py" lives in a place that suggests it is not in
     # standard library, although it is.


### PR DESCRIPTION
### What does this PR do?

Use `os.path.normpath()` on paths found by `getStandardLibraryPaths()` and modules paths inside `isStandardLibraryPath()` to resolve paths that contain relative data like `./` or `../`.

### Why was it initiated? Any relevant Issues?

Fixes #264 (using an virtualenv created from an interpreter created by pyenv). See the issue for history and more details.

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
