### PR TITLE
YamlFormatter improvements

### DIFF
--- a/.vscode/nuitka-package-config-schema.json
+++ b/.vscode/nuitka-package-config-schema.json
@@ -5,7 +5,8 @@
         "additionalProperties": false,
         "properties": {
             "module-name": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[A-Za-z0-9\\.\\_\\-]+$"
             },
             "data-files": {
                 "items": {

--- a/nuitka/tools/quality/auto_format/YamlFormatter.py
+++ b/nuitka/tools/quality/auto_format/YamlFormatter.py
@@ -50,11 +50,6 @@ class _IndentingDumper(yaml.SafeDumper):
     Custom dumper enforcing indentation.
     """
 
-    def write_line_break(self, data=None):
-        super(_IndentingDumper, self).write_line_break(data)
-        if len(self.indents) == 1:
-            super(_IndentingDumper, self).write_line_break()
-
     def increase_indent(self, flow=False, indentless=False):
         return super(_IndentingDumper, self).increase_indent(flow, False)
 
@@ -359,9 +354,14 @@ def formatYaml(path):
     # new_data = sorted(new_data, key=lambda d: d["module-name"].lower())
 
     with openTextFile(path, "w", encoding="utf-8") as output_file:
-        dumped = yaml.dump(
-            new_data, Dumper=_IndentingDumper, width=10000000, sort_keys=False
-        )
+        dumped = ""
+        for entry in new_data:
+            dumped += (
+                yaml.dump(
+                    [entry], Dumper=_IndentingDumper, width=10000000, sort_keys=False
+                )
+                + "\n"
+            )
 
         output_file.writelines(line + "\n" for line in header)
         output_file.writelines(

--- a/nuitka/tools/quality/auto_format/YamlFormatter.py
+++ b/nuitka/tools/quality/auto_format/YamlFormatter.py
@@ -111,7 +111,7 @@ def _strPresenter(dumper, data):
     return dumper.represent_scalar(
         'tag:yaml.org,2002:str',
         data,
-        style='"'  # _decideStrFormat(data)
+        style=_decideStrFormat(data)
         if (
             data not in MASTER_KEYS
             and data not in DATA_FILES_KEYS

--- a/nuitka/tools/quality/auto_format/YamlFormatter.py
+++ b/nuitka/tools/quality/auto_format/YamlFormatter.py
@@ -59,6 +59,48 @@ class _IndentingDumper(yaml.SafeDumper):
         return super(_IndentingDumper, self).increase_indent(flow, False)
 
 
+def _decideStrFormat(string: str):
+    """
+    take the character that is not closest to the beginning or end
+    """
+    single_quote_left = string.find("'")
+    single_quote_right = string.rfind("'")
+    quote_left = string.find('"')
+    quote_right = string.rfind('"')
+
+    if single_quote_left == -1 and not quote_left == -1:
+        return "'"
+
+    elif quote_left == -1 and not single_quote_left == -1:
+        return '"'
+
+    elif (
+        single_quote_left == -1
+        and single_quote_right == -1
+        and quote_left == -1
+        and quote_right == -1
+    ):
+        return '"'
+
+    elif single_quote_left > quote_left and single_quote_right < quote_right:
+        return "'"
+
+    elif single_quote_left < quote_left and single_quote_right > quote_right:
+        return '"'
+
+    else:
+        return '"'
+
+
+def _testDecideStrFormat():
+    assert _decideStrFormat("") == '"'
+    assert _decideStrFormat("'") == '"'
+    assert _decideStrFormat('"') == "'"
+    assert _decideStrFormat(""" '" """) == '"'
+    assert _decideStrFormat(""" "'" """) == "'"
+    assert _decideStrFormat(""" '"' """) == '"'
+
+
 def _strPresenter(dumper, data):
     """
     custom Representer for strings
@@ -69,7 +111,7 @@ def _strPresenter(dumper, data):
     return dumper.represent_scalar(
         'tag:yaml.org,2002:str',
         data,
-        style='"'
+        style='"'  # _decideStrFormat(data)
         if (
             data not in MASTER_KEYS
             and data not in DATA_FILES_KEYS
@@ -325,3 +367,6 @@ def formatYaml(path):
         output_file.writelines(
             line + "\n" for line in _restoreComments(dumped.splitlines(), comments)
         )
+
+
+_testDecideStrFormat()


### PR DESCRIPTION
1. add regex check for module-name to schema
2. use the most matching quotes for strings
3. add newline after each entry