### PR TITLE
run_all.py new special-comment mechanism & Urllib3Using.py

### DIFF
--- a/tests/standalone/FlaskUsing.py
+++ b/tests/standalone/FlaskUsing.py
@@ -19,7 +19,7 @@
 #
 from flask import Flask
 
-# nuitka-skip-test-unless: flask
+# nuitka-skip-unless-imports: flask
 
 app = Flask(__name__)
 

--- a/tests/standalone/FlaskUsing.py
+++ b/tests/standalone/FlaskUsing.py
@@ -18,6 +18,9 @@
 #     limitations under the License.
 #
 from flask import Flask
+
+# nuitka-skip-test-unless: flask
+
 app = Flask(__name__)
 
 @app.route("/")

--- a/tests/standalone/GtkUsing.py
+++ b/tests/standalone/GtkUsing.py
@@ -25,7 +25,7 @@ import gtk
 
 import pygtk
 
-# nuitka-skip-test-unless: pygtk
+# nuitka-skip-unless-imports: pygtk
 
 pygtk.require("2.0")
 

--- a/tests/standalone/GtkUsing.py
+++ b/tests/standalone/GtkUsing.py
@@ -24,6 +24,9 @@ import sys
 import gtk
 
 import pygtk
+
+# nuitka-skip-test-unless: pygtk
+
 pygtk.require("2.0")
 
 print("OK")

--- a/tests/standalone/IdnaUsing.py
+++ b/tests/standalone/IdnaUsing.py
@@ -22,6 +22,6 @@ from __future__ import print_function
 import idna.core
 import sys
 
-# nuitka-skip-test-unless: idna.core
+# nuitka-skip-unless-imports: idna.core
 
 print(idna.core, "idna.idnadata" in sys.modules)

--- a/tests/standalone/IdnaUsing.py
+++ b/tests/standalone/IdnaUsing.py
@@ -22,4 +22,6 @@ from __future__ import print_function
 import idna.core
 import sys
 
+# nuitka-skip-test-unless: idna.core
+
 print(idna.core, "idna.idnadata" in sys.modules)

--- a/tests/standalone/LxmlUsing.py
+++ b/tests/standalone/LxmlUsing.py
@@ -19,7 +19,7 @@
 #
 import lxml.etree
 
-# nuitka-skip-test-unless: lxml.etree
+# nuitka-skip-unless-imports: lxml.etree
 
 tree = lxml.etree.fromstring("<root>value</root>")
 assert tree.tag == "root"

--- a/tests/standalone/LxmlUsing.py
+++ b/tests/standalone/LxmlUsing.py
@@ -19,6 +19,8 @@
 #
 import lxml.etree
 
+# nuitka-skip-test-unless: lxml.etree
+
 tree = lxml.etree.fromstring("<root>value</root>")
 assert tree.tag == "root"
 assert tree.text == "value"

--- a/tests/standalone/NumpyUsing.py
+++ b/tests/standalone/NumpyUsing.py
@@ -19,6 +19,6 @@
 #
 import numpy
 
-# nuitka-skip-test-unless: numpy
+# nuitka-skip-unless-imports: numpy
 
 numpy.test()

--- a/tests/standalone/NumpyUsing.py
+++ b/tests/standalone/NumpyUsing.py
@@ -18,4 +18,7 @@
 #     limitations under the License.
 #
 import numpy
+
+# nuitka-skip-test-unless: numpy
+
 numpy.test()

--- a/tests/standalone/OpenGLUsing.py
+++ b/tests/standalone/OpenGLUsing.py
@@ -18,3 +18,5 @@
 #     limitations under the License.
 #
 import OpenGL
+
+# nuitka-skip-test-unless: OpenGL

--- a/tests/standalone/OpenGLUsing.py
+++ b/tests/standalone/OpenGLUsing.py
@@ -19,4 +19,4 @@
 #
 import OpenGL
 
-# nuitka-skip-test-unless: OpenGL
+# nuitka-skip-unless-imports: OpenGL

--- a/tests/standalone/PyQt4Plugins.py
+++ b/tests/standalone/PyQt4Plugins.py
@@ -19,6 +19,6 @@
 #
 from PyQt4 import QtGui
 
-# nuitka-skip-test-unless: PyQt4.QtGui
+# nuitka-skip-unless-imports: PyQt4.QtGui
 
 print(QtGui.QImageReader.supportedImageFormats())

--- a/tests/standalone/PyQt4Plugins.py
+++ b/tests/standalone/PyQt4Plugins.py
@@ -19,4 +19,6 @@
 #
 from PyQt4 import QtGui
 
+# nuitka-skip-test-unless: PyQt4.QtGui
+
 print(QtGui.QImageReader.supportedImageFormats())

--- a/tests/standalone/PyQt4Using.py
+++ b/tests/standalone/PyQt4Using.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 
 from PyQt4.QtCore import pyqtSlot, pyqtSignal, QObject, QMetaObject
 
-# nuitka-skip-test-unless: PyQt4.QtGui
+# nuitka-skip-unless-imports: PyQt4.QtGui
 
 class Communicate(QObject):
     speak = pyqtSignal(int)

--- a/tests/standalone/PyQt4Using.py
+++ b/tests/standalone/PyQt4Using.py
@@ -25,6 +25,8 @@ from __future__ import print_function
 
 from PyQt4.QtCore import pyqtSlot, pyqtSignal, QObject, QMetaObject
 
+# nuitka-skip-test-unless: PyQt4.QtGui
+
 class Communicate(QObject):
     speak = pyqtSignal(int)
     def __init__(self,name = "",parent = None):

--- a/tests/standalone/PyQt5Plugins.py
+++ b/tests/standalone/PyQt5Plugins.py
@@ -19,6 +19,6 @@
 #
 from PyQt5 import QtGui
 
-# nuitka-skip-test-unless: PyQt5.QtGui
+# nuitka-skip-unless-imports: PyQt5.QtGui
 
 print(QtGui.QImageReader.supportedImageFormats())

--- a/tests/standalone/PyQt5Plugins.py
+++ b/tests/standalone/PyQt5Plugins.py
@@ -19,4 +19,6 @@
 #
 from PyQt5 import QtGui
 
+# nuitka-skip-test-unless: PyQt5.QtGui
+
 print(QtGui.QImageReader.supportedImageFormats())

--- a/tests/standalone/PyQt5SSLSupport.py
+++ b/tests/standalone/PyQt5SSLSupport.py
@@ -18,4 +18,7 @@
 #     limitations under the License.
 #
 from PyQt5.QtNetwork import QSslSocket
+
+# nuitka-skip-test-unless: PyQt5.QtGui
+
 print("SSL support: %r" % (QSslSocket.supportsSsl(),))

--- a/tests/standalone/PyQt5SSLSupport.py
+++ b/tests/standalone/PyQt5SSLSupport.py
@@ -19,6 +19,6 @@
 #
 from PyQt5.QtNetwork import QSslSocket
 
-# nuitka-skip-test-unless: PyQt5.QtGui
+# nuitka-skip-unless-imports: PyQt5.QtGui
 
 print("SSL support: %r" % (QSslSocket.supportsSsl(),))

--- a/tests/standalone/PyQt5Using.py
+++ b/tests/standalone/PyQt5Using.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import QCoreApplication  # @UnresolvedImport
 
 import sys
 
-# nuitka-skip-test-unless: PyQt5.QtGui
+# nuitka-skip-unless-imports: PyQt5.QtGui
 
 app = QCoreApplication([])
 app.setOrganizationName("BOGUS_NAME")

--- a/tests/standalone/PyQt5Using.py
+++ b/tests/standalone/PyQt5Using.py
@@ -26,6 +26,8 @@ from PyQt5.QtCore import QCoreApplication  # @UnresolvedImport
 
 import sys
 
+# nuitka-skip-test-unless: PyQt5.QtGui
+
 app = QCoreApplication([])
 app.setOrganizationName("BOGUS_NAME")
 app.setOrganizationDomain("bogosity.com")

--- a/tests/standalone/PySideUsing.py
+++ b/tests/standalone/PySideUsing.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 
 from PySide.QtCore import Slot, Signal, QObject, QMetaObject
 
-# nuitka-skip-test-unless: PySide.QtCore
+# nuitka-skip-unless-imports: PySide.QtCore
 
 class Communicate(QObject):
     speak = Signal(int)

--- a/tests/standalone/PySideUsing.py
+++ b/tests/standalone/PySideUsing.py
@@ -25,6 +25,8 @@ from __future__ import print_function
 
 from PySide.QtCore import Slot, Signal, QObject, QMetaObject
 
+# nuitka-skip-test-unless: PySide.QtCore
+
 class Communicate(QObject):
     speak = Signal(int)
     def __init__(self,name = "",parent = None):

--- a/tests/standalone/TkInterUsing.py
+++ b/tests/standalone/TkInterUsing.py
@@ -25,6 +25,8 @@ try:
 except ImportError:
     import tkinter
 
+# nuitka-skip-test-unless: Tkinter,tkinter
+
 try:
     root = tkinter.Tk()  # this will fail in absence of TCL
 except tkinter.TclError as e:

--- a/tests/standalone/TkInterUsing.py
+++ b/tests/standalone/TkInterUsing.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     import tkinter
 
-# nuitka-skip-test-unless: Tkinter,tkinter
+# nuitka-skip-unless-expression: __import__("Tkinter" if sys.version_info[0] < 3 else "tkinter")
 
 try:
     root = tkinter.Tk()  # this will fail in absence of TCL

--- a/tests/standalone/Urllib3Using.py
+++ b/tests/standalone/Urllib3Using.py
@@ -1,0 +1,22 @@
+import urllib3
+
+# testing request
+http = urllib3.PoolManager()
+r = http.request('GET', 'http://httpbin.org/robots.txt')
+r = http.request('POST','http://httpbin.org/post',fields={'hello': 'world'})
+
+# testing response
+r.status
+r.data
+r.headers
+
+# testing JSON content
+import json
+r = http.request('GET', 'http://httpbin.org/ip')
+json.loads(r.data.decode('utf-8'))
+
+# testing binary content
+r = http.request('GET', 'http://httpbin.org/bytes/8')
+r.data
+
+print('Reached end of file')

--- a/tests/standalone/Urllib3Using.py
+++ b/tests/standalone/Urllib3Using.py
@@ -1,5 +1,7 @@
 import urllib3
 
+# nuitka-skip-test-unless: urllib3
+
 # testing request
 http = urllib3.PoolManager()
 r = http.request('GET', 'http://httpbin.org/robots.txt')

--- a/tests/standalone/Urllib3Using.py
+++ b/tests/standalone/Urllib3Using.py
@@ -1,24 +1,59 @@
 import urllib3
+import os
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from threading import Thread
 
 # nuitka-skip-unless-imports: urllib3
 
+def runHTTPServer():
+    class myServer(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == '/':
+                self.path = '/index.html'
+            try:
+                file_to_open = open(self.path[1:]).read()
+                self.send_response(200)
+            except:
+                file_to_open = 'File not found'
+                self.send_response(404)
+            self.end_headers()
+            self.wfile.write(bytes(file_to_open,'utf-8'))
+    
+    server_address = ("127.0.0.1",8020)
+    global server
+    server = HTTPServer(server_address,myServer)
+    server.serve_forever()
+
+Thread(target=runHTTPServer).start()
+print('Server started')
+
 # testing request
 http = urllib3.PoolManager()
-r = http.request('GET', 'http://httpbin.org/robots.txt')
-r = http.request('POST','http://httpbin.org/post',fields={'hello': 'world'})
-
-# testing response
-r.status
-r.data
-r.headers
+r = http.request('GET', 'http://localhost:8020/')
+# print response
+print(r.status,r.data,r.headers)
 
 # testing JSON content
 import json
-r = http.request('GET', 'http://httpbin.org/ip')
-json.loads(r.data.decode('utf-8'))
+# make a temporary test file
+with open('testjson.json','w') as f:
+    f.write('{"origin": "128.195.97.166, 128.195.97.166"}')
 
-# testing binary content
-r = http.request('GET', 'http://httpbin.org/bytes/8')
-r.data
+r = http.request('GET', 'http://localhost:8020/testjson.json')
+print(json.loads(r.data.decode('utf-8')))
+os.remove('testjson.json')
+
+server.shutdown()
+print('Server shutdown')
+
+# test ssl
+import socket
+import ssl
+hostname = 'www.google.com'
+context = ssl.create_default_context()
+with socket.create_connection((hostname, 443)) as sock:
+    with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+        print(ssock.version())
 
 print('Reached end of file')
+

--- a/tests/standalone/Urllib3Using.py
+++ b/tests/standalone/Urllib3Using.py
@@ -1,6 +1,6 @@
 import urllib3
 
-# nuitka-skip-test-unless: urllib3
+# nuitka-skip-unless-imports: urllib3
 
 # testing request
 http = urllib3.PoolManager()

--- a/tests/standalone/Win32ComUsing.py
+++ b/tests/standalone/Win32ComUsing.py
@@ -22,4 +22,6 @@
 from win32com import storagecon
 from win32com.shell import shell, shellcon
 
+# nuitka-skip-test-unless: win32com
+
 print("OK.")

--- a/tests/standalone/Win32ComUsing.py
+++ b/tests/standalone/Win32ComUsing.py
@@ -22,6 +22,6 @@
 from win32com import storagecon
 from win32com.shell import shell, shellcon
 
-# nuitka-skip-test-unless: win32com
+# nuitka-skip-unless-imports: win32com
 
 print("OK.")

--- a/tests/standalone/run_all.py
+++ b/tests/standalone/run_all.py
@@ -291,7 +291,7 @@ for filename in sorted(os.listdir(".")):
     extra_flags = ["expect_success", "standalone", "remove_output"]
 
     # specials: these modules need custom checks(implemented below), skip automated checking
-    specials = {'TkInterUsing.py'}
+    specials = ['TkInterUsing.py']
     # skip each test if their respective required import is not present
     required_m = find_required_module(filename)
     if required_m and not filename in specials and not hasModule(required_m):

--- a/tests/standalone/run_all.py
+++ b/tests/standalone/run_all.py
@@ -289,9 +289,9 @@ def checkRequirements(filename):
                     imports_needed = line[30:].rstrip().split(',')
                     for i in imports_needed:
                         if not hasModule(i):
-                            return(False,i+" not installed for this Python version, but test needs it")
+                            return (False,i+" not installed for this Python version, but test needs it")
     # default return value
-    return(True,"")
+    return (True,"")
 
 
 for filename in sorted(os.listdir(".")):

--- a/tests/standalone/run_all.py
+++ b/tests/standalone/run_all.py
@@ -470,6 +470,16 @@ for filename in sorted(os.listdir(".")):
             )
             continue
 
+    # skip testing Urllib3Using.py unless urllib3 is installed
+    if filename == "Urllib3Using.py":
+        if not hasModule("urllib3"):
+            reportSkip(
+                "Urllib3 not installed for this Python version, but test needs it",
+                ".",
+                filename,
+            )
+            continue
+
         # For the warnings.
         extra_flags.append("ignore_stderr")
 

--- a/tests/standalone/run_all.py
+++ b/tests/standalone/run_all.py
@@ -267,12 +267,11 @@ _win_dll_whitelist = (
 # finds the special comment in each test module and returns the import module needed for each test
 # special comments are the the following format:
 # "# nuitka-skip-test-unless: module"
-def find_required_module(filename: str) -> str:
+def find_required_module(filename):
     with open(filename,'r') as f:
         for line in f:
             if '# nuitka-skip-test-unless: ' in line:
                 return line[27:].rstrip()
-
 
 for filename in sorted(os.listdir(".")):
     if not filename.endswith(".py"):
@@ -297,7 +296,7 @@ for filename in sorted(os.listdir(".")):
     required_m = find_required_module(filename)
     if required_m and not filename in specials and not hasModule(required_m):
         reportSkip(
-                f"{required_m} not installed for this Python version, but test needs it",
+                required_m + " not installed for this Python version, but test needs it",
                 ".",
                 filename,
         )

--- a/tests/standalone/run_all.py
+++ b/tests/standalone/run_all.py
@@ -264,6 +264,16 @@ _win_dll_whitelist = (
     "MFCM140U.DLL",
 )
 
+# finds the special comment in each test module and returns the import module needed for each test
+# special comments are the the following format:
+# "# nuitka-skip-test-unless: module"
+def find_required_module(filename: str) -> str:
+    with open(filename,'r') as f:
+        for line in f:
+            if '# nuitka-skip-test-unless: ' in line:
+                return line[27:].rstrip()
+
+
 for filename in sorted(os.listdir(".")):
     if not filename.endswith(".py"):
         continue
@@ -281,125 +291,79 @@ for filename in sorted(os.listdir(".")):
 
     extra_flags = ["expect_success", "standalone", "remove_output"]
 
-    if filename == "PySideUsing.py":
+    # specials: these modules need custom checks(implemented below), skip automated checking
+    specials = {'TkInterUsing.py'}
+    # skip each test if their respective required import is not present
+    required_m = find_required_module(filename)
+    if required_m and not filename in specials and not hasModule(required_m):
+        reportSkip(
+                f"{required_m} not installed for this Python version, but test needs it",
+                ".",
+                filename,
+        )
+        continue
+
+    elif filename == "PySideUsing.py":
         # Don't test on platforms not supported by current Debian testing, and
         # which should be considered irrelevant by now.
         if python_version.startswith("2.6") or python_version.startswith("3.2"):
             reportSkip("irrelevant Python version", ".", filename)
-            continue
-
-        if not hasModule("PySide.QtCore"):
-            reportSkip(
-                "PySide not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
             continue
 
         # For the warnings.
         extra_flags.append("ignore_stderr")
 
-    if "PyQt4" in filename:
+    elif "PyQt4" in filename:
         # Don't test on platforms not supported by current Debian testing, and
         # which should be considered irrelevant by now.
         if python_version.startswith("2.6") or python_version.startswith("3.2"):
             reportSkip("irrelevant Python version", ".", filename)
-            continue
-
-        if not hasModule("PyQt4.QtGui"):
-            reportSkip(
-                "PyQt4 not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
             continue
 
         # For the plug-in information.
         extra_flags.append("ignore_infos")
 
-    if "Idna" in filename:
-        if not hasModule("idna.core"):
-            reportSkip(
-                "idna not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
+    elif "Idna" in filename:
         # For the warnings of Python2.
         if python_version.startswith("2"):
             extra_flags.append("ignore_stderr")
 
-    if "PyQt5" in filename:
+    elif "PyQt5" in filename:
         # Don't test on platforms not supported by current Debian testing, and
         # which should be considered irrelevant by now.
         if python_version.startswith("2.6") or python_version.startswith("3.2"):
             reportSkip("irrelevant Python version", ".", filename)
-            continue
-
-        if not hasModule("PyQt5.QtGui"):
-            reportSkip(
-                "PyQt5 not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
             continue
 
         # For the plug-in information.
         extra_flags.append("ignore_infos")
 
     # TODO: Temporary only
-    if os.name == "nt" and "PyQt" in filename:
+    elif os.name == "nt" and "PyQt" in filename:
         continue
 
-    if "PySide" in filename or "PyQt" in filename:
+    elif "PySide" in filename or "PyQt" in filename:
         extra_flags.append("plugin_enable:qt-plugins")
 
-    if filename == "CtypesUsing.py":
+    elif filename == "CtypesUsing.py":
         extra_flags.append("plugin_disable:pylint-warnings")
 
-    if filename == "GtkUsing.py":
+    elif filename == "GtkUsing.py":
         # Don't test on platforms not supported by current Debian testing, and
         # which should be considered irrelevant by now.
         if python_version.startswith("2.6") or python_version.startswith("3.2"):
             reportSkip("irrelevant Python version", ".", filename)
             continue
 
-        if not hasModule("pygtk"):
-            reportSkip(
-                "pygtk not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
         # For the warnings.
         extra_flags.append("ignore_stderr")
 
-    if filename.startswith("Win"):
+    elif filename.startswith("Win"):
         if os.name != "nt":
             reportSkip("Windows only test", ".", filename)
             continue
 
-    if filename == "Win32ComUsing.py":
-        if not hasModule("win32com"):
-            reportSkip(
-                "win32com not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
-    if filename == "LxmlUsing.py":
-        if not hasModule("lxml.etree"):
-            reportSkip(
-                "lxml.etree not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
-    if filename == "TkInterUsing.py":
+    elif filename == "TkInterUsing.py":
         if python_version.startswith("2"):
             if not hasModule("Tkinter"):
                 reportSkip(
@@ -423,65 +387,24 @@ for filename in sorted(os.listdir(".")):
         if os.name == "nt":
             extra_flags.append("plugin_enable:tk-inter")
 
-    if filename == "FlaskUsing.py":
-        if not hasModule("flask"):
-            reportSkip(
-                "flask not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
+    elif filename == "FlaskUsing.py":
         # For the warnings.
         extra_flags.append("ignore_stderr")
 
-    if filename == "NumpyUsing.py":
+    elif filename == "NumpyUsing.py":
         # TODO: Disabled for now.
         reportSkip("numpy.test not fully working yet", ".", filename)
         continue
 
-        if not hasModule("numpy"):
-            reportSkip(
-                "numpy not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
         extra_flags.append("plugin_enable:data-files")
 
-    if filename == "PmwUsing.py":
-        if not hasModule("Pwm"):
-            reportSkip(
-                "Pwm not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
+    elif filename == "PmwUsing.py":
         extra_flags.append("plugin_enable:pmw-freeze")
 
-    if filename == "OpenGLUsing.py":
-        if not hasModule("OpenGL"):
-            reportSkip(
-                "OpenGL not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
-    # skip testing Urllib3Using.py unless urllib3 is installed
-    if filename == "Urllib3Using.py":
-        if not hasModule("urllib3"):
-            reportSkip(
-                "Urllib3 not installed for this Python version, but test needs it",
-                ".",
-                filename,
-            )
-            continue
-
+    elif filename == "OpenGLUsing.py":
         # For the warnings.
         extra_flags.append("ignore_stderr")
+
 
     my_print("Consider output of recursively compiled program:", filename)
 


### PR DESCRIPTION
### What does this PR do?
This PR changes the mechanism in which run_all checks for whether import requirements are satisfied. Now each test file should include a special comment in one of the following formats:

`# nuitka-skip-unless-expression: expression to be evaluated`
(a test would be skipped if this expression evaluated to false)
OR
`# nuitka-skip-unless-imports: module1,module2,...`
(a test would be skipped if any modules are missing)

The new helper function `checkRequirements` inside run_all.py will search for these comments in every test module and do the respective checks as specified.
This new mechanism makes it more clear what imports are required for each test file, as they will be stated in a special comment inside each test file. It also improves code readability and eliminates repetition in run_all.py 

This PR also changed every existing test file to include the special comment stating their required imports

In addition, the new Urllib3Using.py module is added, which run_all.py uses to test Nuitka's compatibility with urllib3.

### Why was it initiated? Any relevant Issues?
This is part of my Google Summer of Code proposal.

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
