### PR TITLE
Added support for lightning module

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -1350,6 +1350,11 @@
         prefixes:
           - 'lib_lightgbm'
 
+- module-name: 'lightning'
+  data-files:
+    patterns:
+      - 'version.info'
+
 - module-name: 'lightning_fabric'
   data-files:
     patterns:


### PR DESCRIPTION
Thank you for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
Adds support for the lightning module by including the missing version.info file

# Why was it initiated? Any relevant Issues?
The lightning module is not currently able to be used after being built by nuitka

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.


I decided to make this PR in order to address my issue with the lightning module and enable other users to be able to use the module as well. I have based my fix on the discussion on this thread and merged PR
[Add support for pytorch-lightning](https://github.com/Nuitka/Nuitka/pull/2109)