### PR TITLE
dont follow symbolic links that point to other files in dist folder

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1648,7 +1648,7 @@ LTO with MSVC with help this a lot, although for big compilations
 
 More ``anti-bloat`` work on more packages rounds up the work.
 
-For macOS specifically, the WebEngine support is cruical to some users,
+For macOS specifically, the WebEngine support is crucial to some users,
 and the new ``--macos-app-mode`` with more GUI friendly default resolves
 long standing problems in this area.
 
@@ -4683,7 +4683,7 @@ organisational changes.
 Bug Fixes
 =========
 
--  Python3.6+: Fixes to asyncgen, need to raise ``StopAsyncInteration``
+-  Python3.6+: Fixes to asyncgen, need to raise ``StopAsyncIteration``
    rather than ``StopIteration`` in some situations to be fully
    compatible.
 
@@ -5648,7 +5648,7 @@ Bug Fixes
 New Features
 ============
 
--  Pyton3.5+: Added support for onefile compression. This is using
+-  Python3.5+: Added support for onefile compression. This is using
    ``zstd`` which is known to give very good compression with very high
    decompression, much better than e.g. ``zlib``.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1127,7 +1127,7 @@ nuitka (0.5.28.2+ds-1) unstable; urgency=medium
 nuitka (0.5.28.1+ds-1) unstable; urgency=medium
 
   * New upstream hotfix release.
-  * Also ignore sbuild non-existant directory (Closes: #871125).
+  * Also ignore sbuild non-existent directory (Closes: #871125).
 
  -- Kay Hayen <kay.hayen@gmail.com>  Sun, 22 Oct 2017 10:44:31 +0200
 

--- a/doc/Doxyfile.template
+++ b/doc/Doxyfile.template
@@ -1551,7 +1551,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/nuitka/build/static_src/HelpersAttributes.c
+++ b/nuitka/build/static_src/HelpersAttributes.c
@@ -746,7 +746,7 @@ static bool SET_INSTANCE(PyObject *target, PyObject *attr_name, PyObject *value)
 
 #if (PYTHON_VERSION < 0x300 || defined(_NUITKA_USE_UNEXPOSED_API)) && !defined(_NUITKA_EXPERIMENTAL_DISABLE_ATTR_OPT)
 
-// Classes in Pyhon3 might share keys.
+// Classes in Python3 might share keys.
 #define CACHED_KEYS(type) (((PyHeapTypeObject *)type)->ht_cached_keys)
 
 static bool SET_ATTRIBUTE_GENERIC(PyTypeObject *type, PyObject *target, PyObject *attr_name, PyObject *value) {

--- a/nuitka/build/static_src/OnefileSplashScreen.cpp
+++ b/nuitka/build/static_src/OnefileSplashScreen.cpp
@@ -103,7 +103,7 @@ IWICBitmapSource *getBitmapFromImageStream(IStream *image_stream) {
 }
 
 HBITMAP CreateHBITMAP(IWICBitmapSource *ipBitmap) {
-    // Get image dimenstions.
+    // Get image dimensions.
     UINT width = 0;
     UINT height = 0;
     if (FAILED(ipBitmap->GetSize(&width, &height)) || width == 0 || height == 0) {

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -52,7 +52,7 @@
 - module-name: 'appdirs'
   anti-bloat:
     # Keep this the same as for 'pkg_resources._vendor.appdirs' module.
-    # TODO: May allow naming spefific "anti-bloat" blocks, and reference them by
+    # TODO: May allow naming specific "anti-bloat" blocks, and reference them by
     # name, that works like an include statement to the module.
     - description: 'remove pywin32 reference'
       replacements_plain:
@@ -4062,7 +4062,7 @@
 
 - module-name: 'torch.utils.data._typing'
   anti-bloat:
-    - description: 'compatiblity workaround'
+    - description: 'compatibility workaround'
       replacements_plain:
         ? "\ndef _dp_init_subclass"
         : |-

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -836,7 +836,11 @@ def copyFileWithPermissions(source_path, dest_path):
     """
 
     try:
-        shutil.copy2(source_path, dest_path, follow_symlinks=not isRelativeLinkInDist(source_path))
+        shutil.copy2(
+            source_path,
+            dest_path,
+            follow_symlinks=not isRelativeLinkInDist(source_path),
+        )
     except PermissionError as e:
         if e.errno != errno.EACCES:
             raise
@@ -1182,8 +1186,6 @@ def isRelativeLinkInDist(filename):
         # link points to a file outside of the dist
         return False
     return True
-
-
 
 
 def replaceFileAtomic(source_path, dest_path):

--- a/tests/basics/BuiltinsTest.py
+++ b/tests/basics/BuiltinsTest.py
@@ -741,7 +741,7 @@ print(zip([1, 2, 3], "String"))
 try:
     zip(1, "String")
 except TypeError as e:
-    print("Occured", repr(e))
+    print("Occurred", repr(e))
 print(zip())
 x = [(u, v) for (u, v) in zip(range(8), reversed(range(8)))]
 print(x)

--- a/tests/basics/ExceptionRaisingTest.py
+++ b/tests/basics/ExceptionRaisingTest.py
@@ -64,7 +64,7 @@ def raiseExceptionAndReraise(arg):
 try:
     raiseExceptionAndReraise(0)
 except:
-    print("Catched reraised", sys.exc_info())
+    print("Caught reraised", sys.exc_info())
 
 print("After catching, sys.exc_info is this", sys.exc_info())
 print("*" * 20)
@@ -140,12 +140,12 @@ def checkExceptionConversion():
     try:
         raise Exception("some string")
     except Exception as err:
-        print("Catched raised object", err, type(err))
+        print("Caught raised object", err, type(err))
 
     try:
         raise Exception, "some string"
     except Exception as err:
-        print("Catched raised type, value pair", err, type(err))
+        print("Caught raised type, value pair", err, type(err))
 
 
 checkExceptionConversion()
@@ -367,14 +367,14 @@ print("*" * 20)
 print("Testing exception that escapes __del__ and therefore cannot be raised")
 
 
-def devide(a, b):
+def divide(a, b):
     return a / b
 
 
 def unraisableExceptionInDel():
     class C:
         def __del__(self):
-            c = devide(1, 0)
+            c = divide(1, 0)
             print(c)
 
     def f():
@@ -557,7 +557,7 @@ def checkReraiseAfterNestedTryExcept():
     try:
         reraise()
     except Exception as e:
-        print("Catched", repr(e))
+        print("Caught", repr(e))
 
 
 checkReraiseAfterNestedTryExcept()

--- a/tests/basics/ExecEvalTest.py
+++ b/tests/basics/ExecEvalTest.py
@@ -324,7 +324,7 @@ def evalInContractions():
 print "Eval in a list contraction or generator expression", evalInContractions()
 
 
-def execDefinesFunctionToLocalsExplicity():
+def execDefinesFunctionToLocalsExplicitly():
     exec """\
 def makeAddPair(a, b):
     def addPair(c, d):
@@ -338,7 +338,7 @@ def makeAddPair(a, b):
     return "yes"
 
 
-print "Exec adds functions declares in explicit locals() given.", execDefinesFunctionToLocalsExplicity()
+print "Exec adds functions declares in explicit locals() given.", execDefinesFunctionToLocalsExplicitly()
 
 os.unlink(tmp_filename)
 

--- a/tests/basics/TrickAssignmentsTest32.py
+++ b/tests/basics/TrickAssignmentsTest32.py
@@ -1270,7 +1270,7 @@ def someFunctionThatReturnsDeletedValueViaFormat():
         def __format__(self, string):
             nonlocal a
             del a
-            return "formated string"
+            return "formatted string"
 
     c = C()
 

--- a/tests/basics/TryExceptFramesTest.py
+++ b/tests/basics/TryExceptFramesTest.py
@@ -72,7 +72,7 @@ def catcher():
     try:
         raising(True)
     except ZeroDivisionError:
-        print("Catched.")
+        print("Caught.")
 
         print("Top traceback code is '%s'." % sys.exc_info()[2].tb_frame.f_code.co_name)
         print(

--- a/tests/basics/YieldFromTest33.py
+++ b/tests/basics/YieldFromTest33.py
@@ -82,7 +82,7 @@ def test_broken_getattr_handling():
 test_broken_getattr_handling()
 
 
-def test_throw_catched_subgenerator_handling():
+def test_throw_caught_subgenerator_handling():
     def g1():
         try:
             print("Starting g1")
@@ -117,7 +117,7 @@ def test_throw_catched_subgenerator_handling():
         print("Yielded %s" % (x,))
 
 
-test_throw_catched_subgenerator_handling()
+test_throw_caught_subgenerator_handling()
 
 
 def give_cpython_generator():

--- a/tests/benchmarks/pybench/CommandLine.py
+++ b/tests/benchmarks/pybench/CommandLine.py
@@ -477,7 +477,7 @@ class Application:
                 handler = getattr(self, handlername)
             except AttributeError:
                 if value == '':
-                    # count the number of occurances
+                    # count the number of occurrences
                     if values.has_key(optionname):
                         values[optionname] = values[optionname] + 1
                     else:

--- a/tests/benchmarks/pybench/pybench.py
+++ b/tests/benchmarks/pybench/pybench.py
@@ -178,7 +178,7 @@ class Test:
         The tests must set .rounds to a value high enough to let the
         test run between 20-50 seconds. This is needed because
         clock()-timing only gives rather inaccurate values (on Linux,
-        for example, it is accurate to a few hundreths of a
+        for example, it is accurate to a few hundredths of a
         second). If you don't want to wait that long, use a warp
         factor larger than 1.
 

--- a/tests/benchmarks/pybench/systimes.py
+++ b/tests/benchmarks/pybench/systimes.py
@@ -24,7 +24,7 @@
 
     This module implements various different strategies for measuring
     performance timings. It tries to choose the best available method
-    based on the platforma and available tools.
+    based on the platform and available tools.
 
     On Windows, it is recommended to have the Mark Hammond win32
     package installed. Alternatively, the Thomas Heller ctypes

--- a/tests/distutils/example_1/setup.py
+++ b/tests/distutils/example_1/setup.py
@@ -17,7 +17,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-""" Distutils examle that contains a package and a data file.
+""" Distutils example that contains a package and a data file.
 
 """
 

--- a/tests/distutils/example_cfg_1/setup.py
+++ b/tests/distutils/example_cfg_1/setup.py
@@ -17,7 +17,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-""" Distutils examle that contains a package and a data file.
+""" Distutils example that contains a package and a data file.
 
 """
 

--- a/tests/distutils/py_modules_only/setup.py
+++ b/tests/distutils/py_modules_only/setup.py
@@ -17,7 +17,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
-""" Distutils examle that contains only plain module.
+""" Distutils example that contains only plain module.
 
 """
 


### PR DESCRIPTION
# What does this PR do?

Before, Nuitka would always follow symbolic links when copying data files. This would mean that if there are multiple links that point to a file within the data dir, it would create multiple copies of that file. With this PR, it will detect when symbolic links point to a file within the dir and will instead copy them as a symbolic link decreasing the package size.

# TODOs

- [ ] I'm not familiar with how the final package is being compressed. If needed, we might have to set a flag in the compression tool to not follow symbolic links there as well.
- [ ] Not implemented for onefile
