### PR TITLE
Added ipcqueue dependency on _cffi_backend

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -119,6 +119,8 @@ class NuitkaPluginPopularImplicitImports(NuitkaPluginBase):
             yield "_cffi_backend"
         elif full_name == "brotli._brotli":
             yield "_cffi_backend"
+        elif full_name == "ipcqueue":
+            yield "_cffi_backend"
         elif full_name == "_dbus_glib_bindings":
             yield "_dbus_bindings"
         elif full_name == "_mysql":


### PR DESCRIPTION
This PR adds a single entry to the ImplicitImports plugin - the "ipcqueue" Python module (Posix and SysV message-queues) has a dependency upon _cffi_backend.