### PR TITLE
PR for GH-389

### DIFF
--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -149,12 +149,12 @@ static argv_type_t convertCommandLineParameters(int argc, char **argv) {
     setlocale(LC_ALL, "");
 
     for (int i = 0; i < argc; i++) {
-#ifdef __APPLE__
-        argv_copy[i] = _Py_DecodeUTF8_surrogateescape(argv[i], strlen(argv[i]));
-#elif PYTHON_VERSION < 350
-        argv_copy[i] = _Py_char2wchar(argv[i], NULL);
-#else
+#if PYTHON_VERSION >= 350
         argv_copy[i] = Py_DecodeLocale(argv[i], NULL);
+#elif defined(__APPLE__) && PYTHON_VERSION >= 320
+        argv_copy[i] = _Py_DecodeUTF8_surrogateescape(argv[i], strlen(argv[i]));
+#else
+        argv_copy[i] = _Py_char2wchar(argv[i], NULL);
 #endif
 
         assert(argv_copy[i]);


### PR DESCRIPTION
Fixes a crash issue when using nuitka on mac os x and parsing sys.argv

(hopefully didn't mess up anything)
