### PR TITLE
Prevent raising file error when used DLLs and included data files conflict at same folder.

### DIFF
--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -824,6 +824,9 @@ def copyFile(source_path, dest_path):
     while 1:
         try:
             shutil.copyfile(source_path, dest_path)
+        except shutil.SameFileError:
+            pass
+       
         except PermissionError as e:
             if e.errno != errno.EACCES:
                 raise

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -824,7 +824,7 @@ def copyFile(source_path, dest_path):
     while 1:
         try:
             shutil.copyfile(source_path, dest_path)
-        except shutil.SameFileError:
+        except shutil.Error:
             pass
        
         except PermissionError as e:


### PR DESCRIPTION
# What does this PR do?

# Why was it initiated? Any relevant Issues?
When copied DLLs and included data files conflict at same folder, shutil module raises SameFileError and this exception stops Nuitka. Simply, when same file exists at same folder, don't raise an error and continue to generating executable.

# PR Checklist

- [*] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
