### PR TITLE
OptionParsing: --macos-app-version belongs to macos_group

### DIFF
--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -1154,7 +1154,7 @@ Name of the product to use in macOS bundle information. Defaults to base
 filename of the binary.""",
 )
 
-windows_group.add_option(
+macos_group.add_option(
     "--macos-app-version",
     action="store",
     dest="macos_app_version",


### PR DESCRIPTION
This was falsely assigned to windows_group.


# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
