### PR TITLE
Testing: Allow accessing qt6 dirs

### DIFF
--- a/nuitka/tools/testing/Common.py
+++ b/nuitka/tools/testing/Common.py
@@ -1625,8 +1625,12 @@ def checkLoadedFileAccesses(loaded_filenames, current_dir):
         if loaded_filename == os.path.join(lib_prefix_dir, "dist-packages/gobject"):
             continue
 
-        # PyQt5 seems to do this, but won't use contents then.
+        # PyQt5 and PySide6 seems to do this, but won't use contents then.
         if loaded_filename in (
+            "/usr/lib/qt6/plugins",
+            "/usr/lib/qt6",
+            "/usr/lib64/qt6/plugins",
+            "/usr/lib64/qt6",
             "/usr/lib/qt5/plugins",
             "/usr/lib/qt5",
             "/usr/lib64/qt5/plugins",


### PR DESCRIPTION
# What does this PR do?

Ignore QT6 dir access in the tests like QT5 dirs are already ignored.

# Why was it initiated? Any relevant Issues?

openSUSE test suite failures

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
