### PR TITLE
add missing paddleocr data files

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3226,7 +3226,11 @@
         'cpp_extension,': ''
       when: 'not use_setuptools'
 
-- module-name: 'paddleocr' # checksum: 90264499
+- module-name: 'paddleocr' # checksum: 7cd62957
+  data-files:
+    - patterns:
+        - '**/*.txt'
+
   import-hacks:
     - global-sys-path:
         # This package forces itself into "sys.path" and expects absolute


### PR DESCRIPTION
fixes #3076

## Summary by Sourcery

New Features:
- Add missing data files for the 'paddleocr' module, including all text files.