### PR TITLE
add data-files to AXML parser packages

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -44,10 +44,20 @@
     dirs:
       - 'lib'
 
+- module-name: 'androguard.core.resources'
+  data-files:
+    patterns:
+      - 'public.xml'
+
 - module-name: 'anyio._core._eventloop'
   implicit-imports:
     - depends:
         - 'anyio._backends._asyncio'
+
+- module-name: 'apkutils.axml'
+  data-files:
+    patterns:
+      - 'public.xml'
 
 - module-name: 'appdirs'
   anti-bloat:
@@ -2093,6 +2103,11 @@
     - description: 'workaround for MSVC bug with scipy docscrape 1.8.x'
       replacements_plain:
         "return l2.startswith('-'*len(l1)) or l2.startswith('='*len(l1))": "r = l2.startswith('-'*len(l1)) or l2.startswith('='*len(l1)); return r"
+
+- module-name: 'pyaxmlparser.resources'
+  data-files:
+    patterns:
+      - 'public.xml'
 
 - module-name: 'pycparser.c_parser'
   implicit-imports:


### PR DESCRIPTION
# What does this PR do?

This PR updates the standard package config to support AXML parsing libraries ([apkutils](https://gitee.com/kin9-0rz/apkutils), [androguard](https://github.com/androguard/androguard), and [pyaxmlparser](https://github.com/appknox/pyaxmlparser)) by defining the required `public.xml` as a data-file for the dependent packages.

# Why was it initiated? Any relevant Issues?

Solves #2289 

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
