### PR TITLE
Standalone: Add missing resource file for "pyocd" and cmsis_pack_manager

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -559,6 +559,12 @@
       replacements_plain:
         '__version__ = get_distribution(__name__).version': 'raise DistributionNotFound'
 
+- module-name: 'cmsis_pack_manager.cmsis_pack_manager'
+  dlls:
+    - from_filenames:
+        prefixes:
+          - 'native'
+
 - module-name: 'connexion'
   data-files:
     dirs:
@@ -3010,6 +3016,12 @@
   implicit-imports:
     - depends:
         - 'pymssql._mssql'
+
+- module-name: 'pyocd'
+  data-files:
+    patterns:
+      - 'debug/sequences/*.lark'
+      - 'debug/svd/*.zip'
 
 - module-name: 'pyodbc'
   implicit-imports:


### PR DESCRIPTION
pypi link: https://pypi.org/project/pyocd/
and
https://pypi.org/project/cmsis-pack-manager/

have runed `python3.8 .\bin\autoformat-nuitka-source nuitka`