### PR TITLE
#470: Add test case for distutils when working with namespace packages

### DIFF
--- a/tests/distutils/example_3/setup.py
+++ b/tests/distutils/example_3/setup.py
@@ -1,0 +1,40 @@
+#     Copyright 2019, Kay Hayen, mailto:kay.hayen@gmail.com
+#
+#     Python test originally created or extracted from other peoples work. The
+#     parts from me are licensed as below. It is at least Free Software where
+#     it's copied from other people. In these cases, that will normally be
+#     indicated.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+from setuptools import setup
+
+# use `python setup.py bdist_nuitka` to use nuitka or use
+# in the setup(..., build_with_nuitka=True, ...)
+# and bdist and build will allways use nuitka
+
+setup(
+    name='bdist_nuitka_test_3',
+    description='nuitka bdist_nuitka test-case compiling a namespace' +
+                ' package',
+    author='Some Three',
+    author_email='some3@sum.e',
+    version="0.1",
+    packages=["outer.inner"],
+    command_options={ 'nuitka' :
+        {'--show-scons': True,
+         '--show-progress': None,
+         '--file-reference-choice':'original',
+        }
+    },
+)

--- a/tests/distutils/example_3/setup.py
+++ b/tests/distutils/example_3/setup.py
@@ -31,10 +31,4 @@ setup(
     author_email='some3@sum.e',
     version="0.1",
     packages=["outer.inner"],
-    command_options={ 'nuitka' :
-        {'--show-scons': True,
-         '--show-progress': None,
-         '--file-reference-choice':'original',
-        }
-    },
 )


### PR DESCRIPTION
I forgot to create a branch for this on my fork, but this is a pretty small changeset so I'm not too worried.

# What does this PR do?

This PR adds a test case in `tests/distutils/example_3`, which provides a very simple example of a [native namespace package](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages). The package itself contains only an `__init__.py`, but that is sufficient for this test case.

Please note that native namespace packages were introduced with **Python 3.3**.

# Why was it initiated? Any relevant Issues?

This PR was requested by @kayhayen in #470.