### PR TITLE
Don't use PyFloat_AS_DOUBLE() as an l-value

### DIFF
--- a/nuitka/build/static_src/HelpersConstantsBlob.c
+++ b/nuitka/build/static_src/HelpersConstantsBlob.c
@@ -976,11 +976,7 @@ static unsigned char const *_unpackBlobConstants(PyObject **output, unsigned cha
                 static PyObject *_const_float_minus_0_0 = NULL;
 
                 if (_const_float_minus_0_0 == NULL) {
-                    _const_float_minus_0_0 = PyFloat_FromDouble(0.0);
-
-                    // Older Python3 has variable signs from C, so be explicit about it.
-                    PyFloat_AS_DOUBLE(_const_float_minus_0_0) =
-                        copysign(PyFloat_AS_DOUBLE(_const_float_minus_0_0), -1.0);
+                    _const_float_minus_0_0 = PyFloat_FromDouble(copysign(0.0, -1.0));
                 }
                 z = _const_float_minus_0_0;
 
@@ -991,10 +987,7 @@ static unsigned char const *_unpackBlobConstants(PyObject **output, unsigned cha
                 static PyObject *_const_float_plus_nan = NULL;
 
                 if (_const_float_plus_nan == NULL) {
-                    _const_float_plus_nan = PyFloat_FromDouble(Py_NAN);
-
-                    // Older Python3 has variable signs for NaN from C, so be explicit about it.
-                    PyFloat_AS_DOUBLE(_const_float_plus_nan) = copysign(PyFloat_AS_DOUBLE(_const_float_plus_nan), 1.0);
+                    _const_float_plus_nan = PyFloat_FromDouble(copysign(Py_NAN, 1.0));
                 }
                 z = _const_float_plus_nan;
 
@@ -1004,11 +997,7 @@ static unsigned char const *_unpackBlobConstants(PyObject **output, unsigned cha
                 static PyObject *_const_float_minus_nan = NULL;
 
                 if (_const_float_minus_nan == NULL) {
-                    _const_float_minus_nan = PyFloat_FromDouble(Py_NAN);
-
-                    // Older Python3 has variable signs for NaN from C, so be explicit about it.
-                    PyFloat_AS_DOUBLE(_const_float_minus_nan) =
-                        copysign(PyFloat_AS_DOUBLE(_const_float_minus_nan), -1.0);
+                    _const_float_minus_nan = PyFloat_FromDouble(copysign(Py_NAN, -1.0));
                 }
                 z = _const_float_minus_nan;
 
@@ -1018,10 +1007,7 @@ static unsigned char const *_unpackBlobConstants(PyObject **output, unsigned cha
                 static PyObject *_const_float_plus_inf = NULL;
 
                 if (_const_float_plus_inf == NULL) {
-                    _const_float_plus_inf = PyFloat_FromDouble(Py_HUGE_VAL);
-
-                    // Older Python3 has variable signs from C, so be explicit about it.
-                    PyFloat_AS_DOUBLE(_const_float_plus_inf) = copysign(PyFloat_AS_DOUBLE(_const_float_plus_inf), 1.0);
+                    _const_float_plus_inf = PyFloat_FromDouble(copysign(Py_HUGE_VAL, 1.0));
                 }
                 z = _const_float_plus_inf;
 
@@ -1031,11 +1017,7 @@ static unsigned char const *_unpackBlobConstants(PyObject **output, unsigned cha
                 static PyObject *_const_float_minus_inf = NULL;
 
                 if (_const_float_minus_inf == NULL) {
-                    _const_float_minus_inf = PyFloat_FromDouble(Py_HUGE_VAL);
-
-                    // Older Python3 has variable signs from C, so be explicit about it.
-                    PyFloat_AS_DOUBLE(_const_float_minus_inf) =
-                        copysign(PyFloat_AS_DOUBLE(_const_float_minus_inf), -1.0);
+                    _const_float_minus_inf = PyFloat_FromDouble(copysign(Py_HUGE_VAL, -1.0));
                 }
                 z = _const_float_minus_inf;
 

--- a/nuitka/build/static_src/HelpersOperationInplaceAdd.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceAdd.c
@@ -1418,14 +1418,7 @@ static inline bool _INPLACE_OPERATION_ADD_FLOAT_FLOAT(PyObject **operand1, PyObj
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1655,7 +1648,7 @@ static inline bool _INPLACE_OPERATION_ADD_OBJECT_FLOAT(PyObject **operand1, PyOb
 
     exit_result_ok_cfloat:
         if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
+            PyFloat_SET_DOUBLE(*operand1, cfloat_result);
         } else {
             // We got an object handed, that we have to release.
             Py_DECREF(*operand1);
@@ -1884,14 +1877,7 @@ static inline bool _INPLACE_OPERATION_ADD_FLOAT_OBJECT(PyObject **operand1, PyOb
         goto exit_result_ok_cfloat;
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2628,14 +2614,7 @@ static inline bool _INPLACE_OPERATION_ADD_FLOAT_CFLOAT(PyObject **operand1, doub
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplaceAddUtils.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceAddUtils.c
@@ -138,3 +138,16 @@ NUITKA_MAY_BE_UNUSED static bool UNICODE_ADD_INCREMENTAL(PyObject **operand1, Py
     return UNICODE_APPEND(operand1, operand2);
 #endif
 }
+
+
+void PyFloat_SET_DOUBLE(PyObject **pobj, double fval) {
+    if (Py_REFCNT(*pobj) == 1) {
+        PyFloatObject *float_obj = *(PyFloatObject**)pobj;
+        float_obj->ob_fval = fval;
+    }
+    else {
+        PyObject *old_obj = *pobj;
+        *pobj = PyFloat_FromDouble(fval);
+        Py_DECREF(old_obj);
+    }
+}

--- a/nuitka/build/static_src/HelpersOperationInplaceFloordiv.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceFloordiv.c
@@ -1225,14 +1225,7 @@ static inline bool _INPLACE_OPERATION_FLOORDIV_FLOAT_FLOAT(PyObject **operand1, 
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1474,14 +1467,7 @@ static inline bool _INPLACE_OPERATION_FLOORDIV_OBJECT_FLOAT(PyObject **operand1,
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1727,14 +1713,7 @@ static inline bool _INPLACE_OPERATION_FLOORDIV_FLOAT_OBJECT(PyObject **operand1,
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2359,14 +2338,7 @@ static inline bool _INPLACE_OPERATION_FLOORDIV_FLOAT_CFLOAT(PyObject **operand1,
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplaceMod.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceMod.c
@@ -1197,14 +1197,7 @@ static inline bool _INPLACE_OPERATION_MOD_FLOAT_FLOAT(PyObject **operand1, PyObj
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1436,14 +1429,7 @@ static inline bool _INPLACE_OPERATION_MOD_OBJECT_FLOAT(PyObject **operand1, PyOb
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1679,14 +1665,7 @@ static inline bool _INPLACE_OPERATION_MOD_FLOAT_OBJECT(PyObject **operand1, PyOb
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2295,14 +2274,7 @@ static inline bool _INPLACE_OPERATION_MOD_FLOAT_CFLOAT(PyObject **operand1, doub
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplaceMult.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceMult.c
@@ -1245,14 +1245,7 @@ static inline bool _INPLACE_OPERATION_MULT_FLOAT_FLOAT(PyObject **operand1, PyOb
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1482,14 +1475,7 @@ static inline bool _INPLACE_OPERATION_MULT_OBJECT_FLOAT(PyObject **operand1, PyO
         goto exit_result_ok_cfloat;
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1724,14 +1710,7 @@ static inline bool _INPLACE_OPERATION_MULT_FLOAT_OBJECT(PyObject **operand1, PyO
         goto exit_result_ok_cfloat;
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2359,14 +2338,7 @@ static inline bool _INPLACE_OPERATION_MULT_FLOAT_CFLOAT(PyObject **operand1, dou
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplaceOlddiv.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceOlddiv.c
@@ -1213,14 +1213,7 @@ static inline bool _INPLACE_OPERATION_OLDDIV_FLOAT_FLOAT(PyObject **operand1, Py
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1446,14 +1439,7 @@ static inline bool _INPLACE_OPERATION_OLDDIV_OBJECT_FLOAT(PyObject **operand1, P
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1684,14 +1670,7 @@ static inline bool _INPLACE_OPERATION_OLDDIV_FLOAT_OBJECT(PyObject **operand1, P
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2305,14 +2284,7 @@ static inline bool _INPLACE_OPERATION_OLDDIV_FLOAT_CFLOAT(PyObject **operand1, d
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplacePow.c
+++ b/nuitka/build/static_src/HelpersOperationInplacePow.c
@@ -152,14 +152,7 @@ static inline bool _INPLACE_OPERATION_POW_FLOAT_FLOAT(PyObject **operand1, PyObj
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok_left:
@@ -491,14 +484,7 @@ static inline bool _INPLACE_OPERATION_POW_OBJECT_FLOAT(PyObject **operand1, PyOb
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok_left:
@@ -835,14 +821,7 @@ static inline bool _INPLACE_OPERATION_POW_FLOAT_OBJECT(PyObject **operand1, PyOb
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok_left:

--- a/nuitka/build/static_src/HelpersOperationInplaceSub.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceSub.c
@@ -1382,14 +1382,7 @@ static inline bool _INPLACE_OPERATION_SUB_FLOAT_FLOAT(PyObject **operand1, PyObj
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1603,14 +1596,7 @@ static inline bool _INPLACE_OPERATION_SUB_OBJECT_FLOAT(PyObject **operand1, PyOb
         goto exit_result_ok_cfloat;
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1829,14 +1815,7 @@ static inline bool _INPLACE_OPERATION_SUB_FLOAT_OBJECT(PyObject **operand1, PyOb
         goto exit_result_ok_cfloat;
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2544,14 +2523,7 @@ static inline bool _INPLACE_OPERATION_SUB_FLOAT_CFLOAT(PyObject **operand1, doub
     goto exit_result_ok_cfloat;
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/build/static_src/HelpersOperationInplaceTruediv.c
+++ b/nuitka/build/static_src/HelpersOperationInplaceTruediv.c
@@ -1253,14 +1253,7 @@ static inline bool _INPLACE_OPERATION_TRUEDIV_FLOAT_FLOAT(PyObject **operand1, P
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:
@@ -1485,14 +1478,7 @@ static inline bool _INPLACE_OPERATION_TRUEDIV_OBJECT_FLOAT(PyObject **operand1, 
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -1721,14 +1707,7 @@ static inline bool _INPLACE_OPERATION_TRUEDIV_FLOAT_OBJECT(PyObject **operand1, 
         }
 
     exit_result_ok_cfloat:
-        if (Py_REFCNT(*operand1) == 1) {
-            PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-        } else {
-            // We got an object handed, that we have to release.
-            Py_DECREF(*operand1);
-
-            *operand1 = PyFloat_FromDouble(cfloat_result);
-        }
+        PyFloat_SET_DOUBLE(operand1, cfloat_result);
         goto exit_result_ok;
 
     exit_result_ok:
@@ -2351,14 +2330,7 @@ static inline bool _INPLACE_OPERATION_TRUEDIV_FLOAT_CFLOAT(PyObject **operand1, 
     }
 
 exit_result_ok_cfloat:
-    if (Py_REFCNT(*operand1) == 1) {
-        PyFloat_AS_DOUBLE(*operand1) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF(*operand1);
-
-        *operand1 = PyFloat_FromDouble(cfloat_result);
-    }
+    PyFloat_SET_DOUBLE(operand1, cfloat_result);
     goto exit_result_ok;
 
 exit_result_ok:

--- a/nuitka/code_generation/templates_c/HelperSlotsFloat.c.j2
+++ b/nuitka/code_generation/templates_c/HelperSlotsFloat.c.j2
@@ -250,14 +250,7 @@ exit_result_ok_cfloat:
     {{ target.getAssignFromFloatExpressionCode(result, "cfloat_result") }}
 {% else %}
     {# TODO: Check the reference we were handed down. #}
-    if (Py_REFCNT({{ operand1 }}) == 1) {
-        PyFloat_AS_DOUBLE({{ operand1 }}) = cfloat_result;
-    } else {
-        // We got an object handed, that we have to release.
-        Py_DECREF({{ operand1 }});
-
-        {{ left.getAssignFromFloatExpressionCode(operand1, "cfloat_result") }}
-    }
+    PyFloat_SET_DOUBLE({{ operand1 }}, cfloat_result);
 {% endif %}
     {{ goto_exit(props, exit_result_ok) }}
 {% endif %}


### PR DESCRIPTION
* Use copysign() with PyFloat_FromDouble() in HelpersConstantsBlob.c.
* Add PyFloat_SET_DOUBLE() function and use it in in-place operations.

Python 3.12 PyFloat_AS_DOUBLE() can no longer be used as an l-value: https://github.com/python/cpython/commit/02f72b8b938e301bbaaf0142547014e074bd564c

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
