### PR TITLE
Standalone: Add invisible `md__mypyc` dependency for `charset_normalizer`

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -211,6 +211,11 @@
     - depends:
         - 'chainer.distributions.utils'
 
+- module-name: 'charset_normalizer'
+  implicit-imports:
+    - depends:
+        - 'charset_normalizer.md__mypyc'
+
 - module-name: 'clr'
   dlls:
     - from_filenames:


### PR DESCRIPTION
# What does this PR do?

Adds explicit import of `charset_normalizer.md__mypyc` for `charset_normalizer` module.

This PR closes: https://github.com/Nuitka/Nuitka/issues/2020

# Why was it initiated? Any relevant Issues?

`charset_normalizer` is missing an import that is only ever imported in a cythonized submodule. Thus, Nuitka cannot see it.

Binaries are properly generated by Nuitka, but their execution ends up with a traceback:

```pytb
Traceback (most recent call last):
  File "/tmp/onefile_1583_1674827414_883837/requests/compat.py", line 11, in <module requests.compat>
ModuleNotFoundError: No module named 'chardet'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/onefile_1583_1674827414_883837/__main__.py", line 60, in <module>
  File "/tmp/onefile_1583_1674827414_883837/__main__.py", line 54, in main
  File "/tmp/onefile_1583_1674827414_883837/meta_package_manager/__init__.py", line 33, in <module meta_package_manager>
  File "/tmp/onefile_1583_1674827414_883837/click_extra/__init__.py", line 66, in <module click_extra>
  File "/tmp/onefile_1583_1674827414_883837/click_extra/config.py", line 45, in <module click_extra.config>
  File "/tmp/onefile_1583_1674827414_883837/requests/__init__.py", line 45, in <module requests>
  File "/tmp/onefile_1583_1674827414_883837/requests/exceptions.py", line 9, in <module requests.exceptions>
  File "/tmp/onefile_1583_1674827414_883837/requests/compat.py", line 13, in <module requests.compat>
  File "/tmp/onefile_1583_1674827414_883837/charset_normalizer/__init__.py", line 24, in <module charset_normalizer>
  File "/tmp/onefile_1583_1674827414_883837/charset_normalizer/api.py", line 5, in <module charset_normalizer.api>
  File "/tmp/onefile_1583_1674827414_883837/charset_normalizer/cd.py", line 9, in <module charset_normalizer.cd>
ModuleNotFoundError: No module named 'charset_normalizer.md__mypyc'
Error: Process completed with exit code 1.
```

This is [also affecting PyInstaller](https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534), but the [original author of `charset_normalizer` doesn't see a problem in this situation](https://github.com/Ousret/charset_normalizer/issues/253#issuecomment-1383234292). This issue is worth reporting here as it is a [direct dependency on the popular `request` package](https://github.com/psf/requests/issues/6331), and likely to be reported a lot by Nuitka users.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
