### PR TITLE
Added Pandas compatibility for >= 1.0.0

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -1052,6 +1052,9 @@
     - description: "remove useless distutils usage"
       replacements:
         # TODO: Smells not only like regexp, must be one.
+        'LooseVersion("1.14")': "'\"1.14\"'"
+        'LooseVersion("1.15")': "'\"1.15\"'"
+        'LooseVersion("1.16")': "'\"1.16\"'"
         'LooseVersion("1.17")': "'\"1.17\"'"
         'LooseVersion("1.18")': "'\"1.18\"'"
         'LooseVersion("1.19")': "'\"1.19\"'"


### PR DESCRIPTION
# What does this PR do?
Updated LooseVersion checks in anti bloat config
Ref: https://github.com/pandas-dev/pandas/blob/1.0.x/pandas/compat/numpy/__init__.py#L11-L17

# Why was it initiated? Any relevant Issues?
Generated binary with pandas (1.1.x or 1.0.x) dependency fails because of unknown variable LooseVersion.
```
...
  File "/tmp/onefile_3918_1661593705_527601/pandas/__init__.py", line 22, in <module pandas>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "/tmp/onefile_3918_1661593705_527601/pandas/compat/numpy/__init__.py", line 11, in <module pandas.compat.numpy>
NameError: name 'LooseVersion' is not defined
```

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
