### PR TITLE
fix: correct the lookup of `command`

### DIFF
--- a/nuitka/build/SconsCaching.py
+++ b/nuitka/build/SconsCaching.py
@@ -292,7 +292,7 @@ def _getCcacheStatistics(ccache_logfile):
                 result = result.strip()
 
                 try:
-                    command = data[commands[pid]]
+                    command = commands[pid]
                 except KeyError:
                     # It seems writing to the file can be lossy, so we can have results for
                     # unknown commands, but we don't use the command yet anyway, so just

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2140,7 +2140,7 @@
         prefixes:
           - 'libusb'
 
-- module-name: 'license-expression' # checksum: 810a705a
+- module-name: 'license_expression' # checksum: 810a705a
   data-files:
     dirs:
       - 'data'


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

This PR corrects the lookup behavior of `command`.

When working with #3045 , I find the code here looks a bit strange. The values in `data` here should be results rather than commands, so it makes no sense for me to look for `command` in `data`.

I have not checked logic outside this function, so my view might be wrong.

# Why was it initiated? Any relevant Issues?

No issues related.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
