### PR TITLE
Fix --python-flags=no_docstrings without implying no_asserts

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -543,7 +543,9 @@ def getPythonFlags():
                     _python_flags.add("no_warnings")
                 elif part in ("-O", "no_asserts", "noasserts"):
                     _python_flags.add("no_asserts")
-                elif part in ("-OO", "no_docstrings", "nodocstrings"):
+                elif part in ("no_docstrings", "nodocstrings"):
+                    _python_flags.add("no_docstrings")
+                elif part in ("-OO",):
                     _python_flags.add("no_docstrings")
                     _python_flags.add("no_asserts")
                 else:


### PR DESCRIPTION
Derived from issue #589.