### PR TITLE
[implicit_import] added 'pandas._libs.window' to 'pandas.core.window'

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -931,6 +931,7 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             yield "pandas._libs.tslibs.nattype"
             yield "pandas._libs.tslibs.base"
         elif full_name == "pandas.core.window":
+            yield "pandas._libs.window"
             yield "pandas._libs.skiplist"
         elif full_name == "pandas._libs.testing":
             yield "cmath"


### PR DESCRIPTION
Hello

# Why was it initiated? Any relevant Issues?
This PR comes in addition to issue #837. The currently last comment of @EBenkler describes the problem I had, when using the `pandas` module in a project.
Even if I just have

```python
import pandas as pd
```

as a minimum code sample I ran into:

```
import pandas as pd
  File "/.../lib/python3.9/site-packages/pandas/__init__.py", line 51, in <module pandas>
    from pandas.core.api import (
  File "/.../lib/python3.9/site-packages/pandas/core/api.py", line 31, in <module pandas.core.api>
    from pandas.core.groupby import Grouper, NamedAgg
  File "/.../lib/python3.9/site-packages/pandas/core/groupby/__init__.py", line 1, in <module pandas.core.groupby>
    from pandas.core.groupby.generic import DataFrameGroupBy, NamedAgg, SeriesGroupBy
  File "/.../lib/python3.9/site-packages/pandas/core/groupby/generic.py", line 65, in <module pandas.core.groupby.generic>
    from pandas.core.frame import DataFrame
  File "/.../lib/python3.9/site-packages/pandas/core/frame.py", line 119, in <module pandas.core.frame>
    from pandas.core import algorithms, common as com, generic, nanops, ops
  File "/.../lib/python3.9/site-packages/pandas/core/generic.py", line 111, in <module pandas.core.generic>
    from pandas.core.window import Expanding, ExponentialMovingWindow, Rolling, Window
  File "/.../lib/python3.9/site-packages/pandas/core/window/__init__.py", line 1, in <module pandas.core.window>
    from pandas.core.window.ewm import (  # noqa:F401
  File "/.../lib/python3.9/site-packages/pandas/core/window/ewm.py", line 9, in <module pandas.core.window.ewm>
    import pandas._libs.window.aggregations as window_aggregations
ModuleNotFoundError: No module named 'pandas._libs.window'
```


# What does this PR do?
I fixed the above error by adding the module `pandas._libs.window` to the implicit imports. Then my code sample works without problems.

I didn't created a new test case in the `tests` directory, because the current test case in `tests/standalone/PandasUsing.py` is nearly the same as my code sample. But I can't say why this error did not occur in your test environment.


# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
    **Partial. Only tested the `PandasUsing.py`**
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
    **No, because test already exists (see above)**
- [ ] Ideally new or changed features have documentation updates.
    **No new features**
