### PR TITLE
Fix usage of deprecated sysconfig variable with mingw

### DIFF
--- a/nuitka/PythonFlavors.py
+++ b/nuitka/PythonFlavors.py
@@ -141,7 +141,7 @@ def isMSYS2MingwPython():
 
     import sysconfig
 
-    return "-mingw_" in sysconfig.get_config_var("SO")
+    return "-mingw_" in sysconfig.get_config_var("EXT_SUFFIX")
 
 
 def isTermuxPython():


### PR DESCRIPTION

    This fixes the following error with mingw python 3.11.

    nuitka/PythonFlavors.py", line 144, in isMSYS2MingwPython
        return "-mingw_" in sysconfig.get_config_var("SO")
    TypeError: argument of type 'NoneType' is not iterable

    SO config variable in sysconfig was removed in python 3.11. It was
    deprecated in Python 3.4 and was suggested for removal in Python 3.5.
    See this cpython commit
    https://github.com/python/cpython/commit/0860b26a4f7abeb61aad9f4b96de8e78eed8c12a

