### PR TITLE
fix: tolerate decoding error in ccache logs

### DIFF
--- a/nuitka/build/SconsCaching.py
+++ b/nuitka/build/SconsCaching.py
@@ -279,7 +279,11 @@ def _getCcacheStatistics(ccache_logfile):
         # can be matched against it.
         commands = {}
 
-        for line in getFileContentByLine(ccache_logfile):
+        # Due to upstream issues, lines in the log might have different encodings.
+        # All command and result lines use the platform's default encoding,
+        # so we follow this to ensure these lines are correct.
+        # Unrecognized characters are replaced by byte values, e.g. "\xde\xad"
+        for line in getFileContentByLine(ccache_logfile, errors="backslashreplace"):
             match = re_command.match(line)
 
             if match:
@@ -313,7 +317,9 @@ def _getCcacheStatistics(ccache_logfile):
 
                     all_text = []
 
-                    for line2 in getFileContentByLine(ccache_logfile):
+                    for line2 in getFileContentByLine(
+                        ccache_logfile, errors="backslashreplace"
+                    ):
                         match = re_anything.match(line2)
 
                         if match:

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -787,19 +787,22 @@ def withTemporaryFile(suffix="", mode="w", delete=True, temp_path=None):
         yield temp_file
 
 
-def getFileContentByLine(filename, mode="r", encoding=None):
+def getFileContentByLine(filename, mode="r", encoding=None, errors=None):
     # We read the whole, to keep lock times minimal. We only deal with small
     # files like this normally.
-    return getFileContents(filename, mode, encoding=encoding).splitlines()
+    return getFileContents(
+        filename, mode, encoding=encoding, errors=errors
+    ).splitlines()
 
 
-def getFileContents(filename, mode="r", encoding=None):
+def getFileContents(filename, mode="r", encoding=None, errors=None):
     """Get the contents of a file.
 
     Args:
         filename: str with the file to be read
         mode: "r" for str, "rb" for bytes result
         encoding: optional encoding to used when reading the file, e.g. "utf8"
+        errors: optional error handler decoding the content, as defined in `codecs`
 
     Returns:
         str or bytes - depending on mode.
@@ -807,7 +810,7 @@ def getFileContents(filename, mode="r", encoding=None):
     """
 
     with withFileLock("reading file %s" % filename):
-        with openTextFile(filename, mode, encoding=encoding) as f:
+        with openTextFile(filename, mode, encoding=encoding, errors=errors) as f:
             return f.read()
 
 
@@ -829,18 +832,23 @@ def getFileFirstLine(filename, mode="r", encoding=None):
             return f.readline()
 
 
-def openTextFile(filename, mode, encoding=None):
+def openTextFile(filename, mode, encoding=None, errors=None):
     if encoding is not None:
         import codecs
 
-        return codecs.open(filename, mode, encoding=encoding)
+        # `errors` defaults to "strict" in `codecs.open`
+        if errors is None:
+            errors = "strict"
+
+        return codecs.open(filename, mode, encoding=encoding, errors=errors)
     else:
         # Avoid deprecation warning, is now the default.
         if python_version >= 0x370:
             mode = mode.replace("U", "")
 
         # Encoding was checked to be not needed.
-        return open(filename, mode)  # pylint: disable=unspecified-encoding
+        # pylint: disable=unspecified-encoding
+        return open(filename, mode, errors=errors)
 
 
 def putTextFileContents(filename, contents, encoding=None):

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -836,10 +836,6 @@ def openTextFile(filename, mode, encoding=None, errors=None):
     if encoding is not None:
         import codecs
 
-        # `errors` defaults to "strict" in `codecs.open`
-        if errors is None:
-            errors = "strict"
-
         return codecs.open(filename, mode, encoding=encoding, errors=errors)
     else:
         # Avoid deprecation warning, is now the default.


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

This PR plans to address the encoding issues in ccache logs.

I have done some simple tests locally and found ccache does not treat all encoding consistently in their logs (probably because of some unspecified behaviors in `std::filesystem::path::string` but I didn't investigate it further). My tests also find that all command and result lines (with which we are only concerned if I understand the code correctly) are encoded with local encoding.

Given the inconsistent in the log, I suggest we decode the log using the local encoding (which effectively reverts 0a55ff85dbead8519982da32a0f7cd540be0f575) and just ignore errors in the irrelevant parts.

# Why was it initiated? Any relevant Issues?

This should fix #3039.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
