### PR TITLE
Standalone: Added data file for "lark" package.

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -755,6 +755,11 @@
       - 'fonts'
       - 'images'
 
+- module-name: 'lark'
+  data-files:
+    dirs:
+      - 'grammars'
+
 - module-name: 'lightgbm.libpath'
   dlls:
     - from_filenames:


### PR DESCRIPTION
# What does this PR do?

Adds the [`grammars` folder](https://github.com/lark-parser/lark/tree/master/lark/grammars) of the [`lark`](https://github.com/lark-parser/lark) package which are imported dynamically and are not embedded naturally by Nuitka.

# Why was it initiated? Any relevant Issues?

I stumble upon this issue while trying to make a standalone executable of my [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) project, which depends on [Click Extra](https://github.com/kdeldycke/click-extra) for CLI configuration loading and colorisation, which depends on [`commentjson`](https://github.com/vaidik/commentjson) to allow commented JSON-based config files, which at last depends on `lark-parser`.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
