### PR TITLE
Added implicit dependencies of "scipy.signal" module

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4643,6 +4643,11 @@
     - no-auto-follow:
         'matplotlib': 'plotting will lack matplotlib'
 
+- module-name: 'scipy.signal' # checksum: 4ded0e67
+  implicit-imports:
+    - depends:
+        - 'scipy.special._cdflib'
+
 - module-name: 'scipy.sparse.csgraph' # checksum: 8997608e
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?

Allows `scipy.signal` to be used in Nuitka-compiled projects without raising errors due to missing `_cdflib`

# Why was it initiated? Any relevant Issues?

No open issue AFAIK, but came across the problem myself and fix seemed straightforward.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
