### PR TITLE
Add data file for `license-expression` package

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2140,6 +2140,11 @@
         prefixes:
           - 'libusb'
 
+- module-name: 'license-expression' # checksum: 810a705a
+  data-files:
+    dirs:
+      - 'data'
+
 - module-name: 'lightgbm' # checksum: 38422ad6
   data-files:
     dirs:


### PR DESCRIPTION
# What does this PR do?

Adds the [`data` folder](https://github.com/nexB/license-expression/tree/main/src/license_expression/data) of the [`license-expression`](https://github.com/nexB/license-expression) package is where the license database is stored. While seems to be available is the source distribution, Nuitka has not enough metadata to import it naturally.

# Why was it initiated? Any relevant Issues?

I stumble upon this issue while trying to make a standalone executable of my [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) project, which depends on [`cyclonedx-python-lib`](https://github.com/CycloneDX/cyclonedx-python-lib) for SBOM export, itself depending on `license-expression`.

If [compiling of my CLI ends up without any error](https://github.com/kdeldycke/meta-package-manager/actions/runs/10150356524/job/28067304207#step:7:39), I get an [immediate issue while running it](https://github.com/kdeldycke/meta-package-manager/actions/runs/10150356524/job/28068453054#step:4:42):
```pytb
Traceback (most recent call last):
  File "/tmp/onefile_1690_1722281965_555845/__main__.py", line 49, in <module>
  File "/tmp/onefile_1690_1722281965_555845/__main__.py", line 43, in main
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/meta_package_manager/cli.py", line 79, in <module meta_package_manager.cli>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/meta_package_manager/sbom.py", line 52, in <module meta_package_manager.sbom>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/spdx/writer/json/json_writer.py", line 10, in <module spdx_tools.spdx.writer.json.json_writer>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/spdx/writer/write_utils.py", line 9, in <module spdx_tools.spdx.writer.write_utils>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/spdx/validation/document_validator.py", line 11, in <module spdx_tools.spdx.validation.document_validator>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/spdx/validation/file_validator.py", line 9, in <module spdx_tools.spdx.validation.file_validator>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/spdx/validation/license_expression_validator.py", line 8, in <module spdx_tools.spdx.validation.license_expression_validator>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/tmp/onefile_1690_1722281965_555845/spdx_tools/common/spdx_licensing.py", line 7, in <module spdx_tools.common.spdx_licensing>
  File "/tmp/onefile_1690_1722281965_555845/license_expression/__init__.py", line 820, in get_spdx_licensing
  File "/tmp/onefile_1690_1722281965_555845/license_expression/__init__.py", line 833, in get_license_index
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/onefile_1690_1722281965_555845/license_expression/data/scancode-licensedb-index.json'
```

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
