### PR TITLE
Distutils: Allow slashes in package names

### DIFF
--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -110,7 +110,7 @@ class build(distutils.command.build.build):
         ]
 
         command += [
-            "--include-package=%s" % package_name
+            "--include-package=%s" % package_name.replace("/", ".")
             for package_name in self.compile_packages
         ]
 


### PR DESCRIPTION
compile_packages should use '.' separators, however setuptools
allows '/', as seen in package websockets.
