### PR TITLE
Enhance Clang component not found exit info

### DIFF
--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -434,7 +434,7 @@ def addClangClPathFromMSVC(env):
 
     if cl_exe is None:
         scons_logger.sysexit(
-            "Error, Visual Studio required for using ClangCL on Windows."
+            "Error, You need to install MSVC to use ClangCL on Windows."
         )
 
     clang_dir = os.path.join(cl_exe[: cl_exe.lower().rfind("msvc")], "Llvm")
@@ -465,7 +465,9 @@ def addClangClPathFromMSVC(env):
     if clangcl_path is None:
         # llvm project on windows also include clang-cl.exe
         scons_details_logger.sysexit(
-            "clang-cl.exe not found at '%s' or in %PATH%." % clang_dir
+            """clang-cl.exe not found in Visual Studio '%s' or in PATH.\n
+            "Install it from Visual Studio installer or from LLVM project release"""
+            % clang_dir
         )
 
     env["CC"] = "clang-cl"

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -463,8 +463,9 @@ def addClangClPathFromMSVC(env):
     clangcl_path = getExecutablePath("clang-cl", env=env)
 
     if clangcl_path is None:
+        # llvm project on windows also include clang-cl.exe
         scons_details_logger.sysexit(
-            "Visual Studio has no Clang component found at '%s'." % clang_dir
+            "clang-cl.exe not found at '%s' or in %PATH%." % clang_dir
         )
 
     env["CC"] = "clang-cl"


### PR DESCRIPTION
I change the `clang-cl.exe` not found error message
to make it more clearly