### PR TITLE
Added support for 'pytorch_lightning'

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -926,6 +926,11 @@
         prefixes:
           - 'lib_lightgbm'
 
+- module-name: 'lightning_fabric'
+  data-files:
+    patterns:
+      - 'version.info'
+
 - module-name: 'llvmlite.binding.analysis'
   anti-bloat:
     - description: 'remove IPython reference'
@@ -2137,6 +2142,11 @@
         relative_path: 'runtime'
         prefixes:
           - 'Python.Runtime'
+
+- module-name: 'pytorch_lightning'
+  data-files:
+    patterns:
+      - 'version.info'
 
 - module-name: 'pytorch_lightning.utilities.imports'
   anti-bloat:


### PR DESCRIPTION
# What does this PR do?

PyTorch lightning parses a `version.info` at runtime. version.info is missing when PyTorch lightning is used with nuitka.
This PR ensures that the version.info is copied.

# Why was it initiated? Any relevant Issues?
PyTorch lightning usage

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

Please let me know if i need to update tests / docs (:

