### PR TITLE
docs: typo in pip development requirements instructions

### DIFF
--- a/Developer_Manual.rst
+++ b/Developer_Manual.rst
@@ -184,7 +184,7 @@ In order to set up hooks, you need to execute these commands:
 
    # Where python is the one you use with Nuitka, this then gets all
    # development requirements, can be full PATH.
-   python -m pip install requirements-devel.txt
+   python -m pip install -r requirements-devel.txt
    python ./misc/install-git-hooks.py
 
 


### PR DESCRIPTION
Minor documentation fix in developer manual about pip-installing the development requirements from file.