### PR TITLE
readme: fix typo 'Studion' -> 'Studio'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Requirements
       garbage outputs, but only for that language).
 
    -  On Windows the ``clang-cl`` compiler on Windows can be used if
-      provided by the Visual Studion installer.
+      provided by the Visual Studio installer.
 
 -  Python: Version 2.6, 2.7 or 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
 


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md)

# What does this PR do?
Fixes typo in README.rst.

# Why was it initiated? Any relevant Issues?
I saw typo.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Travis and Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
