### PR TITLE
Add support for SHA224

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -502,6 +502,8 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
                 yield crypto_module_name + ".Hash._BLAKE2s", True
             elif full_name == crypto_module_name + ".Hash.SHA1":
                 yield crypto_module_name + ".Hash._SHA1", True
+            elif full_name == crypto_module_name + ".Hash.SHA224":
+                yield crypto_module_name + ".Hash._SHA224", True
             elif full_name == crypto_module_name + ".Hash.SHA256":
                 yield crypto_module_name + ".Hash._SHA256", True
             elif full_name == crypto_module_name + ".Hash.MD5":


### PR DESCRIPTION
I checked the changes made in https://github.com/Nuitka/Nuitka/pull/384/commits and I assume this is the way to include SHA224. However, I feel all algorithms should be supported if some are still not included. See my comments: https://github.com/Nuitka/Nuitka/issues/215#issuecomment-500709057