### PR TITLE
Fix missing "%" in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -503,7 +503,7 @@ and then deleted, however this default
 ``--onefile-tempdir-spec="%TEMP%/onefile_%PID%_%TIME%"`` can be
 overridden with a path specification that is using then using a cached
 path, avoiding repeated unpacking, e.g. with
-``--onefile-tempdir-spec="%CACHE_DIR%/%COMPANY%/%PRODUCT%/%VERSION"``
+``--onefile-tempdir-spec="%CACHE_DIR%/%COMPANY%/%PRODUCT%/%VERSION%"``
 which uses version information, and user specific cache directory.
 
 .. note::


### PR DESCRIPTION
# What does this PR do?

A `%` was missing in the example for the `--onefile-tempdir-spec` parameter.

# Why was it initiated? Any relevant Issues?

This PR was done only to correct the typo.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
