### PR TITLE
Fix working with UNC paths and reparse points on Windows

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -6136,10 +6136,12 @@
     dirs:
       - 'resources'
 
-- module-name: 'toga_winforms' # checksum: 286969f5
+- module-name: 'toga_winforms' # checksum: 5dda2bcf
   data-files:
     dirs:
       - 'resources'
+    include-metadata:
+      - 'toga-winforms'
   dlls:
     - from_filenames:
         relative_path: 'libs/WebView2/arm64'

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -236,7 +236,7 @@ def _getRealPathWindows(path):
             if str is not bytes:
                 result = result.decode("utf8")
 
-            if result.startswith("UNC"):
+            if result.startswith("UNC\\"):
                 # Avoid network mounts being converted to UNC shared paths by newer
                 # Python versions, many tools won't work with those.
                 _real_path_windows_cache[path] = path

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -239,8 +239,7 @@ def _getRealPathWindows(path):
             if result.startswith("UNC"):
                 # Avoid network mounts being converted to UNC shared paths by newer
                 # Python versions, many tools won't work with those.
-                # Dont touch already mapped links to UNC paths
-                _real_path_windows_cache[path] = path # '\\' + result[3:].rstrip("\r\n")
+                _real_path_windows_cache[path] = path
             else:
                 _real_path_windows_cache[path] = os.path.join(
                     os.path.dirname(path), result.rstrip("\r\n")
@@ -305,7 +304,7 @@ def getFilenameRealPath(path):
                 assert path.startswith(drive_real_path)
 
                 path = drive + path[len(drive_real_path) :]
-        else:       
+        else:
             path = path.strip(os.path.sep)
 
             if os.path.sep in path:


### PR DESCRIPTION
# What does this PR do?

Fix working with UNC paths (Samba folders / Shared VM folders / etc)
https://github.com/Nuitka/Nuitka/issues/2767


# Why was it initiated? Any relevant Issues?
https://github.com/Nuitka/Nuitka/issues/2767

Now it works on windows both with UNC paths mapped to folder and even unmapped UNC paths (`\\somecomp\somefolder`). 

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [V] All tests still pass. 
   - On windows tests only on Python 3.12 (several hours)
   - On Linux failed on Python 2, but looks python 2 broken on my box

I think no documentation changes needed.
About tests, theoretically in possible checking working UNC paths on Windows, I can try to write it if needed, but not sure that possible to cover nontrivial cases (Windows Sandox, Hyper-V shared folders, etc). 