### PR TITLE
support iptc xtwrapper dependency

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -531,6 +531,14 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             shutil.copy(uuid_dll_path, dist_dll_path)
 
             return ((uuid_dll_path, dist_dll_path, None),)
+        elif full_name == "iptc" and getOS() == "Linux":
+            import iptc.util
+            xtwrapper_dll_path = iptc.util.find_library("xtwrapper")[0]._name
+            dist_dll_path = os.path.join(dist_dir, os.path.basename(xtwrapper_dll_path))
+
+            shutil.copy(xtwrapper_dll_path, dist_dll_path)
+
+            return ((xtwrapper_dll_path, dist_dll_path, None),)
 
         return ()
 


### PR DESCRIPTION
### What does this PR do?
[python-iptables](https://github.com/ldx/python-iptables) makes use of a C-library which is put in a non-standard place (according to ldconfig standards).
As such python-iptables provides it's own wrapper around ldconfig-based `find_library()`.
Let's just use it.

See also https://github.com/ldx/python-iptables/issues/276

### Why was it initiated? Any relevant Issues?
#398

### PR Checklist
- [x] Correct base branch selected? `develop` for new features and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [x] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, and you are
      welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
