### PR TITLE
Hotfix: Add Missing Scipy v1.6.0 Implicit Imports to ImplicitImports Plugin

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -771,7 +771,7 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
         elif full_name == "scipy._lib":
             yield "scipy._lib.messagestream"
 
-        # scipy imports -------------------------------------------------------
+        # statsmodels imports -------------------------------------------------------
         elif full_name == "statsmodels.nonparametric":
             yield "statsmodels.nonparametric.linbin"
             yield "statsmodels.nonparametric._smoothers_lowess"

--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -770,6 +770,10 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             yield "scipy.sparse.csgraph._validation"
         elif full_name == "scipy._lib":
             yield "scipy._lib.messagestream"
+        elif full_name == "scipy.spatial":
+            yield "scipy.spatial.transform"
+        elif full_name == "scipy.spatial.transform":
+            yield "scipy.spatial.transform._rotation_groups"
 
         # statsmodels imports -------------------------------------------------------
         elif full_name == "statsmodels.nonparametric":


### PR DESCRIPTION
# What does this PR do?

The spicy module has additional implicit imports that are missing in the ImplicitImports plugin.

# Why was it initiated? Any relevant Issues?

If you compile a python program Ising Nuitka with the following flags
`--plugin-enable=numpy --plugin-enable=implicit-imports --follow-imports --standalone`
then try to run that program, you'll get the following error
`ModuleNotFoundError: No module named 'scipy.spatial.transform._rotation_groups'`

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis and Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
