### PR TITLE
Fix crash in isDebianSuitableForStaticLinking if version is non-numeric.

### DIFF
--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -81,7 +81,11 @@ def isDebianSuitableForStaticLinking():
         if dist_version is None:
             return True
 
-        dist_version = tuple(int(x) for x in dist_version.split("."))
+        try:
+            dist_version = tuple(int(x) for x in dist_version.split("."))
+        except ValueError:
+            # dist_version contains a non-numeric string such as "sid".
+            return True
 
         return dist_version >= (10,)
     else:


### PR DESCRIPTION
# What does this PR do?

Update `isDebianSuitableForStaticLinking` to account for the possibility of non-numeric versions.

I think `sid` is the only string that should ever show up here, but it seems like this check is designed to return `True` in all unexpected situations, so I caught the `ValueError` rather than adding an explicit check for `dist_version == "sid"`.

As far as I can tell there are no existing tests covering this logic, so I didn't update any.

# Why was it initiated? Any relevant Issues?

Currently, `nuitka --onefile` crashes on Debian sid because `getLinuxDistribution` returns dist_version `sid` rather than a numeric version number:

```
$ python -m nuitka --onefile hello.py
Nuitka-Options:INFO: Used command line options: --onefile hello.py
Traceback (most recent call last):
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/__main__.py", line 137, in <module>
    main()
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/__main__.py", line 88, in main
    Options.parseArgs()
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/Options.py", line 445, in parseArgs
    if shallUseStaticLibPython() and getSystemStaticLibPythonPath() is None:
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/Options.py", line 955, in shallUseStaticLibPython
    _shall_use_static_lib_python, reason = _shallUseStaticLibPython()
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/Options.py", line 924, in _shallUseStaticLibPython
    and isDebianSuitableForStaticLinking()
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/utils/StaticLibraries.py", line 85, in isDebianSuitableForStaticLinking
    dist_version = tuple(int(x) for x in dist_version.split("."))
  File "/home/tortoise/.local/lib/python3.9/site-packages/nuitka/utils/StaticLibraries.py", line 85, in <genexpr>
    dist_version = tuple(int(x) for x in dist_version.split("."))
ValueError: invalid literal for int() with base 10: 'sid'

```

I didn't find an existing issue for this. I could make one if you want but it would be more work than the fix.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
