### PR TITLE
Include OpenGL DLLs for PyQt QML applications

### DIFF
--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -110,7 +110,7 @@ class Plugins(object):
             for extra_dll in plugin.considerExtraDlls(dist_dir, module):
                 if not os.path.isfile(extra_dll[0]):
                     sys.exit(
-                        "Error, attempting to copy plugin determinted filename %r for module %r that is not a file."
+                        "Error, attempting to copy plugin determined filename %r for module %r that is not a file."
                         % (extra_dll[0], module.getFullName())
                     )
 

--- a/nuitka/plugins/standard/PySidePyQtPlugin.py
+++ b/nuitka/plugins/standard/PySidePyQtPlugin.py
@@ -98,6 +98,8 @@ if os.path.exists(guess_path):
         return False
 
     def considerExtraDlls(self, dist_dir, module):
+        # pylint: disable=too-many-branches,too-many-locals
+
         full_name = module.getFullName()
 
         if full_name in ("PyQt4", "PyQt5"):
@@ -217,6 +219,26 @@ if os.path.exists(guess_path):
                     if not os.path.isdir(filename)
                     if not os.path.basename(filename) == "qmldir"
                 ]
+
+                # Also copy required OpenGL DLLs on Windows
+                if os.name == "nt":
+                    qt_bin_dir = os.path.normpath(os.path.join(plugin_dir, "..", "bin"))
+                    opengl_dlls = (
+                        "libegl.dll",
+                        "libglesv2.dll",
+                        "opengl32sw.dll",
+                    )
+
+                    info("Copying OpenGL DLLs to %r" % (dist_dir,))
+
+                    for filename in getFileList(qt_bin_dir):
+                        basename = os.path.basename(filename).lower()
+
+                        if basename in opengl_dlls or basename.startswith("d3dcompiler_"):
+                            shutil.copy(
+                                filename,
+                                os.path.join(dist_dir, basename)
+                            )
 
             return result
 


### PR DESCRIPTION
### What does this PR do?

Inlude OpenGL DLLS on Windows when packaging a PyQt app using QML.
So those new DLLs will be included when using such plugin options:
```
--plugin-enable=qt-plugins=qml
--plugin-enable=qt-plugins=all
```

### Why was it initiated? Any relevant Issues?

Fixes #270.

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.