### PR TITLE
Fixed bad diagnostic error, if user use old plugin option format like --enable-plugin=numpy=scipy

### DIFF
--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -776,7 +776,7 @@ def _considerPluginOptions():
             if "=" in plugin_name:
                 sys.exit(
                     "Error, plugin options format changed. Use '--plugin-enable=%s --help' to know new options."
-                    % plugin_name
+                    % plugin_name.split('=', 1)[0]
                 )
 
             addPluginCommandLineOptions(parser=parser, plugin_name=plugin_name)


### PR DESCRIPTION
# What does this PR do?
Fixed bad diagnostic message — if user used old plugin options format, like 
«--enable-plugin=numpy=scipy» it gets error message
«Error, plugin options format changed. Use '--enable-plugin=numpy=scipy --help», and catched in bad recursion.

