### PR TITLE
pyreadstat_implicit_dep

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -1199,6 +1199,7 @@ Error, package '%s' requires '--onefile' to be used on top of '--macos-create-ap
         elif full_name == "pyreadstat.pyreadstat":
             yield "pyreadstat._readstat_writer"
             yield "pyreadstat.worker"
+            yield "multiprocessing"
         elif full_name == "cytoolz.itertoolz":
             yield "cytoolz.utils"
         elif full_name == "cytoolz.functoolz":


### PR DESCRIPTION
This is a follow-up to #1072

The strange thing is that this was already required when I did the #1072 PR (it was introduced in pyreadstat 1.0.3), so I suppose something else added the multiprocessing module implicitly?