### PR TITLE
fix storing ellipsis as a docstring…

### DIFF
--- a/nuitka/tree/TreeHelpers.py
+++ b/nuitka/tree/TreeHelpers.py
@@ -66,8 +66,9 @@ def extractDocFromBody(node):
             doc = body[0].value.s
             body = body[1:]
         elif getKind(body[0].value) == "Constant":  # python3.8
-            doc = body[0].value.value
-            body = body[1:]
+            if body[0].value.value is not Ellipsis:
+                doc = body[0].value.value
+                body = body[1:]
 
         if "no_docstrings" in Options.getPythonFlags():
             doc = None


### PR DESCRIPTION
# What does this PR do?
fix storing **ellipsis** `...` as a **docstring** when the object [e.g. a class] body is just an ellipsis. 
in standard it should be None, same as when using `pass` as the object body.

# Why was it initiated? Any relevant Issues?
Yes #852 , 
here is the code which get mis-compiled, and cause **_deprecated_** decorator in **_matplotlib_** to raise exeption as it assumes the **docstring**  is a string [or None].

\'_matplotlib/colors.py_\'  , note: the `...` is from the code it self, **NOT** presenting omitted text.
```
@cbook.deprecation.deprecated('3.2', alternative='TwoSlopeNorm')
class DivergingNorm(TwoSlopeNorm):
    ...
```

# PR Checklist
#### Note: Unfortunately, I didn't do the tests, it's small direct fix and I don't have a ready Nuitka dev-environment.

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis and Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
