### PR TITLE
Add GI extra dlls: soup, secret

### DIFF
--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -104,4 +104,4 @@ if not os.environ.get("GI_TYPELIB_PATH"):
 
         if module.getFullName() == "gi._gi":
             # TODO: Get local relevant DLL names from GI
-            for dll in ["gtk-3-0", "soup-2.4-1"] : yield tryLocateAndLoad(dll)
+            for dll in ["gtk-3-0", "soup-2.4-1", "libsecret-1-0"] : yield tryLocateAndLoad(dll)

--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -86,37 +86,22 @@ if not os.environ.get("GI_TYPELIB_PATH"):
 
     @standalone_only
     def getExtraDlls(self, module):
+        def tryLocateAndLoad(dll_name):
+            # Support various name forms in MSYS2 over time.
+            dll_path = self.locateDLL(dll_name)
+            if dll_path is None:
+                dll_path = self.locateDLL("%s" % dll_name)
+            if dll_path is None:
+                dll_path = self.locateDLL("lib%s" % dll_name)
+
+            if dll_path is not None:
+                yield self.makeDllEntryPoint(
+                    source_path=dll_path,
+                    dest_path=os.path.basename(dll_path),
+                    package_name=None,
+                    reason="needed by 'gi._gi'",
+                )
+
         if module.getFullName() == "gi._gi":
-            gtk_dll_name = "gtk-3"
-
-            # Support various name forms in MSYS2 over time.
-            gtk_dll_path = self.locateDLL(gtk_dll_name)
-            if gtk_dll_path is None:
-                gtk_dll_path = self.locateDLL("%s-0" % gtk_dll_name)
-            if gtk_dll_path is None:
-                gtk_dll_path = self.locateDLL("lib%s-0" % gtk_dll_name)
-
-            if gtk_dll_path is not None:
-                yield self.makeDllEntryPoint(
-                    source_path=gtk_dll_path,
-                    dest_path=os.path.basename(gtk_dll_path),
-                    package_name=None,
-                    reason="needed by 'gi._gi'",
-                )
-
-            soup_dll_name = "soup-2.4"
-            # libsoup-2.4-1
-            # Support various name forms in MSYS2 over time.
-            soup_dll_path = self.locateDLL(soup_dll_name)
-            if soup_dll_path is None:
-                soup_dll_path = self.locateDLL("%s-1" % soup_dll_name)
-            if soup_dll_path is None:
-                soup_dll_path = self.locateDLL("lib%s-1" % soup_dll_name)
-
-            if soup_dll_path is not None:
-                yield self.makeDllEntryPoint(
-                    source_path=soup_dll_path,
-                    dest_path=os.path.basename(soup_dll_path),
-                    package_name=None,
-                    reason="needed by 'gi._gi'",
-                )
+            # TODO: Get local relevant DLL names from GI
+            for dll in ["gtk-3-0", "soup-2.4-1"] : yield tryLocateAndLoad(dll)

--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -104,4 +104,5 @@ if not os.environ.get("GI_TYPELIB_PATH"):
 
         if module.getFullName() == "gi._gi":
             # TODO: Get local relevant DLL names from GI
-            for dll in ["gtk-3-0", "soup-2.4-1", "soup-gnome-2.4-1", "libsecret-1-0"] : yield tryLocateAndLoad(dll)
+            for dll in ["gtk-3-0", "soup-2.4-1", "soup-gnome-2.4-1", "libsecret-1-0"]:
+                yield tryLocateAndLoad(dll)

--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -103,3 +103,20 @@ if not os.environ.get("GI_TYPELIB_PATH"):
                     package_name=None,
                     reason="needed by 'gi._gi'",
                 )
+
+            soup_dll_name = "soup-2.4"
+            # libsoup-2.4-1
+            # Support various name forms in MSYS2 over time.
+            soup_dll_path = self.locateDLL(soup_dll_name)
+            if soup_dll_path is None:
+                soup_dll_path = self.locateDLL("%s-1" % soup_dll_name)
+            if soup_dll_path is None:
+                soup_dll_path = self.locateDLL("lib%s-1" % soup_dll_name)
+
+            if soup_dll_path is not None:
+                yield self.makeDllEntryPoint(
+                    source_path=soup_dll_path,
+                    dest_path=os.path.basename(soup_dll_path),
+                    package_name=None,
+                    reason="needed by 'gi._gi'",
+                )

--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -104,4 +104,4 @@ if not os.environ.get("GI_TYPELIB_PATH"):
 
         if module.getFullName() == "gi._gi":
             # TODO: Get local relevant DLL names from GI
-            for dll in ["gtk-3-0", "soup-2.4-1", "libsecret-1-0"] : yield tryLocateAndLoad(dll)
+            for dll in ["gtk-3-0", "soup-2.4-1", "soup-gnome-2.4-1", "libsecret-1-0"] : yield tryLocateAndLoad(dll)


### PR DESCRIPTION
# What does this PR do?

This adds three DLLs to be added by the GI library (soup and secret).
There's a [lot of these](https://lazka.github.io/pgi-docs/) and it would be favorable to have an automatism, but this might be a viable start.

# Why was it initiated? Any relevant Issues?

I am trying to package [gtimelog](https://github.com/gtimelog/gtimelog) for Windows, and it is depending on the soup and secret GI modules.

#2471 is related.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
  - Couldn't get autoformat-nuitka-source to run either in MSys2 nor in an Alpine WSL2 container with venv.  Ran isort and black manually, hope this suffices for now.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
  - Haven't checked.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
  - Don't know how I would test this I am afraid.
- [ ] Ideally new or changed features have documentation updates.
  - Where would I add this?