### PR TITLE
fix  #3133 - keyring module missing win32ctypes on Windows

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2072,10 +2072,11 @@
     - depends:
         - 'keyring.backends.*'
 
-- module-name: 'keyring.backends.Windows' # checksum: 2531fce0
+- module-name: 'keyring.backends.Windows' # checksum: a414afda
   implicit-imports:
     - depends:
         - 'win32timezone'
+        - 'win32ctypes.core.ctypes.*'
 
 - module-name: 'kivy' # checksum: 648dc799
   data-files:


### PR DESCRIPTION
This PR fixes #3133 and gets the `keyring` module working (with nuitka) again on Windows

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the missing 'win32ctypes.core.ctypes.*' import for the 'keyring' module on Windows to resolve compatibility issues with Nuitka.

Bug Fixes:
- Fix missing 'win32ctypes.core.ctypes.*' implicit import for the 'keyring' module on Windows, ensuring compatibility with Nuitka.

<!-- Generated by sourcery-ai[bot]: end summary -->