### PR TITLE
Fix, mac ctypes.util does not have _get_soname().

### DIFF
--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -41,6 +41,7 @@ def localDLLFromFilesystem(name, paths):
 
 
 def locateDLL(dll_name):
+    # This function is a case driven by returns, pylint: disable=too-many-return-statements
     import ctypes.util
 
     dll_name = ctypes.util.find_library(dll_name)
@@ -50,6 +51,9 @@ def locateDLL(dll_name):
 
     if isWin32Windows():
         return os.path.normpath(dll_name)
+
+    if sys.platform == "darwin":
+        return dll_name
 
     if os.path.sep in dll_name:
         # Use this from ctypes instead of rolling our own.


### PR DESCRIPTION
# What does this PR do?

On macOS Python ctypes.util does not contain _get_somename() protected method: https://github.com/python/cpython/blob/3.7/Lib/ctypes/util.py#L70 Due to this Nuitka SharedLibraries:locateDLL fails on macOS.

# Why was it initiated? Any relevant Issues?

I stumbled upon this when I was trying to create standalone build from QtQuick Hello World example. 

# PR Checklist

- [x] Correct base branch selected? `develop` for new features and bug fixes too.
      If it's part of a hotfix, it will be moved to `master` during it.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis tests that cover the most important things however, and you
      are welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
