### PR TITLE
Fixed the output of "objdump" not to be translated

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -1409,6 +1409,9 @@ def _getBinaryArch(binary):
         if show_scons_mode:
             print("Scons: Detecting arch with :", command)
 
+        _env = os.environ.copy()
+        _env["LANG"] = "C"
+
         try:
             proc = subprocess.Popen(
                 command,
@@ -1416,6 +1419,7 @@ def _getBinaryArch(binary):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
+                env=_env,
             )
         except OSError:
             return None


### PR DESCRIPTION
# What does this PR do?
Fixed the output of "objdump" not to be translated

# Why was it initiated? Any relevant Issues?
When run with --windows-dependency-tool=pefile option,
_getBinaryArch function does not work properly when the output of "objdump" command is translated