### PR TITLE
Generate Scons Pipeline Debug Script

### DIFF
--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -295,7 +295,11 @@ def runScons(options, env_values, scons_filename):
                 if os.name == "nt":
                     set_smd = "set"
                 for k, v in itertools.chain(env_values.items(), os.environ.items()):
-                    lf.write('%(set_smd)s %(k)s="%(v)s"\n' % vars())
+                    quoted_value = v
+                    if os.name != "nt":
+                        # we should quote only for Linux
+                        quoted_value = '"' + v + '"'
+                    lf.write("%(set_smd)s %(k)s=%(quoted_value)s\n" % vars())
                 lf.write(" ".join(scons_command))
 
         if Options.isShowScons():

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -287,8 +287,8 @@ def runScons(options, env_values, scons_filename):
         Tracing.flushStandardOutputs()
 
         with withEnvironmentVarsOverridden(env_values):
-
-            if source_dir:  # we wrote debug shell script only if build process called, not "--version" call.
+            if source_dir:
+                # we wrote debug shell script only if build process called, not "--version" call.
                 scons_debug_script_name = "scons-debug.sh"
                 if os.name == "nt":
                     scons_debug_script_name = "scons-debug.bat"

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -282,21 +282,21 @@ def runScons(options, env_values, scons_filename):
         )
         if source_dir:
             import itertools
-            scons_debug_script_name = 'scons-debug.sh'
-            if os.name == 'nt':
-                scons_debug_script_name = 'scons-debug.bat'
-            with open(os.path.join(source_dir, scons_debug_script_name), 'w') as lf:
-                if os.name == 'nt':
-                    lf.write('rem scons debug\n')
+
+            scons_debug_script_name = "scons-debug.sh"
+            if os.name == "nt":
+                scons_debug_script_name = "scons-debug.bat"
+            with open(os.path.join(source_dir, scons_debug_script_name), "w") as lf:
+                if os.name == "nt":
+                    lf.write("rem scons debug\n")
                 else:
-                    lf.write('#!/bin/sh\n')
-                win_set = 'export'
-                if os.name == 'nt':
-                    win_set = 'set'
+                    lf.write("#!/bin/sh\n")
+                win_set = "export"
+                if os.name == "nt":
+                    win_set = "set"
                 for k, v in itertools.chain(env_values.items(), os.environ.items()):
                     lf.write(f'{win_set} {k}="{v}"\n')
-                lf.write(f' '.join(scons_command))
-
+                lf.write(f" ".join(scons_command))
 
         if Options.isShowScons():
             Tracing.scons_logger.info("Scons command: %s" % " ".join(scons_command))

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -290,19 +290,19 @@ def runScons(options, env_values, scons_filename):
             if source_dir:
                 # we wrote debug shell script only if build process called, not "--version" call.
                 scons_debug_script_name = "scons-debug.sh"
-                if os.name == "nt":
+                if isWin32Windows():
                     scons_debug_script_name = "scons-debug.bat"
                 with open(os.path.join(source_dir, scons_debug_script_name), "w") as lf:
-                    if os.name == "nt":
+                    if isWin32Windows():
                         lf.write("rem scons debug\n")
                     else:
                         lf.write("#!/bin/sh\n")
                     set_smd = "export"
-                    if os.name == "nt":
+                    if isWin32Windows():
                         set_smd = "set"
                     for k, v in os.environ.items():
                         quoted_value = v
-                        if os.name != "nt":
+                        if isWin32Windows():
                             # we should quote only for Linux
                             quoted_value = '"' + v + '"'
                         lf.write("%(set_smd)s %(k)s=%(quoted_value)s\n" % vars())

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -289,14 +289,14 @@ def runScons(options, env_values, scons_filename):
                 if os.name == 'nt':
                     lf.write('rem scons debug\n')
                 else:
-                    lf.write('#!/bin/sh')
-                win_set = ''    
+                    lf.write('#!/bin/sh\n')
+                win_set = 'export'
                 if os.name == 'nt':
-                    win_set = 'set '    
+                    win_set = 'set'
                 for k, v in itertools.chain(env_values.items(), os.environ.items()):
-                    lf.write(f'{win_set}{k}={v}\n')
+                    lf.write(f'{win_set} {k}="{v}"\n')
                 lf.write(f' '.join(scons_command))
-                
+
 
         if Options.isShowScons():
             Tracing.scons_logger.info("Scons command: %s" % " ".join(scons_command))

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -280,6 +280,23 @@ def runScons(options, env_values, scons_filename):
         scons_command = _buildSconsCommand(
             options=options, scons_filename=scons_filename
         )
+        if source_dir:
+            import itertools
+            scons_debug_script_name = 'scons-debug.sh'
+            if os.name == 'nt':
+                scons_debug_script_name = 'scons-debug.bat'
+            with open(os.path.join(source_dir, scons_debug_script_name), 'w') as lf:
+                if os.name == 'nt':
+                    lf.write('rem scons debug\n')
+                else:
+                    lf.write('#!/bin/sh')
+                win_set = ''    
+                if os.name == 'nt':
+                    win_set = 'set '    
+                for k, v in itertools.chain(env_values.items(), os.environ.items()):
+                    lf.write(f'{win_set}{k}={v}\n')
+                lf.write(f' '.join(scons_command))
+                
 
         if Options.isShowScons():
             Tracing.scons_logger.info("Scons command: %s" % " ".join(scons_command))

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -287,21 +287,29 @@ def runScons(options, env_values, scons_filename):
         Tracing.flushStandardOutputs()
 
         with withEnvironmentVarsOverridden(env_values):
-
-            if source_dir:  
+            if source_dir:
                 # we wrote debug shell script only if build process called, not "--version" call.
                 scons_debug_script_name = scons_debug_stem = "scons-debug"
                 scons_debug_python_name = scons_debug_stem + ".py"
-                with open(os.path.join(source_dir, scons_debug_python_name), "w", encoding="utf-8") as lf:
-                    lf.write("""# -*- coding: utf-8 -*-
-import os                             
-import subprocess 
-env = """ + repr(dict(os.environ)) + """
+                with open(
+                    os.path.join(source_dir, scons_debug_python_name),
+                    "w",
+                    encoding="utf-8",
+                ) as lf:
+                    lf.write(
+                        """# -*- coding: utf-8 -*-
+import os
+import subprocess
+env = """
+                        + repr(dict(os.environ))
+                        + """
 for k, v in env.items():
     os.environ[k] = v
-subprocess.call(""" + repr(scons_command) +  """, shell=False)    
-                    """)
-                    
+subprocess.call("""
+                        + repr(scons_command)
+                        + ", shell=False)"
+                    )
+
                 if isWin32Windows():
                     scons_debug_script_name += ".bat"
                 else:

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -287,26 +287,28 @@ def runScons(options, env_values, scons_filename):
         Tracing.flushStandardOutputs()
 
         with withEnvironmentVarsOverridden(env_values):
-            if source_dir:
+
+            if source_dir:  
                 # we wrote debug shell script only if build process called, not "--version" call.
-                scons_debug_script_name = "scons-debug.sh"
+                scons_debug_script_name = scons_debug_stem = "scons-debug"
+                scons_debug_python_name = scons_debug_stem + ".py"
+                with open(os.path.join(source_dir, scons_debug_python_name), "w", encoding="utf-8") as lf:
+                    lf.write("""# -*- coding: utf-8 -*-
+import os                             
+import subprocess 
+env = """ + repr(dict(os.environ)) + """
+for k, v in env.items():
+    os.environ[k] = v
+subprocess.call(""" + repr(scons_command) +  """, shell=False)    
+                    """)
+                    
                 if isWin32Windows():
-                    scons_debug_script_name = "scons-debug.bat"
+                    scons_debug_script_name += ".bat"
+                else:
+                    scons_debug_script_name += ".sh"
+
                 with open(os.path.join(source_dir, scons_debug_script_name), "w") as lf:
-                    if isWin32Windows():
-                        lf.write("rem scons debug\n")
-                    else:
-                        lf.write("#!/bin/sh\n")
-                    set_smd = "export"
-                    if isWin32Windows():
-                        set_smd = "set"
-                    for k, v in os.environ.items():
-                        quoted_value = v
-                        if isWin32Windows():
-                            # we should quote only for Linux
-                            quoted_value = '"' + v + '"'
-                        lf.write("%(set_smd)s %(k)s=%(quoted_value)s\n" % vars())
-                    lf.write(" ".join(scons_command))
+                    lf.write(" ".join([scons_command[0], scons_debug_python_name]))
 
             try:
                 result = subprocess.call(scons_command, shell=False, cwd=source_dir)

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -291,12 +291,12 @@ def runScons(options, env_values, scons_filename):
                     lf.write("rem scons debug\n")
                 else:
                     lf.write("#!/bin/sh\n")
-                win_set = "export"
+                set_smd = "export"
                 if os.name == "nt":
-                    win_set = "set"
+                    set_smd = "set"
                 for k, v in itertools.chain(env_values.items(), os.environ.items()):
-                    lf.write(f'{win_set} {k}="{v}"\n')
-                lf.write(f" ".join(scons_command))
+                    lf.write('%(set_smd)s %(k)s="%(v)s"\n' % vars())
+                lf.write(" ".join(scons_command))
 
         if Options.isShowScons():
             Tracing.scons_logger.info("Scons command: %s" % " ".join(scons_command))


### PR DESCRIPTION
# What does this PR do?

It generate with not very useful `scons-report.txt`, very useful `scons-debug.sh` or `scons-debug.bat` (for Win), that simplified debugging of Scons build process, experimenting with compiler switches, fastly catching nontrivial bugs in build environment without need to run Nuitka part of code generation as discussed here https://github.com/Nuitka/Nuitka/issues/792#issuecomment-1601361367

Unfortunately, I still cannot see a reliable way to do it as a plugin, to fix exactly that environment variables and switches from SCons Pipeline, without putting this couple of lines closer (just before) SCons pipeline call.

# Why was it initiated? Any relevant Issues?

https://github.com/Nuitka/Nuitka/issues/792#issuecomment-1601361367

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [v] All tests still pass. Check the Developer Manual about `Running the Tests`. 
  - Actually, some python 2.7 / 2.6 tests fail on my desktop (`+AssertionError: gdbm  `), even then I run it with `--skip-cpython27-tests` + `--skip-cpython26-tests`, and even if I run them against pure develop branch.

I promise to add docs and tests, if it OK to include.