### PR TITLE
Handles virtualenv of not installed, self-compiled Python versions

### DIFF
--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -331,15 +331,9 @@ def getSystemPrefixPath():
 
             sys_prefix = getDirectoryRealPath(sys_prefix)
 
-        # Virtualenv of a not installed self-compiled Python version
-        if (
-            os.name != "nt"
-            and os.path.islink(sys.executable)
-            and os.path.isdir(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(sys.executable)), "PCbuild"
-                )
-            )
+        # Self-compiled Python version in source tree
+        if os.path.isdir(
+            os.path.join(os.path.dirname(os.path.realpath(sys.executable)), "PCbuild")
         ):
             sys_prefix = os.path.dirname(os.path.realpath(sys.executable))
 

--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -331,6 +331,18 @@ def getSystemPrefixPath():
 
             sys_prefix = getDirectoryRealPath(sys_prefix)
 
+        # Virtualenv of a not installed self-compiled Python version
+        if (
+            os.name != "nt"
+            and os.path.islink(sys.executable)
+            and os.path.isdir(
+                os.path.join(
+                    os.path.dirname(os.path.realpath(sys.executable)), "PCbuild"
+                )
+            )
+        ):
+            sys_prefix = os.path.dirname(os.path.realpath(sys.executable))
+
         _the_sys_prefix = sys_prefix
 
     return _the_sys_prefix

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -605,6 +605,7 @@ def _detectPythonHeaderPath():
             os.path.join(
                 python_prefix_external, "include", "python" + python_abi_version
             ),
+            # CPython source code checkout
             os.path.join(python_prefix_external, "Include"),
             # Haiku specific paths:
             os.path.join(

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -605,6 +605,7 @@ def _detectPythonHeaderPath():
             os.path.join(
                 python_prefix_external, "include", "python" + python_abi_version
             ),
+            os.path.join(python_prefix_external, "Include"),
             # Haiku specific paths:
             os.path.join(
                 python_prefix_external, "develop/headers", "python" + python_abi_version


### PR DESCRIPTION
# What does this PR do?

This PR allows Nuitka to work with virtualenvs created from not-installed, self-compiled Python version on Unix systems (tested and works on macOS).

# Why was it initiated? Any relevant Issues?

This PR is related to issue #2611.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

---

NOTE: I successfully ran all the tests on Linux. On macOS they fail (either on my branch and on `develop`): 

```
+Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
```