### PR TITLE
More complete support for 'tables' package

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -726,6 +726,14 @@
     dirs:
       - 'resources'
 
+- module-name: 'cpuinfo.cpuinfo' # checksum: 9cf591d7
+  anti-bloat:
+    - description: 'workaround for forking itself'
+      replacements_plain:
+        "getattr(sys, 'frozen', False)": 'True'
+        'getattr(sys, "frozen", False)': 'True'
+      when: 'win32'
+
 - module-name: 'Crypto.Util._raw_api' # checksum: 6e46e262
   data-files:
     empty_dirs:
@@ -5934,7 +5942,16 @@
         'skiptests': 'un-callable'
       when: 'not use_pytest'
 
-- module-name: 'tables' # checksum: 590cadeb
+- module-name: 'tables' # checksum: 44b1f61b
+  dlls:
+    - from_filenames:
+        prefixes:
+          - 'libblosc2'
+        suffixes:
+          - 'pyd'
+          - 'dll'
+      when: 'win32'
+
   anti-bloat:
     - description: 'remove tables.tests usage'
       replacements_plain:


### PR DESCRIPTION
# What does this PR do?

Bundles libblosc2 with the `tables` package on Windows, and fixes a fork-bomb caused by the 'cpuinfo' package

# Why was it initiated? Any relevant Issues?

https://github.com/Nuitka/Nuitka/issues/2535

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
