### PR TITLE
Fix obvious typo, that breaks idempotency of scons build process — af…

### DIFF
--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -613,7 +613,7 @@ def scanSourceDir(env, dirname, plugins):
 
         # Only C files are of interest here.
         if not hasFilenameExtension(
-            filename_base, (".c", "cpp")
+            filename_base, (".c", ".cpp")
         ) or not filename_base.startswith(("module.", "__", "plugin.")):
             continue
 


### PR DESCRIPTION
# What does this PR do?

Fix obvious typo, that breaks idempotency of scons build process — after renaming `.c` → `.cpp`, in next Scons call (if we have to debug scons process, for example) it wrongly skipped `.cpp` files because of this typo.

# Why was it initiated? Any relevant Issues?
Yes, I wish to make scons compilation reproduceable and debuggable without source code generation phase https://github.com/Nuitka/Nuitka/issues/792#issuecomment-1601361367

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. (Actually, some test on python 2 failed, but they failed without this patch).
- [ ] Ideally new features or fixed regressions ought to be covered via new tests. → I cannot generation of debug script for for Scons build without idempotency of build process.
- [ ] Ideally new or changed features have documentation updates. → Not needed
