### PR TITLE
Fixed Improper Method Call: Replaced `NotImplementedError`

### DIFF
--- a/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Variables/ListVariable.py
+++ b/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Variables/ListVariable.py
@@ -64,17 +64,17 @@ class _ListVariable(collections.UserList):
         self.allowedElems = sorted(allowedElems)
 
     def __cmp__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __eq__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __ge__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __gt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __le__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __lt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __str__(self):
         if len(self) == 0:
             return 'none'

--- a/nuitka/build/inline_copy/lib/scons-3.1.2/SCons/Variables/ListVariable.py
+++ b/nuitka/build/inline_copy/lib/scons-3.1.2/SCons/Variables/ListVariable.py
@@ -64,17 +64,17 @@ class _ListVariable(collections.UserList):
         self.allowedElems = sorted(allowedElems)
 
     def __cmp__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __eq__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __ge__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __gt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __le__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __lt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
     def __str__(self):
         if len(self) == 0:
             return 'none'

--- a/nuitka/build/inline_copy/lib/scons-4.3.0/SCons/Variables/ListVariable.py
+++ b/nuitka/build/inline_copy/lib/scons-4.3.0/SCons/Variables/ListVariable.py
@@ -70,22 +70,22 @@ class _ListVariable(collections.UserList):
         self.allowedElems = sorted(allowedElems)
 
     def __cmp__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __eq__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __ge__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __gt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __le__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __lt__(self, other):
-        raise NotImplementedError
+        return NotImplemented
 
     def __str__(self):
         if not len(self):


### PR DESCRIPTION
# PR Checklist
- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.


## Summary
This PR fixes the improper use of `NotImplementedError` with a proper one `NotImplemented` in the SCons library source code.


## Description
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [ListVariable.py](https://github.com/Nuitka/Nuitka/tree/develop/nuitka/build/inline_copy/lib/scons-2.3.2/SCons/Variables/ListVariable.py#L77), class: _ListVariable, there is a special method `__lt__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should [return NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__sub__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is [shown here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).

The same message is found for two more `ListVariable.py` file of the SCons library.

Recently, [we've fixed the bug for SCons library](https://www.github.com/SCons/scons/pull/4448), which has been merged. Since your project includes a few outdated versions of SCons, it's better to update them.


## Solution / Suggested Changes
The use of `NotImplementedError` has been replaced with `NotImplemented` since their usage are different.


## Previously Found & Fixed
Below is a list of open-source projects where this same bug was found and fixed-
- https://www.github.com/ethereum/web3.py/pull/3080
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/FEniCS/ffcx/pull/636
- https://www.github.com/projecthamster/hamster/pull/737
- https://www.github.com/phoebe-project/phoebe2/pull/795
- https://www.github.com/osm-fr/osmose-backend/pull/2071
- https://www.github.com/SCons/scons/pull/4448


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
