### PR TITLE
Optimization: avoid loop in generated code for args_count == 1

### DIFF
--- a/nuitka/codegen/templates/CodeTemplateCallsPositional.j2
+++ b/nuitka/codegen/templates/CodeTemplateCallsPositional.j2
@@ -44,7 +44,9 @@ PyObject *CALL_FUNCTION_WITH_ARGS{{args_count}}(PyObject *called, PyObject *cons
         PyObject *result;
 
         if (function->m_args_simple && {{args_count}} == function->m_args_positional_count){
-{% if args_count != 0 %}
+{% if args_count == 1 %}
+            Py_INCREF(args[0]);
+{% elif args_count > 1 %}
             for (Py_ssize_t i = 0; i < {{args_count}}; i++) {
                 Py_INCREF(args[i]);
             }
@@ -122,7 +124,10 @@ PyObject *CALL_FUNCTION_WITH_ARGS{{args_count}}(PyObject *called, PyObject *cons
                 python_pars[0] = method->m_object;
                 Py_INCREF(method->m_object);
 
-{% if args_count != 0 %}
+{% if args_count == 1 %}
+                python_pars[1] = args[0];
+                Py_INCREF(args[0]);
+{% elif args_count > 1 %}
                 for (Py_ssize_t i = 0; i < {{args_count}}; i++) {
                     python_pars[i + 1] = args[i];
                     Py_INCREF(args[i]);


### PR DESCRIPTION
I noticed the code at https://github.com/Nuitka/Nuitka/blob/f4b08e086c2898013a08b74bb45b0ee01f04be8a/nuitka/build/static_src/HelpersCalling2.c#L358 has a useless loop and tried to generate simpler code for that case.

Honestly, I have no idea if C compilers are smart enough these days to detect this, so I don't know whether or not this change will have any net effect.

PS: This is against factory, but I can redo it against develop if you think it's worth it.