### PR TITLE
Fix bug: incorrectly access `pyproject.toml` `tool.nuitka` field

### DIFF
--- a/nuitka/distutils/DistutilCommands.py
+++ b/nuitka/distutils/DistutilCommands.py
@@ -323,7 +323,9 @@ class build(distutils.command.build.build):
                 for option, value in toml_options.get("nuitka", {}).items():
                     command.extend(self._parseOptionsEntry(option, value))
 
-                for option, value in toml_options.get("tool.nuitka", {}).items():
+                for option, value in (
+                    toml_options.get("tool", {}).get("nuitka", {}).items()
+                ):
                     command.extend(self._parseOptionsEntry(option, value))
 
             # Process any extra options from setuptools


### PR DESCRIPTION
# What does this PR do?

The `tool.nuitka` field from `pyproject.toml` gets loaded as a nested dict into the `toml_options` variable. 

Therefore `toml_options['tool.nuitka']` is empty and instead we need to access `toml_options['tool']['nuitka']`.

# Why was it initiated? Any relevant Issues?

Despite using `v1.9.4` which includes d249f42645b16a0036d5730b24faffcf317fee07, nuitka didn't recognize the `tool.nuitka` field in my `pyproject.toml`.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

Note: I didn't run the test suite for this small change, however tested on a local repo that this fixed my issue. 
