### PR TITLE
pygame-ce compat with weird missing dlls

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4047,10 +4047,16 @@
     - dirs:
         - '.'
 
-- module-name: 'pygame' # checksum: 8c9db0be
+- module-name: 'pygame' # checksum: f29246e3
   data-files:
     - patterns:
         - 'freesansbold.ttf'
+
+  dlls:
+    - from_filenames:
+        relative_path: '.'
+        prefixes:
+          - ''
 
   options:
     checks:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4047,10 +4047,16 @@
     - dirs:
         - '.'
 
-- module-name: 'pygame' # checksum: f29246e3
+- module-name: 'pygame' # checksum: 67ff3d63
   data-files:
     - patterns:
         - 'freesansbold.ttf'
+    - patterns:
+        - 'pygame_icon_mac.bmp'
+      when: 'macos'
+    - patterns:
+        - 'pygame_icon.bmp'
+      when: 'not macos'
 
   dlls:
     - from_filenames:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
[pygame-ce](https://github.com/pygame-community/pygame-ce) is a fork of pygame that uses a custom SDL Image build. For whatever reason, `libpng16-16.dll` and `libjpeg-62.dll` don't get copied into the build. I'm hoping this is a temporary fix (I tested that this seems to still work fine with the original). We have our own issue [here](https://github.com/pygame-community/pygame-ce/issues/2954) that I'm hoping we can eventually resolve on the library side, rather than Nuitka's side. But for now, this is the only solution I've come up with that doesn't require us to point every user to include our vendored in binaries for png and jpeg

# Why was it initiated? Any relevant Issues?
pygame-ce issue linked above, no Nuitka issue

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
