### PR TITLE
When onefile pack failed, check the output file exists before delete it.

### DIFF
--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -195,7 +195,8 @@ Categories=Utility;"""
 
     if result != 0:
         # Useless now.
-        os.unlink(onefile_output_filename)
+        if os.path.exists(onefile_output_filename):
+            os.unlink(onefile_output_filename)
 
         stderr = getFileContents(stderr_filename, mode="rb")
 


### PR DESCRIPTION
# What does this PR do?
`FileNotFoundError` will be raised when `onefile` command execute failed. 
At that time, the `onefile_output_filename` may not exists, so add a check before delete it.

# Why was it initiated? Any relevant Issues?
#1170 
Finally found that problem occur when `onefile_output_filename` not exists.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
