### PR TITLE
Anti-bloat: Removed xgboost docstring dependencies

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3994,7 +3994,7 @@
   anti-bloat:
     - description: 'remove docstring dependency'
       replacements_plain:
-        'fit.__doc__ = XGBModel.fit.__doc__.replace(' : 'fit.__doc__ = "Fit gradient boosting model".replace('
+        'fit.__doc__ = XGBModel.fit.__doc__.replace(': 'fit.__doc__ = "Fit gradient boosting model".replace('
       when: 'no_docstrings and no_asserts'
 
 - module-name: 'Xlib.display'

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3990,6 +3990,13 @@
         prefixes:
           - 'xgboost'
 
+- module-name: 'xgboost.sklearn'
+  anti-bloat:
+    - description: 'remove docstring dependency'
+      replacements_plain:
+        'fit.__doc__ = XGBModel.fit.__doc__.replace(' : 'fit.__doc__ = "Fit gradient boosting model".replace('
+      when: 'no_docstrings and no_asserts'
+
 - module-name: 'Xlib.display'
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?
This PR removes docstrings dependecies from xgboost.sklearn package only if python flags no_docstrings and no_asserts are given.

# Why was it initiated? Any relevant Issues?
It was initiated because xgboost don't work with -OO python flag. Also described in #2006.