### PR TITLE
Fixed PySide workaround

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2920,20 +2920,21 @@
   implicit-imports:
     - post-import-code:
         - |
-          def myconnect(self, func):
-              if hasattr(func, "im_func"):
-                  if hasattr(func.im_func, "__compiled__"):
-                      myconnect._protected = getattr(myconnect, "_protected", set())
-                      myconnect._protected.add(func)
+          def patched_connect(self, receiver, type=None):
+              type = type or QtCore.Qt.ConnectionType.AutoConnection
+              if hasattr(receiver, "im_func"):
+                  if hasattr(receiver.im_func, "__compiled__"):
+                      patched_connect._protected = getattr(patched_connect, "_protected", set())
+                      patched_connect._protected.add(receiver)
 
-                  if not func.im_func.__name__.startswith("_pyside2_workaround_"):
-                      func.im_func.__name__ = "_nuitka_" + func.im_func.__name__
+                  if not receiver.im_func.__name__.startswith("_pyside2_workaround_"):
+                      receiver.im_func.__name__ = "_nuitka_" + receiver.im_func.__name__
 
-              return orig_connect(self, func)
+              return orig_connect(self, receiver, type)
 
           from PySide2 import QtCore
           orig_connect = QtCore.SignalInstance.connect
-          QtCore.SignalInstance.connect = myconnect
+          QtCore.SignalInstance.connect = patched_connect
 
   options:
     checks:
@@ -2971,20 +2972,21 @@
         - 'PySide6.support.deprecated'
     - post-import-code:
         - |
-          def myconnect(self, func):
-              if hasattr(func, "im_func"):
-                  if hasattr(func.im_func, "__compiled__"):
-                      myconnect._protected = getattr(myconnect, "_protected", set())
-                      myconnect._protected.add(func)
+          def patched_connect(self, receiver, type=None):
+              type = type or QtCore.Qt.ConnectionType.AutoConnection
+              if hasattr(receiver, "im_func"):
+                  if hasattr(receiver.im_func, "__compiled__"):
+                      patched_connect._protected = getattr(patched_connect, "_protected", set())
+                      patched_connect._protected.add(receiver)
 
-                  if not func.im_func.__name__.startswith("_pyside6_workaround_"):
-                      func.im_func.__name__ = "_nuitka_" + func.im_func.__name__
+                  if not receiver.im_func.__name__.startswith("_pyside6_workaround_"):
+                      receiver.im_func.__name__ = "_nuitka_" + receiver.im_func.__name__
 
-              return orig_connect(self, func)
+              return orig_connect(self, receiver, type)
 
           from PySide6 import QtCore
           orig_connect = QtCore.SignalInstance.connect
-          QtCore.SignalInstance.connect = myconnect
+          QtCore.SignalInstance.connect = patched_connect
 
 - module-name: 'pysnmp.smi'
   data-files:


### PR DESCRIPTION
# What does this PR do?

A fix for a PySide2/6 workaround for Qt signal `connect` function.
And I've changed the function name for clarity.

# Why was it initiated? Any relevant Issues?

A signal `connect()` in PySide/Qt actually has one more argument that wasn't covered, although used only occasionally.
Without it, it's possible to encounter exception like this:

```python
Traceback (most recent call last):
  File "...", line 33, in <module>
  File "...", line 24, in start_app
  File "...", line 135, in __enter__
  File ".../qtinter/_contexts.py", line 36, in using_asyncio_from_qt
  File ".../qtinter/_base_events.py", line 250, in start
  File ".../qtinter/_base_events.py", line 268, in _qi_loop_startup
  File ".../qtinter/_base_events.py", line 75, in _create_notifier
  File ".../qtinter/_base_events.py", line 31, in __init__
  File ".../qtinter/bindings.py", line 66, in add_callback
TypeError: myconnect() takes 2 positional arguments but 3 were given
```

Relevant: #2162

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

I've run only basic, program and syntax tests for my concrete python 3.10.12.
