### PR TITLE
Extend Cryptodome(x), Add coincurve support

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,3 +1,9 @@
+Nuitka Release 0.6.5 (Draft)
+============================
+
+This release is not done yet.
+
+
 Nuitka Release 0.6.4
 ====================
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nuitka (0.6.5~rc1+ds-1) experimental; urgency=medium
+
+  * New upstream pre-release.
+
+ -- Kay Hayen <kay.hayen@gmail.com>  Fri, 07 Jun 2019 23:32:59 +0200
+
 nuitka (0.6.4+ds-1) experimental; urgency=medium
 
   * New upstream release.

--- a/nuitka/Version.py
+++ b/nuitka/Version.py
@@ -20,7 +20,7 @@
 """
 
 version_string = """\
-Nuitka V0.6.4
+Nuitka V0.6.5rc1
 Copyright (C) 2019 Kay Hayen."""
 
 

--- a/nuitka/plugins/standard/DataFileCollectorPlugin.py
+++ b/nuitka/plugins/standard/DataFileCollectorPlugin.py
@@ -35,6 +35,7 @@ known_data_files = {
     "scrapy": ((None, "VERSION"),),
     "requests": (("certifi", "../certifi/cacert.pem"),),
     "importlib_resources": ((None, "version.txt"),),
+    "coincurve": ((None, "./libsecp256k1.dll"),),
     "boto": ((None, "./endpoints.json"),),
     "moto": (
         (None, "./ec2/resources/instance_types.json"),

--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -506,6 +506,10 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
                 yield crypto_module_name + ".Hash._SHA224", True
             elif full_name == crypto_module_name + ".Hash.SHA256":
                 yield crypto_module_name + ".Hash._SHA256", True
+            elif full_name == crypto_module_name + ".Hash.SHA384":
+                yield crypto_module_name + ".Hash._SHA384", True
+            elif full_name == crypto_module_name + ".Hash.SHA512":
+                yield crypto_module_name + ".Hash._SHA512", True
             elif full_name == crypto_module_name + ".Hash.MD5":
                 yield crypto_module_name + ".Hash._MD5", True
             elif full_name == crypto_module_name + ".Protocol.KDF":
@@ -518,6 +522,10 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             yield "pycparser.lextab", True
         elif full_name == "passlib.hash":
             yield "passlib.handlers.sha2_crypt", True
+
+        #Support for coincurve
+        elif full_name == "coincurve":
+            yield "coincurve._libsecp256k1._dll", True
 
     # We don't care about line length here, pylint: disable=line-too-long
 

--- a/rpm/nuitka.spec
+++ b/rpm/nuitka.spec
@@ -90,7 +90,7 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-* Mon Fri 07 2019 Kay Hayen<kay.hayen@gmail.com> - 0.6.4
+* Fri Jun 07 2019 Kay Hayen<kay.hayen@gmail.com> - 0.6.4
 - adapted for Fedora30
 
 * Mon Mar 26 2018 Kay Hayen<kay.hayen@gmail.com> - 0.5.29


### PR DESCRIPTION
Added support for coincurve
Included libsecp256k1.dll data file required for coincurve to run
Added support for SHA384, SHA512 in Cryptodome(x)

I tested these changes locally, I am not completely sure if the ImplicitImports part is required