### PR TITLE
docs: fix simple typo, resourcs -> resources

### DIFF
--- a/nuitka/utils/WindowsResources.py
+++ b/nuitka/utils/WindowsResources.py
@@ -56,7 +56,7 @@ def getResourcesFromDLL(filename, resource_kinds, with_data=False):
         with_data - Return value includes data or only the name, lang pairs
 
     Returns:
-        List of resourcs in the DLL, see with_data which controls scope.
+        List of resources in the DLL, see with_data which controls scope.
 
     """
     # Quite complex stuff, pylint: disable=too-many-locals


### PR DESCRIPTION
There is a small typo in nuitka/utils/WindowsResources.py.

Should read `resources` rather than `resourcs`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md