### PR TITLE
Fix ResourceWarnings when using os.devnull in subprocess calls

### DIFF
--- a/nuitka/tools/quality/pylint/PyLint.py
+++ b/nuitka/tools/quality/pylint/PyLint.py
@@ -40,10 +40,11 @@ def checkVersion():
         sys.exit("Error, pylint is not installed for this interpreter version.")
 
     if pylint_version is None:
-        pylint_version = Execution.check_output(
-            [os.environ["PYTHON"], "-m", "pylint", "--version"],
-            stderr=open(os.devnull, "w"),
-        )
+        with open(os.devnull, "w") as devnull:
+            pylint_version = Execution.check_output(
+                [os.environ["PYTHON"], "-m", "pylint", "--version"],
+                stderr=devnull,
+            )
 
         if str is not bytes:
             pylint_version = pylint_version.decode("utf8")

--- a/nuitka/tools/testing/Common.py
+++ b/nuitka/tools/testing/Common.py
@@ -363,9 +363,10 @@ def checkCompilesNotWithCPython(dirname, filename, search_mode):
 def checkSucceedsWithCPython(filename):
     command = [_python_executable, filename]
 
-    result = subprocess.call(
-        command, stdout=open(os.devnull, "w"), stderr=subprocess.STDOUT
-    )
+    with open(os.devnull, "w") as devnull:
+        result = subprocess.call(
+            command, stdout=devnull, stderr=subprocess.STDOUT
+        )
 
     return result == 0
 
@@ -733,11 +734,12 @@ def checkRuntimeLoadedFilesForOutsideAccesses(loaded_filenames, white_list):
 
 
 def hasModule(module_name):
-    result = subprocess.call(
-        (os.environ["PYTHON"], "-c" "import %s" % module_name),
-        stdout=open(os.devnull, "w"),
-        stderr=subprocess.STDOUT,
-    )
+    with open(os.devnull, "w") as devnull:
+        result = subprocess.call(
+            (os.environ["PYTHON"], "-c" "import %s" % module_name),
+            stdout=devnull,
+            stderr=subprocess.STDOUT,
+        )
 
     return result == 0
 

--- a/nuitka/tools/testing/run_nuitka_tests/__main__.py
+++ b/nuitka/tools/testing/run_nuitka_tests/__main__.py
@@ -526,7 +526,8 @@ def main():
         sys.stdout.flush()
 
         if hide_output:
-            result = subprocess.call(parts, stdout=open(os.devnull, "w"))
+            with open(os.devnull, "w") as devnull:
+                result = subprocess.call(parts, stdout=devnull)
         else:
             result = subprocess.call(parts)
 


### PR DESCRIPTION
### What does this PR do?

Improve the code by ensuring file descriptors are closed after `subprocess` calls.

### Why was it initiated? Any relevant Issues?

To fix noisy warnings.
```shell
▶ ./bin/check-nuitka-with-pylint
Using concrete python 3.6.8 on x86_64
Working on: ['bin', 'nuitka']
./nuitka/tools/testing/Common.py:739: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  stderr=subprocess.STDOUT,
./nuitka/tools/quality/pylint/PyLint.py:45: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  stderr=open(os.devnull, "w"),
Using PyLint version: 2.2.2
```

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.