### PR TITLE
adding param allowing to overwrite existing directories

### DIFF
--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -163,7 +163,7 @@ def makePath(path):
 
     with withFileLock("creating directory %s" % path):
         if not os.path.isdir(path):
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
 
 
 def isPathExecutable(path):


### PR DESCRIPTION
setup: qemu vm win10 with python 3.8.10 and nuitka 0.6.19.7

When building a binary with `--onefile` option python error

> FileExistsError: [WinError 183]

came up. with every retry, other files were tried to be overwritten. Changing the second parameter of `os.makedirs()` fixed it (see [python docs](https://docs.python.org/3/library/os.html#os.makedirs)). But I don't know if the files that are overwritten now are needed elsewhere. `os.path.isdir()` from line before seems to "fail" in this case. maybe race conditions, when in line 166, condition of 165 is not true anymore?.