### PR TITLE
Improve getFileContents by using pathlib instead of os

### DIFF
--- a/nuitka/importing/PreloadedPackages.py
+++ b/nuitka/importing/PreloadedPackages.py
@@ -116,7 +116,7 @@ def detectPthImportedPackages():
         for path, filename in listDir(prefix):
             if filename.endswith(".pth"):
                 try:
-                    for line in getFileContentByLine(path, "rU"):
+                    for line in getFileContentByLine(path, "r"):
                         if line.startswith("import "):
                             if ";" in line:
                                 line = line[: line.find(";")]

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -14,6 +14,7 @@ import errno
 import fnmatch
 import glob
 import os
+import pathlib
 import pickle
 import shutil
 import stat
@@ -807,8 +808,12 @@ def getFileContents(filename, mode="r", encoding=None):
     """
 
     with withFileLock("reading file %s" % filename):
-        with openTextFile(filename, mode, encoding=encoding) as f:
-            return f.read()
+        if mode == "r":
+            return pathlib.Path(filename).read_text(encoding=encoding)
+        elif mode == "rb":
+            return pathlib.Path(filename).read_bytes()
+        else:
+            raise RuntimeError(f"Unsupported mode {mode}")
 
 
 def getFileFirstLine(filename, mode="r", encoding=None):


### PR DESCRIPTION
Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

Improve getFileContents by using pathlib instead of os

# Why was it initiated? Any relevant Issues?

On Windows 11 under some conditions os.read can fail not finding the
path with an error about Unicode encoding. This does not fail with
pathlib. Additionally, since Python 3 'U' is the default behavior and
since 3.10 has no longer any effect, and is considered deprecated.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
