### PR TITLE
Fixing the issue #2448 of incorrect platform tag naming for the wheel package.

### DIFF
--- a/nuitka/distutils/DistutilCommands.py
+++ b/nuitka/distutils/DistutilCommands.py
@@ -379,7 +379,6 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
         wheel.bdist_wheel.bdist_wheel.finalize_options(self)
         # Force module to use correct platform in name
         self.root_is_pure = False
-        self.plat_name_supplied = self.plat_name is not None
 
     def write_wheelfile(self, wheelfile_base, generator=None):
         if generator is None:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

# What does this PR do?
This PR is to fix the #2448 issue.

# Why was it initiated? Any relevant Issues?
Hey, bro, you thought that issue #2448 was unrelated to Nuitka, so you closed it. However, after a period of breakpoint debugging, I discovered that the cause of this issue lies in a flawed logic within Nuitka's code. 
In the code of the wheel package, at https://github.com/pypa/wheel/blob/e76040b0d970a0fe6211c31888fc929078ba02d9/src/wheel/bdist_wheel.py#L252, when this line of code is executed, the variable `self.plat_name` is still `None`. Its value is initialized later at https://github.com/pypa/wheel/blob/e76040b0d970a0fe6211c31888fc929078ba02d9/src/wheel/bdist_wheel.py#L261. Therefore, at this point, the value of `self.plat_name_supplied` in line 252 is definitely `False`. However, in your Nuitka code, after calling `wheel.bdist_wheel.bdist_wheel.finalize_options(self)`, you run `self.plat_name_supplied = self.plat_name is not None`, which causes the value of `self.plat_name_supplied` to be inconsistent with the expected value. So, I submitted this PR to fix this behavior.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
