### PR TITLE
Quality: Fixed the TypeError in autoformat 

### DIFF
--- a/nuitka/tools/quality/autoformat/Autoformat.py
+++ b/nuitka/tools/quality/autoformat/Autoformat.py
@@ -326,14 +326,10 @@ def autoformat(filename, git_stage, abort):
     if git_stage:
         old_code = getFileHashContent(git_stage["dst_hash"])
     else:
-        old_code = getFileContents(filename)
+        old_code = getFileContents(filename, "rb")
 
-    if not isinstance(old_code, str):
-        with open(tmp_filename, "w") as output_file:
-            output_file.write(old_code.decode("utf-8"))
-    else:
-        with open(tmp_filename, "wb") as output_file:
-            output_file.write(old_code)
+    with open(tmp_filename, "wb") as output_file:
+        output_file.write(old_code)
 
     try:
         _cleanupWindowsNewlines(tmp_filename)

--- a/nuitka/tools/quality/autoformat/Autoformat.py
+++ b/nuitka/tools/quality/autoformat/Autoformat.py
@@ -328,7 +328,7 @@ def autoformat(filename, git_stage, abort):
     else:
         old_code = getFileContents(filename)
 
-    with open(tmp_filename, "w") as output_file:
+    with open(tmp_filename, "wb") as output_file:
         output_file.write(old_code)
 
     try:

--- a/nuitka/tools/quality/autoformat/Autoformat.py
+++ b/nuitka/tools/quality/autoformat/Autoformat.py
@@ -328,8 +328,12 @@ def autoformat(filename, git_stage, abort):
     else:
         old_code = getFileContents(filename)
 
-    with open(tmp_filename, "wb") as output_file:
-        output_file.write(old_code)
+    if not isinstance(old_code, str):
+        with open(tmp_filename, "w") as output_file:
+            output_file.write(old_code.decode("utf-8"))
+    else:
+        with open(tmp_filename, "wb") as output_file:
+            output_file.write(old_code)
 
     try:
         _cleanupWindowsNewlines(tmp_filename)

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -262,8 +262,8 @@ def getFileContentByLine(filename, mode="r"):
         return f.readlines()
 
 
-def getFileContents(filename):
-    with open(filename, "r") as f:
+def getFileContents(filename, mode="r"):
+    with open(filename, mode) as f:
         return f.read()
 
 


### PR DESCRIPTION
fixed #334 

After rebasing I was getting another `TypeError` i.e. `TypeError: write() argument must be str, not bytes`

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?

### Why was it initiated? Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
