### PR TITLE
Fix wrong path to sh.exe (for git.exe) on installing git-hook

### DIFF
--- a/misc/install-git-hooks.py
+++ b/misc/install-git-hooks.py
@@ -63,7 +63,7 @@ PATH while executing this will be sufficient."""
 
         if not os.path.exists(sh_path):
             sh_path = os.path.join(
-                os.path.dirname(git_path), "..", "..", "bin", "sh.exe"
+                os.path.dirname(git_path), "..", "bin", "sh.exe"
             )
 
         sh_path = os.path.normpath(sh_path)


### PR DESCRIPTION
In all git distro on Win, git.exe and sh.exe are colocated subfolders on same level - git.exe on 'bin' and 'cmd', sh.exe on 'bin'

# PR Checklist
- [*] Correct base branch selected? Should be `develop` branch.
- [*] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [*] All tests still pass. Check the Developer Manual about `Running the Tests`.
