### PR TITLE
Onefile: Preserve the original argv[0] in __compiled__.onefile_argv0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1404,6 +1404,31 @@ which you expect to be inside the onefile binary, access them like this.
    except NameError:
       open(os.path.join(os.path.dirname(sys.argv[0]), "user-provided-file.txt"))
 
+Note that when the program is launched from the onefile executable, the
+original ``sys.argv[0]`` from the invocation command line will not be
+preserved. For advanced use cases where one needs access to the original
+``sys.argv[0]``, it may be found at ``__compiled__.onefile_argv0``. The
+field will read back as ``None`` if the program is not launched from the
+onefile executable, thus not having gone through the onefile bootstrap
+stage; the original ``sys.argv[0]`` would be preserved as well in this
+case.
+
+.. code:: python
+
+   # Suppose the onefile binary is placed at /opt/abc/bin/foo, and it was
+   # symlinked to /usr/local/bin/bar, and invoked as `bar ...`:
+   assert sys.argv[0] == "/usr/local/bin/bar"
+   assert __compiled__.onefile_argv0 == "bar"
+
+   # If the onefile tempdir is overridden and the program is invoked
+   # directly from the unpacked location, sys.argv[0] would not be touched.
+   #
+   # Suppose the onefile tempdir is /home/xx/.cache/abc/0.1.2, and the
+   # foo.bin executable inside is symlinked to /usr/local/bin/baz, and
+   # invoked as `baz ...`:
+   assert sys.argv[0] == "baz"
+   assert __compiled__.onefile_argv0 is None
+
 Windows Programs without console give no errors
 ===============================================
 

--- a/README.rst
+++ b/README.rst
@@ -1404,21 +1404,25 @@ which you expect to be inside the onefile binary, access them like this.
    except NameError:
       open(os.path.join(os.path.dirname(sys.argv[0]), "user-provided-file.txt"))
 
-Note that when the program is launched from the onefile executable, the
-original ``sys.argv[0]`` from the invocation command line will not be
-preserved. For advanced use cases where one needs access to the original
-``sys.argv[0]``, it may be found at ``__compiled__.onefile_argv0``. The
-field will read back as ``None`` if the program is not launched from the
-onefile executable, thus not having gone through the onefile bootstrap
-stage; the original ``sys.argv[0]`` would be preserved as well in this
-case.
+.. note::
+
+   When the program is launched from the executable, the original
+   ``sys.argv[0]`` from the invocation command line will not be
+   preserved, it will be made an absolute path.
+
+   For advanced use cases where one needs access to the original
+   ``sys.argv[0]``, it may be found at ``__compiled__.original_argv0``.
+   The field will read back as ``None`` if the program is not launched
+   from the onefile executable, thus not having gone through the onefile
+   bootstrap stage; the original ``sys.argv[0]`` would be preserved as
+   well in this case.
 
 .. code:: python
 
    # Suppose the onefile binary is placed at /opt/abc/bin/foo, and it was
    # symlinked to /usr/local/bin/bar, and invoked as `bar ...`:
    assert sys.argv[0] == "/usr/local/bin/bar"
-   assert __compiled__.onefile_argv0 == "bar"
+   assert __compiled__.original_argv0 == "bar"
 
    # If the onefile tempdir is overridden and the program is invoked
    # directly from the unpacked location, sys.argv[0] would not be touched.
@@ -1427,7 +1431,7 @@ case.
    # foo.bin executable inside is symlinked to /usr/local/bin/baz, and
    # invoked as `baz ...`:
    assert sys.argv[0] == "baz"
-   assert __compiled__.onefile_argv0 is None
+   assert __compiled__.original_argv0 is None
 
 Windows Programs without console give no errors
 ===============================================

--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -383,9 +383,9 @@ For Python version %s MSVC %s or later is required, not %s which is too old."""
                         % (compiler_path,)
                     )
 
-                # This also will trigger using it to use our own gcc in branch below.
-                compiler_path = None
-                env["CC"] = None
+                    # This also will trigger using it to use our own gcc in branch below.
+                    compiler_path = None
+                    env["CC"] = None
 
         if compiler_path is None and msvc_version is None:
             scons_details_logger.info(

--- a/nuitka/build/include/nuitka/helpers.h
+++ b/nuitka/build/include/nuitka/helpers.h
@@ -378,10 +378,11 @@ extern char const *getBinaryDirectoryHostEncoded(bool resolve_symlinks);
 // Get the containing directory as an object with symlinks resolved or not.
 extern PyObject *getContainingDirectoryObject(bool resolve_symlinks);
 
-// Get the original argv[0] as recorded by the onefile bootstrap stage.
-// Returns None if not being invoked by the onefile bootstrapper, or if
-// onefile mode is not in use.
-extern PyObject *getOnefileArgv0Object(void);
+// Get the original argv[0] as recorded by the bootstrap stage. Returns
+// None, if not available, in module mode.
+#if defined(_NUITKA_EXE)
+extern PyObject *getOriginalArgv0Object(void);
+#endif
 
 #ifdef _NUITKA_STANDALONE
 extern void setEarlyFrozenModulesFileAttribute(PyThreadState *tstate);

--- a/nuitka/build/include/nuitka/helpers.h
+++ b/nuitka/build/include/nuitka/helpers.h
@@ -378,6 +378,11 @@ extern char const *getBinaryDirectoryHostEncoded(bool resolve_symlinks);
 // Get the containing directory as an object with symlinks resolved or not.
 extern PyObject *getContainingDirectoryObject(bool resolve_symlinks);
 
+// Get the original argv[0] as recorded by the onefile bootstrap stage.
+// Returns None if not being invoked by the onefile bootstrapper, or if
+// onefile mode is not in use.
+extern PyObject *getOnefileArgv0Object(void);
+
 #ifdef _NUITKA_STANDALONE
 extern void setEarlyFrozenModulesFileAttribute(PyThreadState *tstate);
 #endif

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -276,6 +276,7 @@ NUITKA_MAY_BE_UNUSED static inline managed_static_type_state *Nuitka_PyStaticTyp
  * which makes it easier to write portable code.
  */
 #if PYTHON_VERSION < 0x300
+#define PyUnicode_GET_LENGTH(x) (PyUnicode_GET_SIZE(x))
 #define Nuitka_String_AsString PyString_AsString
 #define Nuitka_String_AsString_Unchecked PyString_AS_STRING
 #define Nuitka_String_Check PyString_Check
@@ -288,6 +289,23 @@ NUITKA_MAY_BE_UNUSED static inline bool Nuitka_StringOrUnicode_CheckExact(PyObje
 #define Nuitka_String_FromStringAndSize PyString_FromStringAndSize
 #define Nuitka_String_FromFormat PyString_FromFormat
 #define PyUnicode_CHECK_INTERNED (0)
+NUITKA_MAY_BE_UNUSED static Py_UNICODE *Nuitka_UnicodeAsWideString(PyObject *str, Py_ssize_t *size) {
+    PyObject *unicode;
+
+    if (!PyUnicode_Check(str)) {
+        // Leaking memory, but for usages its acceptable to
+        // achieve that the pointer remains valid.
+        unicode = PyObject_Unicode(str);
+    } else {
+        unicode = str;
+    }
+
+    if (size != NULL) {
+        *size = (Py_ssize_t)PyUnicode_GET_LENGTH(unicode);
+    }
+
+    return PyUnicode_AsUnicode(unicode);
+}
 #else
 #define Nuitka_String_AsString _PyUnicode_AsString
 
@@ -313,10 +331,6 @@ NUITKA_MAY_BE_UNUSED static char const *Nuitka_String_AsString_Unchecked(PyObjec
 #define Nuitka_String_FromString PyUnicode_FromString
 #define Nuitka_String_FromStringAndSize PyUnicode_FromStringAndSize
 #define Nuitka_String_FromFormat PyUnicode_FromFormat
-#endif
-
-#if PYTHON_VERSION < 0x300
-#define PyUnicode_GET_LENGTH(x) (PyUnicode_GET_SIZE(x))
 #endif
 
 // Wrap the type lookup for debug mode, to identify errors, and potentially

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -331,6 +331,7 @@ NUITKA_MAY_BE_UNUSED static char const *Nuitka_String_AsString_Unchecked(PyObjec
 #define Nuitka_String_FromString PyUnicode_FromString
 #define Nuitka_String_FromStringAndSize PyUnicode_FromStringAndSize
 #define Nuitka_String_FromFormat PyUnicode_FromFormat
+#define Nuitka_UnicodeAsWideString PyUnicode_AsWideCharString
 #endif
 
 // Wrap the type lookup for debug mode, to identify errors, and potentially

--- a/nuitka/build/static_src/CompiledCodeHelpers.c
+++ b/nuitka/build/static_src/CompiledCodeHelpers.c
@@ -1906,20 +1906,6 @@ PyObject *getContainingDirectoryObject(bool resolve_symlinks) {
 #endif
 }
 
-PyObject *getOnefileArgv0Object(void) {
-#if defined(_NUITKA_EXE) && defined(_NUITKA_ONEFILE_MODE)
-    environment_char_t const *onefile_argv0 = getEnvironmentVariable("NUITKA_ONEFILE_ARGV0");
-    if (onefile_argv0 != NULL) {
-        PyObject *result = Nuitka_String_FromFilename(onefile_argv0);
-        unsetEnvironmentVariable("NUITKA_ONEFILE_ARGV0");
-        return result;
-    }
-#endif
-
-    Py_INCREF_IMMORTAL(Py_None);
-    return Py_None;
-}
-
 static void _initDeepCopy(void);
 
 void _initBuiltinModule(void) {

--- a/nuitka/build/static_src/CompiledCodeHelpers.c
+++ b/nuitka/build/static_src/CompiledCodeHelpers.c
@@ -1906,6 +1906,20 @@ PyObject *getContainingDirectoryObject(bool resolve_symlinks) {
 #endif
 }
 
+PyObject *getOnefileArgv0Object(void) {
+#if defined(_NUITKA_EXE) && defined(_NUITKA_ONEFILE_MODE)
+    environment_char_t const *onefile_argv0 = getEnvironmentVariable("NUITKA_ONEFILE_ARGV0");
+    if (onefile_argv0 != NULL) {
+        PyObject *result = Nuitka_String_FromFilename(onefile_argv0);
+        unsetEnvironmentVariable("NUITKA_ONEFILE_ARGV0");
+        return result;
+    }
+#endif
+
+    Py_INCREF_IMMORTAL(Py_None);
+    return Py_None;
+}
+
 static void _initDeepCopy(void);
 
 void _initBuiltinModule(void) {

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1175,6 +1175,13 @@ extern char const *getBinaryFilenameHostEncoded(bool resolve_symlinks);
 PyAPI_FUNC(void) PySys_AddWarnOption(const wchar_t *s);
 #endif
 
+// Preserve and provide the original argv[0] as recorded by the bootstrap stage.
+static environment_char_t *original_argv0 = NULL;
+
+PyObject *getOriginalArgv0Object(void) {
+    return Nuitka_String_FromFilename(original_argv0);
+}
+
 #ifdef _NUITKA_WINMAIN_ENTRY_POINT
 int __stdcall wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, wchar_t *lpCmdLine, int nCmdShow) {
     /* MSVC, MINGW64 */
@@ -1324,7 +1331,19 @@ int main(int argc, char **argv) {
 
 // Make sure, we use the absolute program path for argv[0]
 #if !defined(_NUITKA_ONEFILE_MODE) && _NUITKA_NATIVE_WCHAR_ARGV == 0
+    original_argv0 = argv[0];
     argv[0] = (char *)getBinaryFilenameHostEncoded(false);
+#endif
+
+#if defined(_NUITKA_ONEFILE_MODE)
+    {
+        environment_char_t const *parent_original_argv0 = getEnvironmentVariable("NUITKA_ORIGINAL_ARGV0");
+
+        if (parent_original_argv0 != NULL) {
+            unsetEnvironmentVariable("NUITKA_ORIGINAL_ARGV0");
+            original_argv0 = parent_original_argv0;
+        }
+    }
 #endif
 
 #if PYTHON_VERSION >= 0x300 && _NUITKA_NATIVE_WCHAR_ARGV == 0
@@ -1339,6 +1358,7 @@ orig_argv = argv;
 
 // Make sure, we use the absolute program path for argv[0]
 #if !defined(_NUITKA_ONEFILE_MODE) && _NUITKA_NATIVE_WCHAR_ARGV == 1 && PYTHON_VERSION >= 0x300
+    original_argv0 = orig_argv[0];
     orig_argv[0] = (wchar_t *)getBinaryFilenameWideChars(false);
 #endif
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1176,9 +1176,10 @@ PyAPI_FUNC(void) PySys_AddWarnOption(const wchar_t *s);
 #endif
 
 // Preserve and provide the original argv[0] as recorded by the bootstrap stage.
-static environment_char_t *original_argv0 = NULL;
+static environment_char_t const *original_argv0 = NULL;
 
 PyObject *getOriginalArgv0Object(void) {
+    assert(original_argv0 != NULL);
     return Nuitka_String_FromFilename(original_argv0);
 }
 
@@ -1357,9 +1358,11 @@ orig_argv = argv;
 #endif
 
 // Make sure, we use the absolute program path for argv[0]
-#if !defined(_NUITKA_ONEFILE_MODE) && _NUITKA_NATIVE_WCHAR_ARGV == 1 && PYTHON_VERSION >= 0x300
-    original_argv0 = orig_argv[0];
+#if !defined(_NUITKA_ONEFILE_MODE) && _NUITKA_NATIVE_WCHAR_ARGV == 1
+    original_argv0 = argv[0];
+#if PYTHON_VERSION >= 0x300
     orig_argv[0] = (wchar_t *)getBinaryFilenameWideChars(false);
+#endif
 #endif
 
     // Make sure the compiled path of Python is replaced.

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1341,8 +1341,9 @@ int main(int argc, char **argv) {
         environment_char_t const *parent_original_argv0 = getEnvironmentVariable("NUITKA_ORIGINAL_ARGV0");
 
         if (parent_original_argv0 != NULL) {
+            original_argv0 = strdupFilename(parent_original_argv0);
+
             unsetEnvironmentVariable("NUITKA_ORIGINAL_ARGV0");
-            original_argv0 = parent_original_argv0;
         }
     }
 #endif

--- a/nuitka/build/static_src/MetaPathBasedLoader.c
+++ b/nuitka/build/static_src/MetaPathBasedLoader.c
@@ -95,10 +95,12 @@ static char *appendModuleNameAsPath(char *buffer, char const *module_name, size_
 #if defined(_WIN32) && defined(_NUITKA_STANDALONE)
 
 static void appendModuleNameAsPathW(wchar_t *buffer, PyObject *module_name, size_t buffer_size) {
-    wchar_t const *module_name_wstr = PyUnicode_AsWideCharString(module_name, NULL);
+    Py_ssize_t size;
+    wchar_t const *module_name_wstr = Nuitka_UnicodeAsWideString(module_name, &size);
 
-    while (*module_name_wstr != 0) {
+    while (size > 0) {
         wchar_t c = *module_name_wstr++;
+        size -= 1;
 
         if (c == L'.') {
             c = SEP_L;
@@ -470,11 +472,7 @@ static PyObject *callIntoInstalledExtensionModule(PyThreadState *tstate, PyObjec
     // create the string needed.
     assert(PyUnicode_CheckExact(extension_module_filename));
 
-#if PYTHON_VERSION < 0x300
-    wchar_t const *extension_module_filename_str = PyUnicode_AS_UNICODE(extension_module_filename);
-#else
-    wchar_t const *extension_module_filename_str = PyUnicode_AsWideCharString(extension_module_filename, NULL);
-#endif
+    wchar_t const *extension_module_filename_str = Nuitka_UnicodeAsWideString(extension_module_filename);
 #else
     char const *extension_module_filename_str = Nuitka_String_AsString(extension_module_filename);
 #endif

--- a/nuitka/build/static_src/MetaPathBasedLoader.c
+++ b/nuitka/build/static_src/MetaPathBasedLoader.c
@@ -472,7 +472,7 @@ static PyObject *callIntoInstalledExtensionModule(PyThreadState *tstate, PyObjec
     // create the string needed.
     assert(PyUnicode_CheckExact(extension_module_filename));
 
-    wchar_t const *extension_module_filename_str = Nuitka_UnicodeAsWideString(extension_module_filename);
+    wchar_t const *extension_module_filename_str = Nuitka_UnicodeAsWideString(extension_module_filename, NULL);
 #else
     char const *extension_module_filename_str = Nuitka_String_AsString(extension_module_filename);
 #endif

--- a/nuitka/build/static_src/OnefileBootstrap.c
+++ b/nuitka/build/static_src/OnefileBootstrap.c
@@ -1156,6 +1156,8 @@ int main(int argc, char **argv) {
 #endif
     setEnvironmentVariable("NUITKA_ONEFILE_BINARY", binary_filename);
 
+    setEnvironmentVariable("NUITKA_ONEFILE_ARGV0", argv[0]);
+
     NUITKA_PRINT_TIMING("ONEFILE: Preparing forking of slave process.");
 
 #if defined(_WIN32)

--- a/nuitka/build/static_src/OnefileBootstrap.c
+++ b/nuitka/build/static_src/OnefileBootstrap.c
@@ -1156,7 +1156,7 @@ int main(int argc, char **argv) {
 #endif
     setEnvironmentVariable("NUITKA_ONEFILE_BINARY", binary_filename);
 
-    setEnvironmentVariable("NUITKA_ONEFILE_ARGV0", argv[0]);
+    setEnvironmentVariable("NUITKA_ORIGINAL_ARGV0", argv[0]);
 
     NUITKA_PRINT_TIMING("ONEFILE: Preparing forking of slave process.");
 

--- a/nuitka/code_generation/templates/CodeTemplatesConstants.py
+++ b/nuitka/code_generation/templates/CodeTemplatesConstants.py
@@ -134,7 +134,7 @@ static void _createGlobalConstants(PyThreadState *tstate) {
         {(char *)"no_annotations", (char *)"boolean indicating --python-flag=no_annotations usage"},
         {(char *)"module", (char *)"boolean indicating --module usage"},
         {(char *)"main", (char *)"name of main module at runtime"},
-        {(char *)"onefile_argv0", (char *)"original argv[0] as received by the onefile binary, None otherwise"},
+        {(char *)"original_argv0", (char *)"original argv[0] as received by the onefile binary, None otherwise"},
         {0}
     };
 
@@ -235,8 +235,12 @@ static void _createGlobalConstants(PyThreadState *tstate) {
 #endif
     PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);
 
-    PyObject *onefile_argv0 = getOnefileArgv0Object();
-    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, onefile_argv0);
+#if defined(_NUITKA_EXE)
+    PyObject *original_argv0 = getOriginalArgv0Object();
+#else
+    PyObject *original_argv0 = Py_None;
+# endif
+    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, original_argv0);
 
     // Prevent users from creating the Nuitka version type object.
     Nuitka_VersionInfoType.tp_init = NULL;

--- a/nuitka/code_generation/templates/CodeTemplatesConstants.py
+++ b/nuitka/code_generation/templates/CodeTemplatesConstants.py
@@ -134,6 +134,7 @@ static void _createGlobalConstants(PyThreadState *tstate) {
         {(char *)"no_annotations", (char *)"boolean indicating --python-flag=no_annotations usage"},
         {(char *)"module", (char *)"boolean indicating --module usage"},
         {(char *)"main", (char *)"name of main module at runtime"},
+        {(char *)"onefile_argv0", (char *)"original argv[0] as received by the onefile binary, None otherwise"},
         {0}
     };
 
@@ -233,6 +234,9 @@ static void _createGlobalConstants(PyThreadState *tstate) {
     PyObject *main_name = Nuitka_String_FromString("__main__");
 #endif
     PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);
+
+    PyObject *onefile_argv0 = getOnefileArgv0Object();
+    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, onefile_argv0);
 
     // Prevent users from creating the Nuitka version type object.
     Nuitka_VersionInfoType.tp_init = NULL;


### PR DESCRIPTION
# What does this PR do?

Record the `argv[0]` in the onefile bootstrapper and expose it via `__compiled__.onefile_argv0`, to not regress advanced CLI use cases where the program needs this info to differentiate behavior.

# Why was it initiated? Any relevant Issues?

In commit 9b0406b2a ("Fix, need to make sure `sys.argv[0]` is absolute for best usability"), the original `argv[0]` as received by the onefile binary is thrown away, breaking applications needing this information.

To support these cases, record the original `argv[0]` in the `NUITKA_ONEFILE_ARGV0` environment variable, for exposure via `__compiled__.onefile_argv0`. The field is made `None` if the onefile mode is not in use, or if the binary is not launched via the onefile bootstrapper.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Preserve the original argv[0] in onefile mode by recording it in the NUITKA_ONEFILE_ARGV0 environment variable and exposing it through __compiled__.onefile_argv0, ensuring compatibility with advanced CLI use cases that require this information.

New Features:
- Introduce a new feature to record the original argv[0] in the onefile bootstrapper and expose it via __compiled__.onefile_argv0 for advanced CLI use cases.

Enhancements:
- Add a mechanism to store the original argv[0] in the NUITKA_ONEFILE_ARGV0 environment variable and retrieve it using the getOnefileArgv0Object function.

<!-- Generated by sourcery-ai[bot]: end summary -->