### PR TITLE
Added sqlalchemy implicit dependecies

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2784,6 +2784,16 @@
   implicit-imports:
     - depends:
         - '.dialects.*'
+        
+- module-name: 'sqlalchemy.sql'
+  implicit-imports:
+    - depends:
+        - 'sqlalchemy.sql.default_comparator'
+
+- module-name: 'sqlalchemy.dialects.mssql'
+  implicit-imports:
+    - depends:
+        - 'sqlalchemy.dialects.mssql.pyodbc'
 
 - module-name: 'srsly.msgpack._packer'
   implicit-imports:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2784,7 +2784,7 @@
   implicit-imports:
     - depends:
         - '.dialects.*'
-        
+
 - module-name: 'sqlalchemy.sql'
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?
This pull request add two implicit dependencies of the sqlalchemy package

# Why was it initiated? Any relevant Issues?
A compiled exe that use sqlalchemy with pyodbc or use the default_comparator module raise an import error without this 