### PR TITLE
Fix index out of range while finding module.

### DIFF
--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -624,7 +624,7 @@ def _findModule2(module_name):
 
     preloaded_path = getPreloadedPackagePath(module_name)
 
-    if preloaded_path is not None:
+    if preloaded_path:
         return preloaded_path[0]
 
     return _findModuleInPath(module_name=module_name)


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md)

# What does this PR do?
While `is not None` doesn't check whether the list is empty, it may raise `IndexError: list index out of range`.

# Why was it initiated? Any relevant Issues?
While I try to build use nuitka, I meet this bug.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch. 
- [x] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.

Since this is just a fix, I don't add new features.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates. 
