### PR TITLE
Add "platforms" to the list of "sensible" qt-plugins (temporary fix for #299)

### DIFF
--- a/nuitka/plugins/standard/PySidePyQtPlugin.py
+++ b/nuitka/plugins/standard/PySidePyQtPlugin.py
@@ -125,6 +125,7 @@ if os.path.exists(guess_path):
                             "iconengines",
                             "mediaservice",
                             "printsupport",
+                            "platforms",
                         )
                         if self.hasPluginFamily(plugin_dir, family)
                     )
@@ -135,10 +136,6 @@ if os.path.exists(guess_path):
                 # Make sure the above didn't detect nothing, which would be
                 # indicating the check to be bad.
                 assert plugin_options
-
-                # Seems platforms is required on Windows.
-                if os.name == "nt":
-                    plugin_options.add("platforms")
 
             info(
                 "Copying Qt plug-ins '%s' to '%s'."


### PR DESCRIPTION
For qt-plugins, "platforms" plugin is needed not only on Windows, but also on Linux sometimes. Hence, it should be a part of the "sensible" plugin list - at least until we can figure out when is it not necessary (see #299).