### PR TITLE
Textual package configuration

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3442,6 +3442,13 @@
     patterns:
       - 'data.bin'
 
+- module-name: 'textual'
+  implicit-imports:
+    - depends:
+      - 'pygments.lexers.css'
+      - 'textual.widget'
+      - 'textual.widgets._*'
+
 - module-name: 'thinc.backends.cblas'
   implicit-imports:
     - depends:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3445,12 +3445,12 @@
 - module-name: 'textual'
   implicit-imports:
     - depends:
-      - 'pygments.lexers.css'
+        - 'pygments.lexers.css'
 
 - module-name: 'textual.widgets'
   implicit-imports:
     - depends:
-      - '._*'
+        - '._*'
 
 - module-name: 'thinc.backends.cblas'
   implicit-imports:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3446,8 +3446,11 @@
   implicit-imports:
     - depends:
       - 'pygments.lexers.css'
-      - 'textual.widget'
-      - 'textual.widgets._*'
+
+- module-name: 'textual.widgets'
+  implicit-imports:
+    - depends:
+      - '._*'
 
 - module-name: 'thinc.backends.cblas'
   implicit-imports:


### PR DESCRIPTION
# What does this PR do?

Adds some nuitka package configuration information for the `textual` package.

# Why was it initiated? Any relevant Issues?

textual.widgets does some lazy loading tricks with __getattr__

https://github.com/Textualize/textual/blob/main/src/textual/widgets/__init__.py#L52-L67

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass.  <- No, I got weird errors -- it was trying to run the tests on python 2.7 on my mac, instead of running them inside my venv.
