### PR TITLE
Lets not reexecute if we are debugging (vscode-pydev-debugpy)

### DIFF
--- a/nuitka/__main__.py
+++ b/nuitka/__main__.py
@@ -87,7 +87,7 @@ def main():
         needs_re_execution = True
 
     # In case we need to re-execute.
-    if needs_re_execution:
+    if needs_re_execution and 'debugpy' not in sys.modules:
         from nuitka.utils.ReExecute import reExecuteNuitka  # isort:skip
 
         # Does not return


### PR DESCRIPTION
# What does this PR do?
# Why was it initiated? Any relevant Issues?

Many times, debugging Nuitka troubles (to patch, to find workaround or minimal bugcase), is very convinient to run nuitka on debug mode ('debugpy', 'pydev' — regular python debugging with VSCode).
But for this, every time I  have to patch this way this line for debugging, to disable reexecution (reexecution breaks debugging). So why not make Nuitka debuggable by default?

# PR Checklist

- [*] Correct base branch selected? Should be `develop` branch.
- [*] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [*] All tests still pass. 
```
python3  ./run-tests  --skip-package-tests --skip-cpython26-tests --skip-cpython27-tests --skip-cpython32-tests --skip-cpython33-tests --skip-cpython34-tests --skip-cpython35-tests  --skip-cpython36-tests --skip-cpython37-tests --skip-cpython38-tests --skip-cpython39-tests --no-python2.7 
```
← OK