### PR TITLE
Add check to prevent executing codesign with no parameters.

### DIFF
--- a/nuitka/freezer/Standalone.py
+++ b/nuitka/freezer/Standalone.py
@@ -656,7 +656,7 @@ def copyDllsUsed(dist_dir, standalone_entry_points):
         )
 
     # Add macOS code signature
-    if isMacOS():
+    if isMacOS() and copy_standalone_entry_points:
         addMacOSCodeSignature(
             filenames=[
                 os.path.join(dist_dir, standalone_entry_point.dest_path)


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
This PR fixes an error where codesign would be executed with no file arguments if there are no dependency dylibs. Particularly for Nuitka-Python where python is static.

# Why was it initiated? Any relevant Issues?

```
FATAL: Error, call to 'codesign' failed: ['/usr/bin/codesign', '-s', '-', '--force', '--deep', '--preserve-metadata=entitlements'] -> b'Usage: codesign -s identity [-fv*] [-o flags] [-r reqs] [-i ident] path ... # sign\n       codesign -v [-v*] [-R=<req string>|-R <req file path>] path|[+]pid ... # verify\n       codesign -d [options] path ... # display contents\n       codesign -h pid ... # display hosting paths'.
```

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
