### PR TITLE
Update check for conda envs to support Python > 3.6 (issue #580)

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -361,7 +361,7 @@ def shallClearPythonPathEnvironment():
 
 
 def shallUseStaticLibPython():
-    """ *bool* = derived from sys.version
+    """ *bool* = derived from `sys.prefix` and `os.name`
 
     Notes:
         Currently only AnaConda on non-Windows can do this.

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -369,7 +369,7 @@ def shallUseStaticLibPython():
 
     # For AnaConda default to trying static lib python library, which
     # normally is just not available or if it is even unusable.
-    return "Anaconda" in sys.version and os.name == "nt"
+    return os.path.exists(os.path.join(sys.prefix, 'conda-meta')) and not os.name == "nt"
 
 
 def shallTreatUninstalledPython():

--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -149,7 +149,7 @@ def isUninstalledPython():
         system_path = os.path.normcase(buf.value)
         return not getRunningPythonDLLPath().startswith(system_path)
 
-    return "Anaconda" in sys.version or "WinPython" in sys.version
+    return os.path.exists(os.path.join(sys.prefix, 'conda-meta')) or "WinPython" in sys.version
 
 
 def getRunningPythonDLLPath():

--- a/nuitka/tools/testing/Common.py
+++ b/nuitka/tools/testing/Common.py
@@ -110,7 +110,7 @@ import sys, os;\
 print(".".join(str(s) for s in list(sys.version_info)[:3]));\
 print(("x86_64" if "AMD64" in sys.version else "x86") if os.name == "nt" else os.uname()[4]);\
 print(sys.executable);\
-print("Anaconda" if "Anaconda" in sys.version else "Unknown")\
+print("Anaconda" if os.path.exists(os.path.join(sys.prefix, 'conda-meta')) else "Unknown")\
 """,
         ),
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
# What does this PR do?
Update the check command for conda envs, to support Python > 3.6. Checking if "Anaconda" is in sys.version string, lead to wrong results for Python ver. > 3.6, as explained in [this](https://stackoverflow.com/a/21282816/2809027) stackoverflow answer.
This is also related to static linking of libpython (in fact only available for conda on non-windows OS).

# Why was it initiated? Any relevant Issues?
Related to issue #580 and #95.
Maybe also related to issue #499.

# PR Checklist

- [x] Correct base branch selected? `develop` for new features and bug fixes too.
      If it's part of a hotfix, it will be moved to `master` during it.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis tests that cover the most important things however, and you
      are welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] ~~Ideally new or changed features have documentation updates.~~ Not needed
