### PR TITLE
Add OpenBSD to clang and posix platforms.

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -157,6 +157,8 @@ noelf_mode = getBoolOption("noelf_mode", False)
 
 macosx_target = sys.platform == "darwin"
 
+openbsd_target = sys.platform.startswith("openbsd")
+
 # Windows subsystem mode: Disable console for windows builds.
 win_disable_console = getBoolOption("win_disable_console", False)
 
@@ -172,7 +174,11 @@ target_arch = ARGUMENTS["target_arch"]
 
 # Clang compiler mode, forced on macOS and FreeBSD (excluding PowerPC), optional on Linux.
 clang_mode = getBoolOption("clang_mode", False)
-if macosx_target or ("freebsd" in sys.platform and target_arch != "powerpc"):
+if (
+    macosx_target
+    or openbsd_target
+    or ("freebsd" in sys.platform and target_arch != "powerpc")
+):
     clang_mode = True
 
 # Clang on Windows is always clang-cl for now.

--- a/nuitka/freezer/Standalone.py
+++ b/nuitka/freezer/Standalone.py
@@ -1206,7 +1206,10 @@ def detectBinaryDLLs(
         "otool" (macOS) the list of used DLLs is retrieved.
     """
 
-    if Utils.getOS() in ("Linux", "NetBSD", "FreeBSD") or Utils.isPosixWindows():
+    if (
+        Utils.getOS() in ("Linux", "NetBSD", "FreeBSD", "OpenBSD")
+        or Utils.isPosixWindows()
+    ):
         return _detectBinaryPathDLLsPosix(dll_filename=original_filename)
     elif Utils.isWin32Windows() and Options.getWindowsDependencyTool() == "pefile":
         with TimerReport(


### PR DESCRIPTION
# What does this PR do?

Clang is the default compiler on the most of platforms supported by OpenBSD. It also has gcc in the base system but the version is too old for the Nuitka requirements and will be deleted in the future.

# Why was it initiated? Any relevant Issues?

The changes are needed to support OpenBSD and for the issue #662.

# PR Checklist

- [x] Correct base branch selected? `develop` for new features and bug fixes too.
      If it's part of a hotfix, it will be moved to `master` during it.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis tests that cover the most important things however, and you
      are welcome to rely on those, but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
