### PR TITLE
Typo in `license_expression` package ID

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2140,7 +2140,7 @@
         prefixes:
           - 'libusb'
 
-- module-name: 'license-expression' # checksum: 810a705a
+- module-name: 'license_expression' # checksum: 810a705a
   data-files:
     dirs:
       - 'data'


### PR DESCRIPTION
# What does this PR do?

This fix the bad ID for the `license-expression` package introduced in #3033.

# Why was it initiated? Any relevant Issues?

I'd like to apologise, I mixed up my local copies of Nuitka fork and venv, so I pushed my previous #3033 PR with the wrong package ID. 🙇

I triple-checked this PR really fix the issue with `license-expression` package.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
