### PR TITLE
Call to plugins after end of standalone compilations

### DIFF
--- a/Using-Plugin-Options.rst
+++ b/Using-Plugin-Options.rst
@@ -66,7 +66,7 @@ check single option items via convenience method ``self.getPluginOptionBool("val
 
 Remark
 --------
-Obviously, you can recover the original "raw" string by ``raw = "".join(self.getPluginOptions())``.
+Obviously, you can recover the original "raw" string by ``raw = ",".join(self.getPluginOptions())``.
 If your plugin knows which format to expect, it could do something like this: ``my_option_dict = json.loads(raw)``, or
 this: ``my_option_list = raw.split(";")``.
 

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -799,6 +799,8 @@ def main():
 
                 shutil.copy2(source_filename, target_filename)
 
+            Plugins.onStandaloneDistributionFinished(dist_dir)
+
         # Remove the source directory (now build directory too) if asked to.
         if Options.isRemoveBuildDir():
             removeDirectory(

--- a/nuitka/plugins/PluginBase.py
+++ b/nuitka/plugins/PluginBase.py
@@ -48,20 +48,25 @@ class NuitkaPluginBase(object):
 
     Derive your plugin from "UserPlugin" please.
 
-    This concept allows to adapt Nuitka's behaviour in a number of ways as explained below at the individual methods.
+    Plugins allow to adapt Nuitka's behaviour in a number of ways as explained
+    below at the individual methods.
 
-    It is used to deal with special requirements some packages may have (e.g. PyQt and tkinter),
-    data files to be included (e.g. certifi), inserting hidden code, coping with otherwise undetectable needs,
-    or issuing messages in certain situations.
+    It is used to deal with special requirements some packages may have (e.g. PyQt
+    and tkinter), data files to be included (e.g. certifi), inserting hidden
+    code, coping with otherwise undetectable needs, or issuing messages in
+    certain situations.
 
-    A plugin in general must be activated to be used by Nuitka. This happens by specifying "--enable-plugin"
-    (standard plugins) or "--user-plugin" (user plugins) in the Nuitka command line. However, some plugins
-    are always activated and invisible to the user.
+    A plugin in general must be enabled to be used by Nuitka. This happens by
+    specifying "--enable-plugin" (standard plugins) or by "--user-plugin" (user
+    plugins) in the Nuitka command line. However, some plugins are always enabled
+    and invisible to the user.
 
-    Nuitka comes with a number of "standard" plugins that can be activated when needed. What they are can be
-    displayed using "nuitka --plugin-list file.py" (filename required but ignored).
+    Nuitka comes with a number of "standard" plugins to be enabled as needed.
+    What they are can be displayed using "nuitka --plugin-list file.py" (filename
+    required but ignored).
 
-    User plugins may be specified (and implicitely activated) using their Python script pathname.
+    User plugins may be specified (and implicitely enabled) using their Python
+    script pathname.
     """
 
     # Standard plugins must provide this as a unique string which Nuitka
@@ -208,7 +213,7 @@ class NuitkaPluginBase(object):
             True or False
         """
         # Virtual method, pylint: disable=no-self-use,unused-argument
-        return None
+        return True
 
     def getImplicitImports(self, module):
         """ Return the implicit imports for a given module (iterator).
@@ -388,8 +393,6 @@ class NuitkaPluginBase(object):
                 module=module, trigger_name="-postLoad", code=post_code
             )
 
-        return None
-
     def onModuleEncounter(
         self, module_filename, module_name, module_package, module_kind
     ):
@@ -403,7 +406,6 @@ class NuitkaPluginBase(object):
         Returns:
             True or False
         """
-        # Virtual method, pylint: disable=no-self-use,unused-argument
         return None
 
     @staticmethod
@@ -507,6 +509,24 @@ class NuitkaPluginBase(object):
         # Virtual method, pylint: disable=no-self-use,unused-argument
         return ()
 
+    def onStandaloneDistributionFinished(self, dist_dir):
+        """ Called after successfully finishing a standalone compile.
+
+        Note:
+            It is up to the plugin to take subsequent action. Examples are:
+            insert additional information (license, copyright, company or
+            application description), create installation material, further
+            folder clean-up, start downstream applications etc.
+
+        Args:
+            dist_dir: the created distribution folder
+
+        Returns:
+            None
+        """
+        # Virtual method, pylint: disable=no-self-use,unused-argument
+        return None
+
     def suppressBuiltinImportWarning(self, module, source_ref):
         """ Suppress import warnings for builtin modules.
 
@@ -535,11 +555,17 @@ class NuitkaPluginBase(object):
     def decideCompilation(self, module_name, source_ref):
         """ Decide whether to compile a module (or just use its bytecode).
 
+        Notes:
+            The first plugin not returning None makes the decision. Thereafter,
+            no other plugins will be checked. If all plugins return None, the
+            module will be compiled.
+
         Args:
             module_name: name of module
             source_ref: ???
+
         Returns:
-            None
+            "compiled" or "bytecode" or None (default)
         """
         # Virtual method, pylint: disable=no-self-use,unused-argument
         return None

--- a/nuitka/plugins/PluginBase.py
+++ b/nuitka/plugins/PluginBase.py
@@ -237,6 +237,7 @@ class NuitkaPluginBase(object):
         Returns:
             dict
         """
+        # Virtual method, pylint: disable=no-self-use,unused-argument
         return self.module_aliases.get(module_name, None)
 
     def onModuleSourceCode(self, module_name, source_code):
@@ -406,6 +407,7 @@ class NuitkaPluginBase(object):
         Returns:
             True or False
         """
+        # Virtual method, pylint: disable=no-self-use,unused-argument
         return None
 
     @staticmethod

--- a/nuitka/plugins/PluginBase.py
+++ b/nuitka/plugins/PluginBase.py
@@ -237,7 +237,6 @@ class NuitkaPluginBase(object):
         Returns:
             dict
         """
-        # Virtual method, pylint: disable=no-self-use,unused-argument
         return self.module_aliases.get(module_name, None)
 
     def onModuleSourceCode(self, module_name, source_code):

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -103,6 +103,15 @@ class Plugins(object):
             addUsedModule(pre_modules[full_name])
 
     @staticmethod
+    def onStandaloneDistributionFinished(dist_dir):
+        """ Let plugins postprocess the distribution folder if standalone
+        """
+        for plugin in active_plugin_list:
+            plugin.onStandaloneDistributionFinished(dist_dir)
+
+        return None
+
+    @staticmethod
     def considerExtraDlls(dist_dir, module):
         result = []
 
@@ -126,6 +135,14 @@ class Plugins(object):
 
     @staticmethod
     def removeDllDependencies(dll_filename, dll_filenames):
+        """ Create list of removable shared libraries by scanning through the plugins.
+
+        Args:
+            dll_filename: shared library filename
+            dll_filenames: list of shared library filenames
+        Returns:
+            list of removable files
+        """
         dll_filenames = tuple(sorted(dll_filenames))
 
         result = []
@@ -140,6 +157,13 @@ class Plugins(object):
 
     @staticmethod
     def considerDataFiles(module):
+        """ For a given module, ask plugins for any needed data files it may require.
+
+        Args:
+            module: module object
+        Yields:
+            data file names
+        """
         for plugin in active_plugin_list:
             for value in plugin.considerDataFiles(module):
                 yield value
@@ -209,6 +233,18 @@ class Plugins(object):
 
     @staticmethod
     def suppressBuiltinImportWarning(module, source_ref):
+        """ Let plugins decide whether to suppress import warnings for builtin modules.
+
+        Notes:
+            Return will be True if at least one plugin returns other than False or None,
+            else False.
+
+        Args:
+            module: the module object
+            source_ref: ???
+        Returns:
+            True or False
+        """
         for plugin in active_plugin_list:
             if plugin.suppressBuiltinImportWarning(module, source_ref):
                 return True
@@ -217,6 +253,16 @@ class Plugins(object):
 
     @staticmethod
     def suppressUnknownImportWarning(importing, module_name):
+        """ Let plugins decide whether to suppress import warnings for an unknown module.
+
+        Notes:
+            If all plugins return False or None, the return will be False, else True.
+        Args:
+            importing: the module which is importing "module_name"
+            module_name: the module to be imported
+        returns:
+            True or False (default)
+        """
         if importing.isCompiledPythonModule() or importing.isPythonShlibModule():
             importing_module = importing
         else:
@@ -234,6 +280,14 @@ class Plugins(object):
 
     @staticmethod
     def decideCompilation(module_name, source_ref):
+        """ Let plugins decide whether to compile a module.
+
+        Notes:
+            The decision is made by the first plugin not returning None.
+
+        Returns:
+            "compiled" (default) or "bytecode".
+        """
         for plugin in active_plugin_list:
             value = plugin.decideCompilation(module_name, source_ref)
 
@@ -245,6 +299,8 @@ class Plugins(object):
 
 
 def listPlugins():
+    """ Print available standard plugins.
+    """
     for plugin_name in sorted(plugin_name2plugin_classes):
         print(plugin_name)
 
@@ -252,6 +308,8 @@ def listPlugins():
 
 
 def isObjectAUserPluginBaseClass(obj):
+    """ Verify that a user plugin inherits from UserPluginBase.
+    """
     try:
         return obj is not UserPluginBase and issubclass(obj, UserPluginBase)
     except TypeError:
@@ -259,6 +317,8 @@ def isObjectAUserPluginBaseClass(obj):
 
 
 def importFilePy3NewWay(filename):
+    """ Import a file for Python versions 3.5+.
+    """
     import importlib.util  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
 
     spec = importlib.util.spec_from_file_location(filename, filename)
@@ -268,6 +328,8 @@ def importFilePy3NewWay(filename):
 
 
 def importFilePy3OldWay(filename):
+    """ Import a file for Python versions 3.x where x < 5.
+    """
     from importlib.machinery import (  # pylint: disable=I0021,import-error,no-name-in-module
         SourceFileLoader,  # @UnresolvedImport
     )
@@ -277,12 +339,25 @@ def importFilePy3OldWay(filename):
 
 
 def importFilePy2(filename):
+    """ Import a file for Python version 2.
+    """
     import imp
 
     return imp.load_source(filename, filename)
 
 
 def importFile(filename):
+    """ Import Python module given as a file name.
+
+    Notes:
+        Provides a Python version independent way to import any script files.
+
+    Args:
+        filename: complete path of a Python script
+
+    Returns:
+        Imported Python module defined in filename.
+    """
     if python_version < 300:
         return importFilePy2(filename)
     elif python_version < 350:
@@ -319,6 +394,24 @@ def importUserPlugins():
 
 
 def initPlugins():
+    """ Initialize plugins
+
+    Notes:
+        Load user plugins provided as Python script file names, and standard
+        plugins via their class attribute 'plugin_name'.
+        Several checks are made, see below.
+        The final result is 'active_plugin_list' which contains all enabled
+        plugins.
+
+    Returns:
+        None
+    """
+
+    # load user plugins first to allow any preparative action
+    importUserPlugins()
+
+    # now load standard plugins
+    # ensure plugin is known and not both, enabled and disabled
     for plugin_name in Options.getPluginsEnabled() + Options.getPluginsDisabled():
         if plugin_name not in plugin_name2plugin_classes:
             sys.exit("Error, unknown plug-in '%s' referenced." % plugin_name)
@@ -342,8 +435,6 @@ def initPlugins():
                 and plugin_detector.isRelevant()
             ):
                 active_plugin_list.append(plugin_detector())
-
-    importUserPlugins()
 
 
 initPlugins()


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?
1. After successful creation of the ``dist`` folder in standalone compilations, a new plugin method ``onStandaloneDistributionFinished`` is called with the distribution folder as parameter. Plugins are free to execute any downstream action.

2. User plugins are now loaded **before** any standard plugins. This allows user plugins to in turn enable standard plugins by themselves.

### Why was it initiated? Any relevant Issues?
With these changes, a more complete coverage of the software creation process is possible, while also reducing the need for extra logic to wrap Nuitka. Profiles for various purposes and audiences can be created and implemented as user plugins, like e.g. setting company standards for distributed software, or special debugging, testing or benchmarking plugins can be developed.

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
