### PR TITLE
Removed numba references from shap

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2337,6 +2337,64 @@
       change_function:
         'test': "'(lambda: None)'"
 
+- module-name: 'shap.explainers._exact'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.explainers._partition'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.links'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'import numba': ''
+        '@numba.jit': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.maskers._image'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+        "warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)": ''
+        'from numba.core.errors import NumbaPendingDeprecationWarning': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.maskers._tabular'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.utils._clustering'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+      when: 'not use_numba and standalone'
+
+- module-name: 'shap.utils._masked_model'
+  anti-bloat:
+    - description: 'avoid numba'
+      replacements_plain:
+        'from numba import jit': ''
+        '@jit': ''
+      when: 'not use_numba and standalone'
+
 - module-name: 'shapely.geometry.base'
   anti-bloat:
     - description: 'remove doctest usage'


### PR DESCRIPTION
# What does this PR do?
This PR remove all numba references from shap packages

# Why was it initiated? Any relevant Issues?
Numba is not currently supported in standalone mode. So if you try to run with --noinclude-numba-mode=nofollow it will raise an import error. More info in issue #1990.
