### PR TITLE
Fixing one of list of the parameters for default icons paths and correcting the relevant error message

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -870,8 +870,8 @@ def getIconPaths():
     # Check if Linux icon requirement is met.
     if getOS() == "Linux" and not result and isOnefileMode():
         default_icons = (
-            "/usr/share/pixmaps/python%s.%s.xpm" % python_version_str,
-            "/usr/share/pixmaps/python%s.xpm" % sys.version_info[0],
+            "/usr/share/pixmaps/python%s.%s.xpm" % (sys.version_info.major, sys.version_info.minor),
+            "/usr/share/pixmaps/python%s.xpm" % sys.version_info.major,
             "/usr/share/pixmaps/python.xpm",
         )
 
@@ -882,7 +882,7 @@ def getIconPaths():
         else:
             Tracing.options_logger.sysexit(
                 """\
-Error, the non of the default icons '%s' exist, making --linux-onefile-icon required."""
+Error, none of the default icons '%s' exist, making --linux-onefile-icon required."""
                 % ", ".join(default_icons)
             )
 


### PR DESCRIPTION

# What does this PR do?
It's a simple fix in `nuitka.Options` **getIconPaths** function to ensure the first path in the `default_icons` list can be correctly expanded. There is also a minor correction of the corresponding error message.

# Why was it initiated? Any relevant Issues?

```$ nuitka3 --verbose --follow-imports --standalone  --onefile ./test.py
Traceback (most recent call last):
  File "/home/vagrant/.local/bin/nuitka3", line 8, in <module>
    sys.exit(main())
  File "/home/vagrant/.local/lib/python3.7/site-packages/nuitka/__main__.py", line 83, in main
    Options.parseArgs(will_reexec=True)
  File "/home/vagrant/.local/lib/python3.7/site-packages/nuitka/Options.py", line 179, in parseArgs
    if len(getIconPaths()) > 1:
  File "/home/vagrant/.local/lib/python3.7/site-packages/nuitka/Options.py", line 873, in getIconPaths
    "/usr/share/pixmaps/python%s.%s.xpm" % python_version_str,
TypeError: not enough arguments for format string```

PR#1131 seems like a good attempt but the merge might not have been properly done.
