### PR TITLE
Improve arcade's import config

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -181,8 +181,8 @@
         - 'VERSION'
   anti-bloat:
     - no-auto-follow:
-        'examples': 'Arcade examples are not available unless you do "--include-module=acade.examples"'
-        'experimental': 'Experimental features of Arcade will not be available unless you do "--include-module=acade.experimental"'
+        'examples': 'Arcade examples are not available unless you do "--include-module=arcade.examples"'
+        'experimental': 'Experimental features of Arcade will not be available unless you do "--include-module=arcade.experimental"'
         'future': 'Upcoming features of Arcade will not be available unless you do "--include-module=arcade.future"'
 
 - module-name: 'aspose' # checksum: 1ffc48f1

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -177,10 +177,13 @@
   data-files:
     - dirs:
         - 'resources/system'
+    - patterns:
+        - 'VERSION'
   anti-bloat:
     - no-auto-follow:
-        'examples': 'Arcade examples are not be available unless you do "--include-module=acade.examples"'
+        'examples': 'Arcade examples are not available unless you do "--include-module=acade.examples"'
         'experimental': 'Experimental features of Arcade will not be available unless you do "--include-module=acade.experimental"'
+        'future': 'Upcoming features of Arcade will not be available unless you do "--include-module=arcade.future"'
 
 - module-name: 'aspose' # checksum: 1ffc48f1
   data-files:


### PR DESCRIPTION
Solved repeat issue with arcade compilations missing the VERSION folder.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve the arcade import configuration by adding the 'VERSION' pattern to the data-files section, ensuring the VERSION folder is included in compilations. Correct a typo in the anti-bloat section and add a new entry for future features.

Enhancements:
- Add 'VERSION' pattern to the data-files section in the configuration to ensure the VERSION folder is included in arcade compilations.

<!-- Generated by sourcery-ai[bot]: end summary -->