### PR TITLE
Fix --static-libpython=yes in pyenv

### DIFF
--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -20,14 +20,12 @@
 """
 
 import os
-import subprocess
 
 from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.PythonFlavors import (
     isAnacondaPython,
     isDebianPackagePython,
     isNuitkaPython,
-    isPyenvPython,
 )
 from nuitka.PythonVersions import (
     getPythonABI,
@@ -191,22 +189,15 @@ def _getSystemStaticLibPythonPath():
                 # about that anyway.
                 pass
 
-        if isPyenvPython():
-            try:
-                machine = subprocess.check_output(["gcc", "-dumpmachine"])
+    libpl = sysconfig.get_config_var("LIBPL")
+    if libpl is not None:
+        candidate = os.path.join(
+            libpl,
+            "libpython" + python_abi_version + ".a",
+        )
 
-                candidate = os.path.join(
-                    sys_prefix,
-                    "lib",
-                    "config-" + python_abi_version + "-" + machine,
-                    "libpython" + python_abi_version + ".a",
-                )
-
-                if os.path.exists(candidate):
-                    return candidate
-
-            except subprocess.CalledProcessError:
-                pass
+        if os.path.exists(candidate):
+            return candidate
 
     return None
 

--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -140,6 +140,29 @@ def _getSystemStaticLibPythonPath():
             ),
         ]
 
+        try:
+            import sysconfig
+
+            libpl = sysconfig.get_config_var("LIBPL")
+            if libpl is not None:
+                candidates += [
+                    # Anaconda has this.
+                    os.path.join(
+                        libpl,
+                        "libpython" + python_abi_version.replace(".", "") + ".dll.a",
+                    ),
+                    # MSYS2 mingw64 Python has this.
+                    os.path.join(
+                        libpl,
+                        "libpython" + python_abi_version + ".dll.a",
+                    ),
+                ]
+
+        except ImportError:
+            # Cannot detect this properly for Python 2.6, but we don't care much
+            # about that anyway.
+            pass
+
         for candidate in candidates:
             if os.path.exists(candidate):
                 return candidate
@@ -184,20 +207,20 @@ def _getSystemStaticLibPythonPath():
                 if os.path.exists(candidate):
                     return candidate
 
+                libpl = sysconfig.get_config_var("LIBPL")
+                if libpl is not None:
+                    candidate = os.path.join(
+                        libpl,
+                        "libpython" + python_abi_version + ".a",
+                    )
+
+                    if os.path.exists(candidate):
+                        return candidate
+
             except ImportError:
                 # Cannot detect this properly for Python 2.6, but we don't care much
                 # about that anyway.
                 pass
-
-    libpl = sysconfig.get_config_var("LIBPL")
-    if libpl is not None:
-        candidate = os.path.join(
-            libpl,
-            "libpython" + python_abi_version + ".a",
-        )
-
-        if os.path.exists(candidate):
-            return candidate
 
     return None
 

--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -153,21 +153,6 @@ def _getSystemStaticLibPythonPath():
             ),
         ]
 
-        libpl = _getSysConfigVarLIBPL()
-        if libpl is not None:
-            candidates += [
-                # Anaconda has this.
-                os.path.join(
-                    libpl,
-                    "libpython" + python_abi_version.replace(".", "") + ".dll.a",
-                ),
-                # MSYS2 mingw64 Python has this.
-                os.path.join(
-                    libpl,
-                    "libpython" + python_abi_version + ".dll.a",
-                ),
-            ]
-
         for candidate in candidates:
             if os.path.exists(candidate):
                 return candidate

--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -20,12 +20,14 @@
 """
 
 import os
+import subprocess
 
 from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.PythonFlavors import (
     isAnacondaPython,
     isDebianPackagePython,
     isNuitkaPython,
+    isPyenvPython,
 )
 from nuitka.PythonVersions import (
     getPythonABI,
@@ -187,6 +189,23 @@ def _getSystemStaticLibPythonPath():
             except ImportError:
                 # Cannot detect this properly for Python 2.6, but we don't care much
                 # about that anyway.
+                pass
+
+        if isPyenvPython():
+            try:
+                machine = subprocess.check_output(["gcc", "-dumpmachine"])
+
+                candidate = os.path.join(
+                    sys_prefix,
+                    "lib",
+                    "config-" + python_abi_version + "-" + machine,
+                    "libpython" + python_abi_version + ".a",
+                )
+
+                if os.path.exists(candidate):
+                    return candidate
+
+            except subprocess.CalledProcessError:
                 pass
 
     return None


### PR DESCRIPTION
# What does this PR do?

It adds a new search path to get the static libpython when running in a pyenv.

# Why was it initiated? Any relevant Issues?

I was messing around with running nuitka with python installed with pyenv for a github action (https://github.com/Eeems-Org/remarkable-nuitka-build-action) and it was failing to compile when `--static-libpython` was set to `yes` due to not finding the `libpython*.a` file.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.