### PR TITLE
Fix support for "trio" versions >= 0.26.1

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -7594,11 +7594,15 @@
         '"IPython" in sys.modules': 'False'
       when: 'not use_ipython'
 
-- module-name: 'trio._core._run' # checksum: 44a998aa
+- module-name: 'trio._core._run' # checksum: 8aed5b01
   anti-bloat:
     - description: 'workaround for trio compatibility'
       replacements_plain:
         'coro.cr_frame.f_locals.setdefault(LOCALS_KEY_KI_PROTECTION_ENABLED, system_task)': ''
+    - description: 'workaround for trio compatibility'
+      replacements_plain:
+        'assert coro.cr_frame is not None, "Coroutine frame should exist"': ''
+      when: 'version("trio") >= (0,26,1)'
 
 - module-name: 'tsdownsample._rust' # checksum: d072aa03
   implicit-imports:


### PR DESCRIPTION
# What does this PR do?

https://github.com/python-trio/trio/commit/69819e37d0f02f41a38461cb338b96127caa2909 broke Nuitka's workaround. This PR removes the added assert in `trio._core._run`.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
