### PR TITLE
Add pywebview DLLs from version 4.2

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -5596,6 +5596,21 @@
       - 'lib'
   dlls:
     - from_filenames:
+        relative_path: 'lib/runtimes/win-x86/native'
+        prefixes:
+          - 'WebView2Loader'
+      when: 'win32 and arch_x86'
+    - from_filenames:
+        relative_path: 'lib/runtimes/win-x64/native'
+        prefixes:
+          - 'WebView2Loader'
+      when: 'win32 and arch_amd64'
+    - from_filenames:
+        relative_path: 'lib/runtimes/win-arm64/native'
+        prefixes:
+          - 'WebView2Loader'
+      when: 'win32 and arch_arm64'
+    - from_filenames:
         relative_path: 'lib/x86'
         prefixes:
           - 'WebView2Loader'


### PR DESCRIPTION
# What does this PR do?

This PR updates the DLLs added in the pywebview package, which were changed in version 4.2.

The directories were modified as follows:
- lib/x86 => lib/runtimes/win-x86/native
- lib/x64 => lib/runtimes/win-x64/native
- lib/arm64 => lib/runtimes/win-arm64/native

 For more info check the [directory change on pywebview](https://github.com/r0x0r/pywebview/tree/4.2/webview/lib)
 
# Why was it initiated? Any relevant Issues?
I initiated this to make nuitka compatible with pywebview >= 4.2

# PR Checklist

- [x] Update nuitka/plugins/standard/standard.nuitka-package.config.yml with these changes 

