### PR TITLE
Fixed import error for rapidfuzz 3.X.X

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3181,6 +3181,8 @@
         - '.Postfix_cpp'
         - '.Prefix_py'
         - '.Prefix_cpp'
+        - '.metrics_cpp'
+        - '.metrics_py'
 
 - module-name: 'rasterio._io'
   implicit-imports:


### PR DESCRIPTION
# What does this PR do?
Fixes import error for rapidfuzz 3.X.X(tested 3.0.0, and 3.2.0)
# Why was it initiated? Any relevant Issues?
rapidfuzz-test.py code:
```python
from rapidfuzz import fuzz

# Should print around 96.55 based from the docs
print(fuzz.ratio("this is a test", "this is a test!")) 
```
Using concrete python 3.11.4(x86_64):
```
nuitka --standalone --windows-force-stderr-spec=errors.txt rapidfuzz-test.py
```
Running the .exe file will trigger the following error:
```python
Traceback (most recent call last):
  File "...\rapidfuzz-test.py", line 1, in <module>
  File "...\rapidfuzz\__init__.py", line 10, in <module rapidfuzz>
  File "...\rapidfuzz\distance\__init__.py", line 6, in <module rapidfuzz.distance>
  File "...\rapidfuzz\distance\OSA.py", line 8, in <module rapidfuzz.distance.OSA>
  File "...\rapidfuzz\_utils.py", line 105, in fallback_import
  File "importlib.py", line 126, in import_module
ModuleNotFoundError: No module named 'rapidfuzz.distance.metrics_py'
```
See: [rapidfuzz hook for pyinstaller](https://github.com/maxbachmann/RapidFuzz/blob/main/src/rapidfuzz/__pyinstaller/hook-rapidfuzz.py) which has .metrics_py only since v3.0.0, which is not in the implicit configs.
The only test I did was to compile the code above as the change will only affect importing rapidfuzz.
# PR Checklist

- [X] Correct base branch selected? Should be `develop` branch.
- [X] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
