### PR TITLE
do not check known kernel shared libraries for relative paths

### DIFF
--- a/nuitka/freezer/DllDependenciesPosix.py
+++ b/nuitka/freezer/DllDependenciesPosix.py
@@ -114,13 +114,6 @@ def detectBinaryPathDLLsPosix(dll_filename, package_name, original_dir):
         # been seen with Qt at least.
         filename = os.path.normpath(filename)
 
-        # If we encounter a valid relative path, resolve it to an absolute one.
-        if not os.path.isabs(filename):
-            inclusion_logger.sysexit(
-                "Error: Found a dependency with a relative path. Was a dependency copied to dist early? "
-                + filename
-            )
-
         # Do not include kernel DLLs on the ignore list.
         filename_base = os.path.basename(filename)
         if any(
@@ -128,6 +121,13 @@ def detectBinaryPathDLLsPosix(dll_filename, package_name, original_dir):
             for entry in _linux_dll_ignore_list
         ):
             continue
+
+        # Do not allow relative paths for shared libraries
+        if not os.path.isabs(filename):
+            inclusion_logger.sysexit(
+                "Error: Found a dependency with a relative path. Was a dependency copied to dist early? "
+                + filename
+            )
 
         result.add(filename)
 


### PR DESCRIPTION
Nuitka contains a list of known "kernel" shared libraries that are not included.
Since these are not included, we do not need to ensure that they don't contain
relative paths.

Without this patch I got this error (`nuitka3 --standalone diag.py`):
```
FATAL: Error: Found a dependency with a relative path. Was a dependency copied to dist early? linux-vdso.so.1
```

This occured under these conditions:

    python -m nuitka --version

1.0.5
Commercial: None
Python: 3.10.6 (main, Aug  3 2022, 17:39:45) [GCC 12.1.1 20220730]
Flavor: Unknown
Executable: /usr/bin/python
OS: Linux
Arch: x86_64
Distribution: Sysrescue (based on arch) 9.04

    How did you install Nuitka and Python
    Arch Linux packages python-3.10.6-1 and nuitka-1.0.5-1 installed through pacman.
    No virtualenv used.
