### PR TITLE
WIP: Allow switching compression algorithms for generated AppImages

### DIFF
--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -1267,6 +1267,15 @@ linux_group.add_option(
     help="Add executable icon for onefile binary to use. Can be given only one time. Defaults to Python icon if available.",
 )
 
+linux_group.add_option(
+    "--linux-onefile-compression",
+    action="store",
+    dest="appimage_compression",
+    metavar="COMPRESSION",
+    default="gzip",
+    help="Compression method to use for Linux onefile builds. gzip (default): larger file but faster startup, xz: smaller file but slower startup."
+)
+
 parser.add_option_group(linux_group)
 
 plugin_group = OptionGroup(parser, "Plugin control")

--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -1271,9 +1271,10 @@ linux_group.add_option(
     "--linux-onefile-compression",
     action="store",
     dest="appimage_compression",
+    choices=("gzip", "xz"),
     metavar="COMPRESSION",
     default="gzip",
-    help="Compression method to use for Linux onefile builds. gzip (default): larger file but faster startup, xz: smaller file but slower startup."
+    help="Compression method to use for Linux onefile builds. Defaults to gzip for faster decompression"
 )
 
 parser.add_option_group(linux_group)

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1333,6 +1333,8 @@ def getMacOSAppVersion():
     """*str* version of the app to use for bundle"""
     return options.macos_app_version
 
+def getAppImageCompression():
+    return options.appimage_compression
 
 _python_flags = None
 

--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -170,26 +170,22 @@ Categories=Utility;"""
     stdout_file = openTextFile(stdout_filename, "wb")
     stderr_file = openTextFile(stderr_filename, "wb")
 
-    if options.appimage_compression == "xz" or options.appimage_compression == "gzip":
-        command = (
-            _getAppImageToolPath(
-                for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
-            ),
-            dist_dir,
-            "--comp",
-            options.appimage_compression,
-            "-n",
-            onefile_output_filename,
-        )
+    if options.appimage_compression == "gzip":
+        compress_flags = "--comp gzip"
+    elif options.appimage_compression == "xz":
+        compress_flags = "--comp xz"
     else:
-        command = (
-            _getAppImageToolPath(
-                for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
-            ),
-            dist_dir,
-            "-n",
-            onefile_output_filename,
-        )
+        compress_flags = ""
+
+    command = (
+        _getAppImageToolPath(
+            for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
+        ),
+        dist_dir,
+        compress_flags,
+        "-n",
+        onefile_output_filename,
+    )
 
     stderr_file.write(b"Executed %r\n" % " ".join(command))
 

--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -25,7 +25,7 @@ import sys
 
 from nuitka import Options, OutputDirectories
 from nuitka.build import SconsInterface
-from nuitka.Options import assumeYesForDownloads, getIconPaths, options
+from nuitka.Options import assumeYesForDownloads, getIconPaths, getAppImageCompression
 from nuitka.OutputDirectories import getResultBasepath, getResultFullpath
 from nuitka.plugins.Plugins import Plugins
 from nuitka.PostProcessing import (
@@ -170,19 +170,13 @@ Categories=Utility;"""
     stdout_file = openTextFile(stdout_filename, "wb")
     stderr_file = openTextFile(stderr_filename, "wb")
 
-    if options.appimage_compression == "gzip":
-        compress_flags = "--comp gzip"
-    elif options.appimage_compression == "xz":
-        compress_flags = "--comp xz"
-    else:
-        compress_flags = ""
-
     command = (
         _getAppImageToolPath(
             for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
         ),
         dist_dir,
-        compress_flags,
+        "--comp",
+        getAppImageCompression(),
         "-n",
         onefile_output_filename,
     )

--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -25,7 +25,7 @@ import sys
 
 from nuitka import Options, OutputDirectories
 from nuitka.build import SconsInterface
-from nuitka.Options import assumeYesForDownloads, getIconPaths
+from nuitka.Options import assumeYesForDownloads, getIconPaths, options
 from nuitka.OutputDirectories import getResultBasepath, getResultFullpath
 from nuitka.plugins.Plugins import Plugins
 from nuitka.PostProcessing import (
@@ -170,16 +170,26 @@ Categories=Utility;"""
     stdout_file = openTextFile(stdout_filename, "wb")
     stderr_file = openTextFile(stderr_filename, "wb")
 
-    command = (
-        _getAppImageToolPath(
-            for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
-        ),
-        dist_dir,
-        "--comp",
-        "xz",
-        "-n",
-        onefile_output_filename,
-    )
+    if options.appimage_compression == "xz" or options.appimage_compression == "gzip":
+        command = (
+            _getAppImageToolPath(
+                for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
+            ),
+            dist_dir,
+            "--comp",
+            options.appimage_compression,
+            "-n",
+            onefile_output_filename,
+        )
+    else:
+        command = (
+            _getAppImageToolPath(
+                for_operation=True, assume_yes_for_downloads=assumeYesForDownloads()
+            ),
+            dist_dir,
+            "-n",
+            onefile_output_filename,
+        )
 
     stderr_file.write(b"Executed %r\n" % " ".join(command))
 

--- a/nuitka/utils/Utils.py
+++ b/nuitka/utils/Utils.py
@@ -82,12 +82,6 @@ def getLinuxDistribution():
     # singleton, pylint: disable=global-statement
     global _linux_distribution_info
 
-<<<<<<< HEAD
-=======
-    if getOS() != "Linux":
-        return None, None, None
-
->>>>>>> 632cc2315a16d2976bdc6fd21b72267816456f34
     if _linux_distribution_info is None:
         result = None
         base = None
@@ -97,11 +91,8 @@ def getLinuxDistribution():
             result, base, version = _parseOsReleaseFileContents("/etc/os-release")
         elif os.path.exists("/etc/SuSE-release"):
             result, base, version = _parseOsReleaseFileContents("/etc/SuSE-release")
-<<<<<<< HEAD
         elif os.path.exists("/etc/issue"):
             result, base, version = _parseOsReleaseFileContents("/etc/issue")
-=======
->>>>>>> 632cc2315a16d2976bdc6fd21b72267816456f34
 
         if result is None:
             from .Execution import check_output
@@ -117,14 +108,10 @@ def getLinuxDistribution():
         if result is None:
             from nuitka.Tracing import general
 
-<<<<<<< HEAD
             general.warning(
                 "Cannot detect Linux distribution, this may prevent optimization."
             )
             result = "Unknown"
-=======
-            general.sysexit("Error, cannot detect Linux distribution.")
->>>>>>> 632cc2315a16d2976bdc6fd21b72267816456f34
 
         # Change e.g. "11 (Bullseye)"" to "11".
         if version is not None and version.strip():


### PR DESCRIPTION
# What does this PR do?
Adds a flag to set different supported compression algorithms for generating AppImages on Linux (currently only gzip and xz are supported)

# Why was it initiated? Any relevant Issues?
xz is currently the default, however it takes a long time to extract and offers little size benefits over gzip in my testing. However rather than replacing it entirely this patch allows the user to manually choose which one they want (although it defaults to gzip as per appimagetool's default)

# PR Checklist

- [ ✓ ] Correct base branch selected? Should be `develop` branch.
- [ ✓ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ X ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ X ] Ideally new or changed features have documentation updates.

Note: Don't merge yet! I haven't tested it yet as it's 11:00 on a school night and I really should be getting some sleep. I'll update this once I have done some testing and confirmed it works.