### PR TITLE
MacOS standalone rpath issue (Feature/fix issue #499)

### DIFF
--- a/nuitka/PostProcessing.py
+++ b/nuitka/PostProcessing.py
@@ -27,7 +27,7 @@ import sys
 from nuitka import Options
 from nuitka.codegen import ConstantCodes
 from nuitka.PythonVersions import getPythonABI, getTargetPythonDLLPath, python_version
-from nuitka.utils.SharedLibraries import callInstallNameTool
+from nuitka.utils.SharedLibraries import callInstallNameTool, callInstallNameToolAddRPath
 from nuitka.utils.Utils import getOS, isWin32Windows
 from nuitka.utils.WindowsResources import (
     RT_MANIFEST,
@@ -76,6 +76,8 @@ def executePostProcessing(result_filename):
         python_abi_version = python_version_str + getPythonABI()
         python_dll_filename = "libpython" + python_abi_version + ".dylib"
         python_lib_path = os.path.join(sys.prefix, "lib")
+
+        callInstallNameToolAddRPath(result_filename, python_lib_path)
 
         callInstallNameTool(
             filename=result_filename,

--- a/nuitka/PostProcessing.py
+++ b/nuitka/PostProcessing.py
@@ -77,7 +77,8 @@ def executePostProcessing(result_filename):
         python_dll_filename = "libpython" + python_abi_version + ".dylib"
         python_lib_path = os.path.join(sys.prefix, "lib")
 
-        callInstallNameToolAddRPath(result_filename, python_lib_path)
+        if os.path.exists(os.path.join(sys.prefix, 'conda-meta')):
+            callInstallNameToolAddRPath(result_filename, python_lib_path)
 
         callInstallNameTool(
             filename=result_filename,

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -303,3 +303,28 @@ def callInstallNameTool(filename, mapping):
         sys.exit(
             "Error, call to 'install_name_tool' to fix shared library path failed."
         )
+
+def callInstallNameToolAddRPath(filename, rpath):
+    """Adds the rpath path name `rpath` in the specified `filename` Mach-O
+    binary or shared library. If the Mach-O binary already contains the new
+    `rpath` path name, it is an error.
+
+    Args:
+        filename - Mach-O binary or shared library file name.
+        rpath  - rpath path name.
+
+    Returns:
+        None
+
+    Notes:
+        This is obviously macOS specific.
+    """
+    command = ["install_name_tool", "-add_rpath", os.path.join(rpath, '.'), filename]
+
+    with withMadeWritableFileMode(filename):
+        result = subprocess.call(command, stdout=subprocess.PIPE)
+
+    if result != 0:
+        sys.exit(
+            "Error, call to 'install_name_tool' to add rpath failed."
+        )


### PR DESCRIPTION
# What does this PR do?
Fix **standalone** (i.e. compiled with `--standalone` option) executable rpath (MacOS) for libpython.
For embedded-modules compilation (i.e. `--follow-imports` option) and extension module compilation (i.e. `--module` option), similar problems persist.

This is an hotfix (the issue affects also the `master` branch). Anyway, `develop` is selected as base branch, since the modules affected by this PR changed a lot from `master` to `develop`.

# Why was it initiated? Any relevant Issues?
Related to #499 (and #516).

# PR Checklist

- [x] Correct base branch selected? `develop` for new features and bug fixes too.
      If it's part of a hotfix, it will be moved to `master` during it.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis tests that cover the most important things however, and you
      are welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] ~~Ideally new or changed features have documentation updates.~~ Not needed
