### PR TITLE
fix Windows build failure on mapped network drives

### DIFF
--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -291,7 +291,7 @@ def _restoreWindowsPath(orig_path, path):
             drive_real_path = os.path.realpath(drive + "\\")
             assert path.startswith(drive_real_path)
 
-            path = drive + path[len(drive_real_path) :]
+            path = drive + "\\" + path[len(drive_real_path) :]
     else:
         path = path.strip(os.path.sep)
 


### PR DESCRIPTION
`drive` has a value of something like `"Y:"` so when we prepend this to a subpath, which will not include and leading slash, we need to add the path separator.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
