### PR TITLE
Add PEP 660 editable install support for nuitka.distutils.Build

### DIFF
--- a/nuitka/distutils/Build.py
+++ b/nuitka/distutils/Build.py
@@ -31,6 +31,9 @@ if not hasattr(setuptools.build_meta, "suppress_known_deprecation"):
 else:
     suppress_known_deprecation = setuptools.build_meta.suppress_known_deprecation
 
+SETUPTOOLS_ENABLE_FEATURES = os.getenv("SETUPTOOLS_ENABLE_FEATURES", "").lower()
+LEGACY_EDITABLE = "legacy-editable" in SETUPTOOLS_ENABLE_FEATURES.replace("_", "-")
+
 
 # reusing private "build" package code, pylint: disable=protected-access
 class NuitkaBuildMetaBackend(setuptools.build_meta._BuildMetaBackend):
@@ -52,3 +55,8 @@ get_requires_for_build_sdist = _BACKEND.get_requires_for_build_sdist
 prepare_metadata_for_build_wheel = _BACKEND.prepare_metadata_for_build_wheel
 build_wheel = _BACKEND.build_wheel
 build_sdist = _BACKEND.build_sdist
+
+if not LEGACY_EDITABLE:
+    get_requires_for_build_editable = _BACKEND.get_requires_for_build_editable
+    prepare_metadata_for_build_editable = _BACKEND.prepare_metadata_for_build_editable
+    build_editable = _BACKEND.build_editable


### PR DESCRIPTION
# What does this PR do?

 - Adds support for PEP 660 editable installs to nuitka.distutils.Build
 
# Why was it initiated? Any relevant Issues?

  - To solve the problem that local project packages cannot be installed in editable mode.
  - Related to issue #2356

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
