### PR TITLE
Fix top level package search for junk files that end on .

### DIFF
--- a/nuitka/utils/Distributions.py
+++ b/nuitka/utils/Distributions.py
@@ -82,6 +82,8 @@ def getDistributionTopLevelPackageNames(distribution):
                 continue
             if first_path_element == "__pycache__":
                 continue
+            if first_path_element.endswith("."):
+                continue
 
             if remainder:
                 module_name = ModuleName(first_path_element)


### PR DESCRIPTION
# What does this PR do?

If some junk file in the module distribution files ends on . and `top_level.txt` is not included in the wheel, then ModuleName constructor will raise an assert. Ideally, it should just ignore the file.

https://github.com/Nuitka/Nuitka/blob/c5766f8e2c497d991baaa2f7eefd2c7b940bb2ea/nuitka/utils/Distributions.py#L87

# Why was it initiated? Any relevant Issues?

Newer version of the package `python-rtmidi` failed to build on Linux due to the both `python_rtmidi.` folder present in the .whl file and `top-level.txt` absent for some reason.

```
Nuitka-Options:INFO: Used command line options: --standalone --include-module=smartwheel --include-module=smartwheel.actions --include-module=smartwheel.backgrounds --include-module=smartwheel.serialpipe --include-module=smartwheel.settings_handlers --include-module=smartwheel.ui --include-module=smartwheel.ui.internal --enable-plugin=pyqt6 --include-data-dir=./smartwheel=smartwheel ./main.py
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/plugins/Plugins.py", line 82, in withPluginProblemReporting
    yield
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/plugins/Plugins.py", line 123, in _addActivePlugin
    plugin_instance = plugin_class(**plugin_args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/plugins/standard/PySidePyQtPlugin.py", line 1460, in __init__
    NuitkaPluginQtBindingsPluginBase.__init__(
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/plugins/standard/PySidePyQtPlugin.py", line 65, in __init__
    self.distribution = getDistributionFromModuleName(self.binding_name)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/utils/Distributions.py", line 207, in getDistributionFromModuleName
    distributions = getDistributionsFromModuleName(module_name)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/utils/Distributions.py", line 187, in getDistributionsFromModuleName
    _package_to_distribution = _initPackageToDistributionName()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/utils/Distributions.py", line 155, in _initPackageToDistributionName
    for package_name in getDistributionTopLevelPackageNames(distribution):
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/utils/Distributions.py", line 87, in getDistributionTopLevelPackageNames
    module_name = ModuleName(first_path_element)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/nuitka/utils/ModuleNames.py", line 58, in __init__
    assert checkModuleName(value), value
AssertionError: python_rtmidi.
FATAL: pyqt6: Plugin issue while working on 'Plugin initialization failed'. Please report the bug with the above traceback included.
Error: Process completed with exit code 1.
```

```
❯ tar -xf python_rtmidi-1.5.8-cp310-cp310-manylinux_2_28_x86_64.whl
❯ ls
python_rtmidi-1.5.8-cp310-cp310-manylinux_2_28_x86_64.whl
python_rtmidi-1.5.8.dist-info
python_rtmidi.  # <- the culprint
rtmidi
```

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
