### PR TITLE
fix: locateDLLFromFilesystem fallback in case of no exact match found

### DIFF
--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -47,9 +47,8 @@ def locateDLLFromFilesystem(name, paths):
     for path in paths:
         for root, _dirs, files in os.walk(path):
             for file in files:
-                if name in file and '.so' in file:
+                if name in file and ".so" in file:
                     return os.path.join(root, file)
-            
 
 
 _ldconfig_usage = "The 'ldconfig' is used to analyse dependencies on ELF using systems and required to be found."

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -43,6 +43,13 @@ def locateDLLFromFilesystem(name, paths):
         for root, _dirs, files in os.walk(path):
             if name in files:
                 return os.path.join(root, name)
+    # Fallback in case of no exact match found
+    for path in paths:
+        for root, _dirs, files in os.walk(path):
+            for file in files:
+                if name in file and '.so' in file:
+                    return os.path.join(root, file)
+            
 
 
 _ldconfig_usage = "The 'ldconfig' is used to analyse dependencies on ELF using systems and required to be found."


### PR DESCRIPTION
Closes #1046 