### PR TITLE
fixed scons to accept conda gnu gcc compiler name.

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -318,6 +318,17 @@ blacklisted_tools = (
     "nasm",
 )
 
+gcc_names = ["gcc", "g++", "cc", "c++"]
+
+def has_names(test_names, compiler_name):
+    """returns True the name of the compiler_name contains any of the names in
+    test_names, compiler names, False otherwise."""
+
+    return any(gcc_name in compiler_name for gcc_name in gcc_names)
+
+def has_gcc_names(compiler_name):
+    return has_names(gcc_names, compiler_name)
+
 v_cache = {}
 
 # From gcc.py of Scons
@@ -339,7 +350,7 @@ def detectVersion(env, cc):
     if show_scons_mode:
         print("Scons CC %r version check:" % cc)
 
-    if clvar[0] in ("gcc", "g++", "clang"):
+    if has_names(["gcc", "g++", "cc", "clang"], clvar[0]):
         command = list(clvar) + ["-dumpversion"]
     else:
         command = list(clvar) + ["--version"]
@@ -635,7 +646,7 @@ if "clang" in the_cc_name and "-cl" not in the_cc_name:
 
 # We consider clang to be a form of gcc for the most things, they strive to
 # be compatible.
-gcc_mode = "gcc" in the_cc_name or "g++" in the_cc_name or clang_mode
+gcc_mode =  has_gcc_names(the_cc_name) or clang_mode
 
 msvc_mode = win_target and not gcc_mode
 mingw_mode = win_target and gcc_mode
@@ -1265,7 +1276,7 @@ if debug_mode or unstripped_mode:
         env.Append(CCFLAGS=["-g"])
         env.Append(ASFLAGS=["-g"])
 
-        if "gcc" in the_cc_name or "g++" in the_cc_name:
+        if has_gcc_names(the_cc_name):
             env.Append(CCFLAGS=["-feliminate-unused-debug-types"])
     elif msvc_mode:
         env.Append(CCFLAGS=["/Z7"])
@@ -1432,7 +1443,7 @@ env.Append(
 
 # Tell compiler to create a shared library or program.
 if module_mode:
-    if "gcc" in the_cc_name or "g++" in the_cc_name:
+    if has_gcc_names(the_cc_name):
         env.Append(CCFLAGS=["-shared"])
     elif clang_mode:
         pass


### PR DESCRIPTION
### What does this PR do?

Accepts compiler names in CC/CXX environment variables that contain `cc`/`c++` name.
In particular for conda-forge gnu gcc, `CC=.../x86_64-conda_cos6-linux-gnu-cc`

### Why was it initiated? Any relevant Issues?

fixes https://github.com/Nuitka/Nuitka/issues/328

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [ ] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

not sure how to add a test, the test would create a minimal conda environment with the conda compiler and nuitka installed in the environment, after that compile the simple example in the issue.

Travis, does not seem to enable testing other branches, other than develop.

Local tests under standard gcc of ubuntu, all pass.

Local tests using gcc from conda environment fail, apparently includes are miss calculated.

```
 ./run-tests 
Cannot execute tests with Python 2.6, disabled or not installed.
Executing test case called python2.7-debug with CPython python2.7 and extra flags '--debug'.
Running the basic tests with options '--debug' with python2.7:
Run '/home/**********/.conda/envs/Nuitka/bin/python ./tests/basics/run_all.py search' in '/data/development/projects/**********/Nuitka'.
Using concrete python 2.7.12 on x86_64
Comparing output of 'Asserts.py' using '/usr/bin/python2.7' with flags silent, expect_success, remove_output, recurse_all, original_file, cpython_cache ...
--- /usr/bin/python2.7 (stdout)
+++ nuitka (stdout)

@@ -1,9 +1 @@

-Function that will assert.
-Raised <type 'exceptions.AssertionError'> 
-Function that will not assert.
-No exception.
-Function that will assert with argument.
-Raised <type 'exceptions.AssertionError'> argument
-Assertion with tuple argument.(3,)
-Assertion with plain argument.3
 
--- /usr/bin/python2.7 (stderr)
+++ nuitka (stderr)

@@ -1 +1,32 @@

+In file included from /usr/include/python2.7/Python.h:8:0,
+                 from /data/development/projects/**********/Nuitka/nuitka/build/include/nuitka/prelude.h:43,
+                 from /var/tmp/basics/python2.7-debug/Asserts.build/__constants.c:2:
+/usr/include/python2.7/pyconfig.h:3:12: fatal error: x86_64-linux-gnu/python2.7/pyconfig.h: No such file or directory
+ #  include <x86_64-linux-gnu/python2.7/pyconfig.h>
+            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+In file included from /usr/include/python2.7/Python.h:8:0,
+                 from /var/tmp/basics/python2.7-debug/Asserts.build/__frozen.c:3:
+/usr/include/python2.7/pyconfig.h:3:12: fatal error: x86_64-linux-gnu/python2.7/pyconfig.h: No such file or directory
+ #  include <x86_64-linux-gnu/python2.7/pyconfig.h>
+            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+scons: *** [/var/tmp/basics/python2.7-debug/Asserts.build/__constants.o] Error 1
+scons: *** [/var/tmp/basics/python2.7-debug/Asserts.build/__frozen.o] Error 1
+In file included from /usr/include/python2.7/Python.h:8:0,
+                 from /data/development/projects/**********/Nuitka/nuitka/build/include/nuitka/prelude.h:43,
+                 from /var/tmp/basics/python2.7-debug/Asserts.build/__helpers.c:4:
+/usr/include/python2.7/pyconfig.h:3:12: fatal error: x86_64-linux-gnu/python2.7/pyconfig.h: No such file or directory
+ #  include <x86_64-linux-gnu/python2.7/pyconfig.h>
+            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+scons: *** [/var/tmp/basics/python2.7-debug/Asserts.build/__helpers.o] Error 1
+In file included from /usr/include/python2.7/Python.h:8:0,
+                 from /data/development/projects/**********/Nuitka/nuitka/build/include/nuitka/prelude.h:43,
+                 from /var/tmp/basics/python2.7-debug/Asserts.build/module.__main__.c:19:
+/usr/include/python2.7/pyconfig.h:3:12: fatal error: x86_64-linux-gnu/python2.7/pyconfig.h: No such file or directory
+ #  include <x86_64-linux-gnu/python2.7/pyconfig.h>
+            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+compilation terminated.
+scons: *** [/var/tmp/basics/python2.7-debug/Asserts.build/module.__main__.o] Error 1
 
Exit codes 0 (CPython) != 1 (Nuitka)
Error, outputs differed.
Error exit! 1
```