### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Platform/win32.py
+++ b/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Platform/win32.py
@@ -130,8 +130,10 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         return 127
     else:
         # one temporary file for stdout and stderr
-        tmpFileStdout = os.path.normpath(tempfile.mktemp())
-        tmpFileStderr = os.path.normpath(tempfile.mktemp())
+        tmpFileStdout, tmpFileStdoutName = tempfile.mkstemp(text=True)
+        os.close(tmpFileStdout)
+        tmpFileStderr, tmpFileStderrname = tempfile.mkstemp(text=True)
+        os.close(tmpFileStderr)
 
         # check if output is redirected
         stdoutRedirected = 0
@@ -147,9 +149,9 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
 
         # redirect output of non-redirected streams to our tempfiles
         if stdoutRedirected == 0:
-            args.append(">" + str(tmpFileStdout))
+            args.append(">" + str(tmpFileStdoutName))
         if stderrRedirected == 0:
-            args.append("2>" + str(tmpFileStderr))
+            args.append("2>" + str(tmpFileStderrname))
 
         # actually do the spawn
         try:

--- a/nuitka/build/inline_copy/lib/scons-3.1.2/SCons/Platform/win32.py
+++ b/nuitka/build/inline_copy/lib/scons-3.1.2/SCons/Platform/win32.py
@@ -183,8 +183,10 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
         return 127
     else:
         # one temporary file for stdout and stderr
-        tmpFileStdout = os.path.normpath(tempfile.mktemp())
-        tmpFileStderr = os.path.normpath(tempfile.mktemp())
+        tmpFileStdout, tmpFileStdoutName = tempfile.mkstemp(text=True)
+        os.close(tmpFileStdout)
+        tmpFileStderr, tmpFileStderrName = tempfile.mkstemp(text=True)
+        os.close(tmpFileStderr)
 
         # check if output is redirected
         stdoutRedirected = 0
@@ -199,9 +201,9 @@ def piped_spawn(sh, escape, cmd, args, env, stdout, stderr):
 
         # redirect output of non-redirected streams to our tempfiles
         if stdoutRedirected == 0:
-            args.append(">" + str(tmpFileStdout))
+            args.append(">" + str(tmpFileStdoutName))
         if stderrRedirected == 0:
-            args.append("2>" + str(tmpFileStderr))
+            args.append("2>" + str(tmpFileStderrName))
 
         # actually do the spawn
         try:
@@ -300,7 +302,7 @@ def get_system_root():
             except:
                 pass
 
-    # Ensure system root is a string and not unicode 
+    # Ensure system root is a string and not unicode
     # (This only matters for py27 were unicode in env passed to POpen fails)
     val = str(val)
     _system_root = val


### PR DESCRIPTION
# PR Checklist
- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.


## Summary
This PR fixes an unsafe method (mktemp) with a safer one (mkstemp). [Using an unsafe API to create temporary files (CWE-377)](https://cwe.mitre.org/data/definitions/377.html) can leave application and data vulnerable to attack.


## Description
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [win32.py](https://github.com/Nuitka/Nuitka/tree/develop/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Platform/win32.py#L133), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using mkstemp which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with mkstemp.

> In file: [win32.py](https://github.com/Nuitka/Nuitka/tree/develop/nuitka/build/inline_copy/lib/scons-3.1.2/SCons/Platform/win32.py#L187), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using mkstemp which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with mkstemp.

**Here Are Some Resources That Can Help You Understand**
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)

It appers that the SCons library inside your repository is an outdated one. According to `setup.py` and `scons.py`, the outdated versions are used for POSIX based ssytems such as Unix and Linux. Since the original repo of SCons has updated their `mktemp` methods with `mkstemp`, it's better to adapt the changes to your project too.

I have updated the methods according to the [SCons source code](https://www.github.com/SCons/scons/commit/9368c9247952ff8a8b40da6cd15cd662cfcfdf0d).


## Previously Found & Fixed
Below is a list of open-source projects where this same bug was found and fixed-
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/spcl/dace/pull/1428
- https://www.github.com/scylladb/scylla-cluster-tests/pull/6795
- https://www.github.com/dimagi/commcare-hq/pull/33725
- https://www.github.com/SpikeInterface/spikeinterface/pull/2195
- https://www.github.com/nipy/nipy/pull/552
- https://www.github.com/imageio/imageio/pull/1055
- https://www.github.com/celery/kombu/pull/1828
- https://www.github.com/OCA/reporting-engine/pull/809


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

