### PR TITLE
Fix --enable-console warning message

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -1200,7 +1200,7 @@ instead. It also has the extra mode 'attach' to consider."""
                         else "--enable-console"
                     ),
                     "--windows-console-module=%s"
-                    % ("force" if options.disable_console else "disable"),
+                    % ("disable" if options.disable_console else "force"),
                 )
             )
         else:


### PR DESCRIPTION
# What does this PR do?

Swaps "disable" and "force" in the warning message for the deprecated --enable-console and --disable-console flags

# Why was it initiated?

The warning currently says this:
"The old console option '--enable-console' should not be given anymore, use '--windows-console-module=disable' instead. It also has the extra mode 'attach' to consider."

It should say --windows-console-module=force when the --enable-console flag is present and vice versa.


- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
