### PR TITLE
Add GI plugin to copy typelib files and set search path

### DIFF
--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -1,0 +1,89 @@
+""" Support for gi typelib files
+"""
+import os
+
+from nuitka import Options
+from nuitka.plugins.PluginBase import NuitkaPluginBase
+from nuitka.freezer.IncludedDataFiles import makeIncludedDataDirectory
+
+
+def _isGiModule(module):
+    full_name = module.getFullName()
+    return full_name == "gi"
+
+
+class GiPlugin(NuitkaPluginBase):
+    plugin_name = "gi"
+    plugin_desc = "Support for GI dependencies"
+
+    @classmethod
+    def isRelevant(cls):
+        """This method is called one time only to check, whether the plugin might make sense at all.
+
+        Returns:
+            True if this is a standalone compilation.
+        """
+        return Options.isStandaloneMode()
+
+    @staticmethod
+    def createPreModuleLoadCode(module):
+        """Add typelib search path"""
+
+        if _isGiModule(module):
+            code = r"""
+import os
+if not os.environ.get("GI_TYPELIB_PATH="):
+    os.environ["GI_TYPELIB_PATH"] = os.path.join(__nuitka_binary_dir, "girepository")"""
+
+            return code, "Set typelib search path"
+
+    def considerDataFiles(self, module):
+        """Copy typelib files from the default installation path"""
+        if _isGiModule(module):
+            path = self.queryRuntimeInformationMultiple(
+                info_name="gi_info",
+                setup_codes="import gi; from gi.repository import GObject",
+                values=(
+                    (
+                        "introspection_module",
+                        "gi.Repository.get_default().get_typelib_path('GObject')",
+                    ),
+                ),
+            )
+
+            gi_repository_path = os.path.dirname(path.introspection_module)
+            yield makeIncludedDataDirectory(
+                source_path=gi_repository_path,
+                dest_path="girepository",
+                reason="typelib files for gi modules",
+            )
+
+
+class GiPluginDetector(NuitkaPluginBase):
+    """Only used if plugin is NOT activated
+
+    Notes:
+         We are given the chance to issue a warning if we think we may be required.
+    """
+
+    detector_for = GiPlugin
+
+    @classmethod
+    def isRelevant(cls):
+        """Check whether plugin might be required.
+        Returns:
+            True if this is a standalone compilation.
+        """
+        return Options.isStandaloneMode()
+
+    def onModuleDiscovered(self, module):
+        """This method checks whether gi is required.
+        Notes:
+            For this we check whether its first name part is gi relevant.
+        Args:
+            module: the module object
+        Returns:
+            None
+        """
+        if module.getFullName() == "gi":
+            self.warnUnusedPlugin("Missing gi support.")


### PR DESCRIPTION
# What does this PR do?

Include typelib files for gi libraries and set up the correct search path.

# Why was it initiated? Any relevant Issues?

Following from a discussion on #1011 

I marked it as draft because I still want to improve some things, but the proof of concept seems to work.
I verified with strace to see that the typelib files are loaded from the dist folder.

# TODO

The typelib files seem to be some kind of database format, but they are not actually libraries, so I opted for the `considerDataFiles` method. 
- [ ] Should I still use the DLL option?
- [ ] I hard-coded the path to the `girepository-1.0` folder, but I need to figure out how to detect that from the installation.
- [ ] Currently I am copying the whole folder, but I should add a check to only copy the matching typelibs for loaded modules.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
