### PR TITLE
Removed useless Else statement

### DIFF
--- a/nuitka/utils/Utils.py
+++ b/nuitka/utils/Utils.py
@@ -271,8 +271,7 @@ def getArchitecture():
             return "arm64"
         else:
             return "x86"
-    else:
-        return os.uname()[4]
+    return os.uname()[4]
 
 
 def getCPUCoreCount():


### PR DESCRIPTION
Removed useless Else statement in getArchitechture().

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

This pull request removes a useless else statement in the current `Utils.py` code.

# Why was it initiated? Any relevant Issues?

It was just a small thing that could prevent useless clutter in code.

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
