### PR TITLE
Fix tls-client different operating system dependencies

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4103,10 +4103,26 @@
   dlls:
     - from_filenames:
         relative_path: 'dependencies'
-        # TODO: We might want to match OS and arches here closely, so we do not pick up
-        # unnecessary arches.
         prefixes:
           - 'tls-client'
+        suffixes:
+          - 'dll'
+      when: 'win32'
+    - from_filenames:
+        relative_path: 'dependencies'
+        prefixes:
+          - 'tls-client'
+        suffixes:
+          - 'so'
+      when: 'linux'
+      #i don't use macos but hope it works
+    - from_filenames:
+        relative_path: 'dependencies'
+        prefixes:
+          - 'tls-client'
+        suffixes:
+          - 'dylib'
+      when: 'macos'
 
 - module-name: 'tokenizers.tools.visualizer'
   anti-bloat:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4115,7 +4115,7 @@
         suffixes:
           - 'so'
       when: 'linux'
-      #i don't use macos but hope it works
+      # Hopefully this works on MacOS
     - from_filenames:
         relative_path: 'dependencies'
         prefixes:


### PR DESCRIPTION
# What does this PR do?
Fixes tls-client compiling on differents operating systems. Tested this on both linux and windows, they work. Not sure about MacOS but should work too.  
# Why was it initiated? Any relevant Issues?
due to issue #2253 (tls-client only compiling on windows)  
# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
