### PR TITLE
Distutils nested namespaces

### DIFF
--- a/nuitka/distutils/DistutilCommands.py
+++ b/nuitka/distutils/DistutilCommands.py
@@ -24,6 +24,7 @@ import distutils.command.install  # pylint: disable=I0021,import-error,no-name-i
 import os
 import subprocess
 import sys
+from distutils import dir_util
 
 import wheel.bdist_wheel  # pylint: disable=I0021,import-error,no-name-in-module
 
@@ -230,6 +231,18 @@ class build(distutils.command.build.build):
 
                     if fullpath.lower().endswith((".py", ".pyw", ".pyc", ".pyo")):
                         os.unlink(fullpath)
+
+            # If the Python module has more than one parent package (e.g.
+            # 'a.b.mod'), the compiled module will be in 'a.b/mod.so'. Move it
+            # to 'a/b/mod.so', to make imports work.
+            if package and "." in package:
+                compiled_package_path = os.path.join(build_lib, package)
+                assert os.path.isdir(compiled_package_path), compiled_package_path
+
+                parts = package.split(".")
+                fixed_package_path = os.path.join(build_lib, *parts)
+                dir_util.copy_tree(compiled_package_path, fixed_package_path)
+                dir_util.remove_tree(compiled_package_path)
 
             os.chdir(old_dir)
 

--- a/nuitka/distutils/DistutilCommands.py
+++ b/nuitka/distutils/DistutilCommands.py
@@ -24,11 +24,11 @@ import distutils.command.install  # pylint: disable=I0021,import-error,no-name-i
 import os
 import subprocess
 import sys
-from distutils import dir_util
 
 import wheel.bdist_wheel  # pylint: disable=I0021,import-error,no-name-in-module
 
 from nuitka.tools.testing.Common import my_print
+from nuitka.utils.FileOperations import copyTree, removeDirectory
 
 
 def setupNuitkaDistutilsCommands(dist, keyword, value):
@@ -241,8 +241,8 @@ class build(distutils.command.build.build):
 
                 parts = package.split(".")
                 fixed_package_path = os.path.join(build_lib, *parts)
-                dir_util.copy_tree(compiled_package_path, fixed_package_path)
-                dir_util.remove_tree(compiled_package_path)
+                copyTree(compiled_package_path, fixed_package_path)
+                removeDirectory(compiled_package_path, ignore_errors=False)
 
             os.chdir(old_dir)
 

--- a/tests/distutils/nested_namespaces/a/b/pkg/__init__.py
+++ b/tests/distutils/nested_namespaces/a/b/pkg/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello, this is", __name__)

--- a/tests/distutils/nested_namespaces/setup.py
+++ b/tests/distutils/nested_namespaces/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name="nested_namespaces",
+    version="1.0.0",
+    description=(
+        "bdist_nuitka test-case that verifies that Nuitka correctly handles"
+        " nested implicit namespaces"
+    ),
+    packages=["a.b.pkg"],
+    entry_points={"console_scripts": ["runner = a.b.pkg:main"]},
+)

--- a/tests/distutils/run_all.py
+++ b/tests/distutils/run_all.py
@@ -57,7 +57,7 @@ from nuitka.utils.FileOperations import removeDirectory
 
 
 def main():
-    # Complex stuff, pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # Complex stuff, pylint: disable=too-many-locals,too-many-statements
 
     python_version = setup(needs_io_encoding=True)
 
@@ -83,11 +83,9 @@ def main():
         if active:
             my_print("Consider distutils example:", filename)
 
-            if python_version < "3" and filename == "example_3":
+            py3_only_examples = ("example_3", "nested_namespaces")
+            if python_version < "3" and filename in py3_only_examples:
                 reportSkip("Skipped, only relevant for Python3", ".", filename)
-                continue
-            if python_version < "3.3" and filename == "nested_namespaces":
-                reportSkip("Skipped, only relevant from Python 3.3", ".", filename)
                 continue
 
             case_dir = os.path.join(os.getcwd(), filename)

--- a/tests/distutils/run_all.py
+++ b/tests/distutils/run_all.py
@@ -83,10 +83,12 @@ def main():
         if active:
             my_print("Consider distutils example:", filename)
 
-            if python_version < "3":
-                if filename == "example_3":
-                    reportSkip("Skipped, only relevant for Python3", ".", filename)
-                    continue
+            if python_version < "3" and filename == "example_3":
+                reportSkip("Skipped, only relevant for Python3", ".", filename)
+                continue
+            if python_version < "3.3" and filename == "nested_namespaces":
+                reportSkip("Skipped, only relevant from Python 3.3", ".", filename)
+                continue
 
             case_dir = os.path.join(os.getcwd(), filename)
 


### PR DESCRIPTION
# What does this PR do?

Fixes support of the build_nuitka distutils command for implicit namespace packages nested more than one level deep.

# Why was it initiated? Any relevant Issues?

This bug was reported in  #612.