### PR TITLE
Update Yaml.py to allow merging implicit-imports

### DIFF
--- a/nuitka/utils/Yaml.py
+++ b/nuitka/utils/Yaml.py
@@ -105,9 +105,21 @@ Error, empty (or malformed?) user package configuration '%s' used."""
         # TODO: Full blown merging, including respecting an overload flag, where a config
         # replaces another one entirely, for now we expect to not overlap.
         for key, value in other.items():
-            assert key not in self.data, key
-
-            self.data[key] = value
+            # assert key not in self.data, key
+            if key in self.data:
+                new_implicit_imports = value.get('implicit-imports', None)
+                if new_implicit_imports:
+                    value.pop('implicit-imports')
+                    if self.data[key].get('implicit-imports', None) is None:
+                        self.data[key]['implicit-imports'] = new_implicit_imports
+                    else:
+                        self.data[key]['implicit-imports'].extend(new_implicit_imports)
+                if len(value) > 0:
+                    general.sysexit(
+                        f"Error, duplicate config for module name '{key}' encountered in '{self.name}'."
+                    )
+                else:
+                    general.info(f"merged implicit-imports for '{key}'.")
 
 
 def getYamlPackage():


### PR DESCRIPTION
Hi @kayhayen 

# What does this PR do?

This adds support for a custom package-configuration.yml to merge it's `implicit-imports` for a package with the `implicit-imports` for a package that's defined in the standard configuration here: `nuitka\plugins\standard\standard.nuitka-package.config.yml`

# Why was it initiated? Any relevant Issues?

The current behavior is that if a package is already declared in the standard.nuitka-package.config.yml then trying to add it in a custom package-configuration.yml (that's referenced during a build) will raise and assertion.  However, the desired behavior (for my use case) is to simply append the dependency to the existing `implicit-imports`.

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
