### PR TITLE
support hinted-mode plugins extending NuitkaPluginBase

### DIFF
--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -37,7 +37,7 @@ from nuitka import Options
 from nuitka.ModuleRegistry import addUsedModule
 from nuitka.PythonVersions import python_version
 
-from .PluginBase import UserPluginBase, post_modules, pre_modules
+from .PluginBase import NuitkaPluginBase, UserPluginBase, post_modules, pre_modules
 from .standard.ConsiderPyLintAnnotationsPlugin import (
     NuitkaPluginDetectorPylintEclipseAnnotations,
     NuitkaPluginPylintEclipseAnnotations,
@@ -317,7 +317,7 @@ def isObjectAUserPluginBaseClass(obj):
     """ Verify that a user plugin inherits from UserPluginBase.
     """
     try:
-        return obj is not UserPluginBase and issubclass(obj, UserPluginBase)
+        return obj is not UserPluginBase and (issubclass(obj, UserPluginBase) or issubclass(obj, NuitkaPluginBase))
     except TypeError:
         return False
 


### PR DESCRIPTION
`Usr_Plugin` extends `NuitkaPluginBase` instead of `UserPluginBase`
See https://github.com/Nuitka/NUITKA-Utilities/commit/29d5fd2ea20af6bbe159029e51a925eda56e51a6#r33654001
