### PR TITLE
add support for singed onefile-application on windows

### DIFF
--- a/nuitka/build/Onefile.scons
+++ b/nuitka/build/Onefile.scons
@@ -688,6 +688,9 @@ target = env.Program(result_exe, source_files + source_targets)
 # Avoid dependency on MinGW libraries.
 if win_target and gcc_mode and not clang_mode:
     env.Append(LINKFLAGS=["-static-libgcc"])
+# on Windows link against imagehlp to support signed applications detection
+if win_target:
+    link_libraries.append("imagehlp")
 
 # Avoid IO for compilation as much as possible, this should make the
 # compilation more memory hungry, but also faster.

--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -419,6 +419,12 @@ def packDistFolderToOnefileBootstrap(onefile_output_filename, dist_dir):
                 )
             )
 
+        # add padding to have the start position at a double world boundary
+        # this is needed on windows so that a possible certificate immediately
+        # follows the start position
+        pad = output_file.tell() % 8
+        if pad != 0:
+            output_file.write(bytes(8 - pad))
         output_file.write(struct.pack("Q", start_pos))
 
     closeProgressBar()


### PR DESCRIPTION
parse the pe header using MapAndLoad() system function
to find out whether the application has a trailling certificate
rather then assume that the start position of the container is at the
very end of the file.

Close: #1154