### PR TITLE
Fix: nuitka will not dectect icon not belong to its platform

### DIFF
--- a/nuitka/OptionParsing.py
+++ b/nuitka/OptionParsing.py
@@ -1311,7 +1311,7 @@ windows_group.add_option(
 windows_group.add_option(
     "--windows-icon-from-ico",
     action="append",
-    dest="icon_path",
+    dest="windows_icon_path",
     metavar="ICON_PATH",
     default=[],
     help="""\
@@ -1391,7 +1391,7 @@ is the only way to unlock disabling of console.Defaults to off.""",
 macos_group.add_option(
     "--macos-app-icon",
     action="append",
-    dest="icon_path",
+    dest="macos_icon_path",
     metavar="ICON_PATH",
     default=[],
     help="Add icon for the application bundle to use. Can be given only one time. Defaults to Python icon if available.",
@@ -1496,7 +1496,7 @@ linux_group.add_option(
     "--linux-icon",
     "--linux-onefile-icon",
     action="append",
-    dest="icon_path",
+    dest="linux_icon_path",
     metavar="ICON_PATH",
     default=[],
     help="Add executable icon for onefile binary to use. Can be given only one time. Defaults to Python icon if available.",

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1731,6 +1731,7 @@ def shallOnefileAsArchive():
     return options.onefile_as_archive
 
 
+# pylint: disable=line-too-long
 def getIconPaths():
     """*list of str*, values of ``--windows-icon-from-ico`` ``--macos-app-icon`` ``--linux-icon`` and ``--linux-onefile-icon``"""
 

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1740,6 +1740,12 @@ def getIconPaths():
         result = options.windows_icon_path
     elif isMacOS():
         result = options.macos_icon_path
+    else:
+        result = (
+            options.linux_icon_path
+            + options.windows_icon_path
+            + options.macos_icon_path
+        )
 
     # Check if Linux icon requirement is met.
     if isLinux() and not result and isOnefileMode():

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1732,9 +1732,14 @@ def shallOnefileAsArchive():
 
 
 def getIconPaths():
-    """*list of str*, values of ``--windows-icon-from-ico`` and ``--linux-onefile-icon``"""
+    """*list of str*, values of ``--windows-icon-from-ico`` ``--macos-app-icon`` ``--linux-onefile-icon`` and ``--linux-onefile-icon``"""
 
-    result = options.icon_path
+    if isLinux():
+        result = options.linux_icon_path
+    elif isWin32OrPosixWindows():
+        result = options.windows_icon_path
+    elif isMacOS():
+        result = options.macos_icon_path
 
     # Check if Linux icon requirement is met.
     if isLinux() and not result and isOnefileMode():

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1732,7 +1732,7 @@ def shallOnefileAsArchive():
 
 
 def getIconPaths():
-    """*list of str*, values of ``--windows-icon-from-ico`` ``--macos-app-icon`` ``--linux-onefile-icon`` and ``--linux-onefile-icon``"""
+    """*list of str*, values of ``--windows-icon-from-ico`` ``--macos-app-icon`` ``--linux-icon`` and ``--linux-onefile-icon``"""
 
     if isLinux():
         result = options.linux_icon_path

--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1734,18 +1734,17 @@ def shallOnefileAsArchive():
 def getIconPaths():
     """*list of str*, values of ``--windows-icon-from-ico`` ``--macos-app-icon`` ``--linux-icon`` and ``--linux-onefile-icon``"""
 
+    result = []
     if isLinux():
-        result = options.linux_icon_path
+        result += options.linux_icon_path
     elif isWin32OrPosixWindows():
-        result = options.windows_icon_path
+        result += options.windows_icon_path
     elif isMacOS():
-        result = options.macos_icon_path
+        result += options.macos_icon_path
     else:
-        result = (
-            options.linux_icon_path
-            + options.windows_icon_path
-            + options.macos_icon_path
-        )
+        result += options.windows_icon_path
+        result += options.macos_icon_path
+        result += options.linux_icon_path
 
     # Check if Linux icon requirement is met.
     if isLinux() and not result and isOnefileMode():


### PR DESCRIPTION
before:
```
Nuitka-Scons:INFO: Compiled 203 C files using clcache with 162 cache hits and 41 cache misses.
Nuitka-Postprocessing:INFO: File 'assets\textures\icon.png' is not in Windows icon format, converting to it.
Nuitka-Postprocessing:INFO: Adding 7 icon(s) from icon file 'assets/textures/icon.png'.
Nuitka-Postprocessing:INFO: File 'assets\textures\icon.png' is not in Windows icon format, converting to it.
Nuitka-Postprocessing:INFO: Adding 7 icon(s) from icon file 'assets/textures/icon.png'.
Nuitka-Postprocessing:INFO: File 'assets\textures\icon.png' is not in Windows icon format, converting to it.
Nuitka-Postprocessing:INFO: Adding 7 icon(s) from icon file 'assets/textures/icon.png'.
Nuitka-Options:INFO: Included data file 'config\lndl-logger.toml' due to specified data dir './config' on command line.
```
```toml
windows-icon-from-ico = 'assets/textures/icon.png'
macos-app-icon = 'assets/textures/icon.png'
linux-icon = 'assets/textures/icon.png'
```

Nuitka will package all three icon on windows
and crash on Linux and MacOS because `getIconPaths` will return 3 path, but other 2 is not for linux/macos

now
```
Nuitka-Scons: Compiled 212 C files using clcache with 170 cache hits and 42 cache misses.
Nuitka-Postprocessing: File 'assets\textures\icon.png' is not in Windows icon format, converting to it.
Nuitka-Postprocessing: Adding 7 icon(s) from icon file 'assets/textures/icon.png'.
Nuitka-Options: Included data file 'config\lndl-logger.toml' due to specified data dir './config' on command line.
```