### PR TITLE
Fix NumpyPlugin binaries path on case-sensitive file systems

### DIFF
--- a/nuitka/plugins/standard/NumpyPlugin.py
+++ b/nuitka/plugins/standard/NumpyPlugin.py
@@ -219,7 +219,7 @@ class NumpyPlugin(UserPluginBase):
             info("")
             info(" Copying extra binaries from 'numpy' installation:")
             for f in binaries:
-                bin_file = f[0].lower()  # full binary file name
+                bin_file = os.path.dirname(f[0]) + os.path.sep + os.path.basename(f[0]).lower()  # full binary file name
                 idx = bin_file.find("numpy")  # this will always work (idx > 0)
                 back_end = bin_file[idx:]  # => like 'numpy/core/file.so'
                 tar_file = os.path.join(dist_dir, back_end)


### PR DESCRIPTION
Numpy plugin breaks the path of binaries in case-sensitive file systems, giving a FileNotFoundError with option --plugin-enable=numpy while actually the .so file is really available.

Example:
Having numpy file at "/home/johndo/SOMEPROJECT/venv/lib/python3.7/site-packages/numpy/.libs/libopenblasp-r0-8dca6697.3.0.dev.so"

Gives such errror with nuitka:

FileNotFoundError: [Errno 2] No such file or directory: '/home/johndo/someproject/venv/lib/python3.7/site-packages/numpy/.libs/libopenblasp-r0-8dca6697.3.0.dev.so'

This patch fixes the issue so that only the base file name is lower-cased, leaving the rest of the path as-is.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?

### Why was it initiated? Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
