### PR TITLE
SingleExe.scons: Compile modules in alpha order

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -1596,7 +1596,7 @@ def discoverSourceFiles():
         return target_file
 
     # Scan for Nuitka created source files, and add them too.
-    for filename in os.listdir(source_dir):
+    for filename in sorted(os.listdir(source_dir)):
         # Only C files are of interest here.
         if not filename.endswith((".c", "cpp")) or not filename.startswith(
             ("module.", "__")


### PR DESCRIPTION
The build logs are easier to read when the modules are compiled
in a logical order, and probably this helps to achieve
reproducible builds.

Closes https://github.com/Nuitka/Nuitka/issues/543
