### PR TITLE
Fix typo in warning message

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -692,7 +692,7 @@ but errors may happen."""
         Tracing.general.warning(
             """\
 Using very slow fallback for ordered sets, please install 'ordered-set' or \
-'orderset' PyPI packages for best Python compile time performance."""
+'orderedset' PyPI packages for best Python compile time performance."""
         )
 
     if shallUsePythonDebug() and not isDebugPython():


### PR DESCRIPTION
The module in question is `orderedset`, see: https://github.com/Nuitka/Nuitka/blob/1adf285ad2416876aabe7c474ce9f1ace2344ed9/requirements.txt#L27