### PR TITLE
Add support for SHA384, SHA512

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -505,7 +505,11 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             elif full_name == crypto_module_name + ".Hash.SHA224":
                 yield crypto_module_name + ".Hash._SHA224", True
             elif full_name == crypto_module_name + ".Hash.SHA256":
-                yield crypto_module_name + ".Hash._SHA256", True
+                yield crypto_module_name + ".Hash._SHA256", True                
+            elif full_name == crypto_module_name + ".Hash.SHA384":
+                yield crypto_module_name + ".Hash._SHA384", True
+            elif full_name == crypto_module_name + ".Hash.SHA512":
+                yield crypto_module_name + ".Hash._SHA512", True                
             elif full_name == crypto_module_name + ".Hash.MD5":
                 yield crypto_module_name + ".Hash._MD5", True
             elif full_name == crypto_module_name + ".Protocol.KDF":


### PR DESCRIPTION
I'am supplying this change individually instead. For some reason, GitHub still thinks I removed and added one extra line ( `yield crypto_module_name + ".Hash._SHA256", True`)