### PR TITLE
Normalize paths before comparing

### DIFF
--- a/nuitka/build/SconsCaching.py
+++ b/nuitka/build/SconsCaching.py
@@ -139,7 +139,7 @@ def _injectCcache(
         # Make sure the
         # In case we are on Windows, make sure the Anaconda form runs outside of Anaconda
         # environment, by adding DLL folder to PATH.
-        assert getExecutablePath(os.path.basename(the_compiler), env=env) == cc_path
+        assert os.path.normpath(getExecutablePath(os.path.basename(the_compiler), env=env)) == os.path.normpath(cc_path)
 
         # We use absolute paths for CC, pass it like this, as ccache does not like absolute.
         env["CXX"] = env["CC"] = '"%s" "%s"' % (ccache_binary, cc_path)


### PR DESCRIPTION
# What does this PR do?

Normalize the paths of the downloaded gcc on Windows before comparing them.

# Why was it initiated? Any relevant Issues?

When compiling on msys2 (mingw64) and after downloading the proposed gcc.exe I was getting an error that the path does not match.
It seems msys2 is very tolerant about using forward (/) or backward (\) slashes in paths, and in my case they were not matching up, causing a miscompare.
Using `os.path.normpath` normalizes these paths so they can be safely compared.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
