### PR TITLE
Windows: Retry replace clcache entry after a delay

### DIFF
--- a/nuitka/build/inline_copy/clcache/clcache/caching.py
+++ b/nuitka/build/inline_copy/clcache/clcache/caching.py
@@ -31,6 +31,9 @@ from tempfile import TemporaryFile
 from atomicwrites import atomic_write
 from io import open
 
+from nuitka.utils.Utils import decoratorRetries
+from nuitka.Tracing import general
+
 VERSION = "5.0.0-dev"
 
 HashAlgorithm = hashlib.md5
@@ -457,7 +460,15 @@ class CompilerArtifactsSection(object):
                 artifacts.stderr,
             )
         # Replace the full cache entry atomically
-        os.replace(tempEntryDir, cacheEntryDir)
+        @decoratorRetries(
+            logger=general,
+            purpose="replace %r with %r" % (cacheEntryDir, tempEntryDir),
+            consequence="aborting",
+        )
+        def _replaceEntry():
+            os.replace(tempEntryDir, cacheEntryDir)
+
+        _replaceEntry()
         return size
 
     def getEntry(self, key):


### PR DESCRIPTION
# What does this PR do?
Apply `decoratorRetries` in clcache to overcome random "access denied" errors tied to anti-virus.

# Why was it initiated? Any relevant Issues?
See #1591 
