### PR TITLE
onefile icons linux: look for versioned icon file first

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -869,14 +869,20 @@ def getIconPaths():
 
     # Check if Linux icon requirement is met.
     if getOS() == "Linux" and not result and isOnefileMode():
-        default_icon = "/usr/share/pixmaps/python.xpm"
-        if os.path.exists(default_icon):
-            result.append(default_icon)
+        default_icons = [
+            "/usr/share/pixmaps/python%s.%s.xpm" % (sys.version_info.major, sys.version_info.minor),
+            "/usr/share/pixmaps/python%s.xpm" % sys.version_info.major,
+            "/usr/share/pixmaps/python.xpm",
+        ]
+        for icon in default_icons:
+            if os.path.exists(icon):
+                result.append(icon)
+                break
         else:
             Tracing.options_logger.sysexit(
                 """\
-Error, the default icon %r does not exist, making --linux-onefile-icon required."""
-                % default_icon
+Error, the non of the default icons %r exist, making --linux-onefile-icon required."""
+                % ", ".join(default_icons)
             )
 
     return result


### PR DESCRIPTION
for look for an icon for pythonMAJOR.MINOR.xpm, then pythonMAJOR.xpm
then python.xpm.
on some systems (e.g. ubuntu) python.xpm does not exist.
