### PR TITLE
Fix MacOS app bundle executable name

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -91,6 +91,13 @@
     - depends:
         - 'gobject'
 
+- module-name: 'attr'
+  options:
+    checks:
+      - description: 'attrs is not fully supported before 23.1.0'
+        support_info: 'warning'
+        when: 'version("attrs") < (23,1)'
+
 - module-name: 'av.audio.frame'
   implicit-imports:
     - depends:

--- a/nuitka/utils/MacOSApp.py
+++ b/nuitka/utils/MacOSApp.py
@@ -42,6 +42,10 @@ def createPlistInfoFile(logger, onefile):
     result_filename = OutputDirectories.getResultFullpath(onefile=onefile)
     app_name = Options.getMacOSAppName() or os.path.basename(result_filename)
 
+    executable_name = os.path.basename(
+        OutputDirectories.getResultFullpath(onefile=Options.isOnefileMode())
+    )
+
     signed_app_name = Options.getMacOSSignedAppName() or app_name
     app_version = Options.getMacOSAppVersion() or "1.0"
 
@@ -51,7 +55,7 @@ def createPlistInfoFile(logger, onefile):
             ("CFBundleDisplayName", app_name),
             ("CFBundleName", app_name),
             ("CFBundleIdentifier", signed_app_name),
-            ("CFBundleExecutable", app_name),
+            ("CFBundleExecutable", executable_name),
             ("CFBundleInfoDictionaryVersion", "6.0"),
             ("CFBundlePackageType", "APPL"),
             ("CFBundleShortVersionString", app_version),


### PR DESCRIPTION
# What does this PR do?

During MacOS app bundle generation executable name is set to the application name, which may differ from the actual executable:

[MacOSApp.py:54](https://github.com/Nuitka/Nuitka/blob/36989fb6b35db28132511b947d9b414cb52b6b81/nuitka/utils/MacOSApp.py#LL54C46-L54C46)

```python
infos = OrderedDict(
        [
            ("CFBundleDisplayName", app_name),
            ("CFBundleName", app_name),
            ("CFBundleIdentifier", signed_app_name),
            ("CFBundleExecutable", app_name), #  <- here
            ("CFBundleInfoDictionaryVersion", "6.0"),
            ("CFBundlePackageType", "APPL"),
            ("CFBundleShortVersionString", app_version),
        ]
    )
```

It should fetch the executable name instead.

# Why was it initiated? Any relevant Issues?

If this issue occurs, MacOS .app file is marked as corrupted and cannot be launched.

Unfortunately, I couldn't figure out how to add platform-specific test, but I could try adding it if it is necessary.

# PR Checklist

- [X] Correct base branch selected? Should be `develop` branch.
- [X] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [X] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
