### PR TITLE
getCacheDir: handle Nixpkgs's default HOME

### DIFF
--- a/nuitka/utils/AppDirs.py
+++ b/nuitka/utils/AppDirs.py
@@ -52,7 +52,7 @@ def getCacheDir():
             _cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "Nuitka")
 
         # For people that build with HOME set this, e.g. Debian.
-        if _cache_dir.startswith(("/nonexistent/", "/sbuild-nonexistent/")):
+        if _cache_dir.startswith(("/nonexistent/", "/sbuild-nonexistent/", "/homeless-shelter/")):
             _cache_dir = os.path.join(tempfile.gettempdir(), "Nuitka")
 
         makePath(_cache_dir)


### PR DESCRIPTION
The Nixpkgs standard builders sets `HOME` to `/homeless-shelter`. Add this exception.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
