### PR TITLE
Fix tkinterdnd2 path for Windows

### DIFF
--- a/nuitka/plugins/standard/TkinterPlugin.py
+++ b/nuitka/plugins/standard/TkinterPlugin.py
@@ -145,7 +145,7 @@ The Tcl library dir. See comments for Tk library dir.""",
         elif platform.system() == "Linux":
             return "linux64"
         elif platform.system() == "Windows":
-            return "win64"
+            return "win-x64"
         else:
             return None
 

--- a/nuitka/plugins/standard/TkinterPlugin.py
+++ b/nuitka/plugins/standard/TkinterPlugin.py
@@ -11,7 +11,6 @@ from nuitka.Options import isStandaloneMode, shallCreateAppBundle
 from nuitka.plugins.PluginBase import NuitkaPluginBase
 from nuitka.PythonFlavors import isHomebrewPython
 from nuitka.PythonVersions import getSystemPrefixPath, getTkInterVersion
-from nuitka.utils.FileOperations import listDllFilesFromDirectory, relpath
 from nuitka.utils.Utils import isMacOS, isWin32Windows
 
 # spell-checker: ignore tkinterdnd,tkdnd,tcltk
@@ -149,20 +148,6 @@ The Tcl library dir. See comments for Tk library dir.""",
         else:
             return None
 
-    def _considerDataFilesTkinterDnD(self, module):
-        platform_rep = self._getTkinterDnDPlatformDirectory()
-
-        if platform_rep is None:
-            return
-
-        yield self.makeIncludedPackageDataFiles(
-            package_name="tkinterdnd2",
-            package_directory=module.getCompileTimeDirectory(),
-            pattern=os.path.join("tkdnd", platform_rep, "**"),
-            reason="Tcl needed for 'tkinterdnd2' usage",
-            tags="tcl",
-        )
-
     def _getTclCandidatePaths(self):
         # Check typical locations of the dirs
         yield os.getenv("TCL_LIBRARY")
@@ -234,12 +219,6 @@ The Tcl library dir. See comments for Tk library dir.""",
             IncludedDataFile objects.
         """
 
-        # Extra TCL providing module go here:
-        if module.getFullName() == "tkinterdnd2.TkinterDnD":
-            yield self._considerDataFilesTkinterDnD(module)
-
-            return
-
         if not _isTkInterModule(module) or self.files_copied:
             return
 
@@ -300,27 +279,6 @@ that works, report a bug."""
             )
 
         self.files_copied = True
-
-    def getExtraDlls(self, module):
-        if module.getFullName() == "tkinterdnd2.TkinterDnD":
-            platform_rep = self._getTkinterDnDPlatformDirectory()
-
-            if platform_rep is None:
-                return
-
-            module_directory = module.getCompileTimeDirectory()
-
-            for filename, _dll_filename in listDllFilesFromDirectory(
-                os.path.join(module_directory, "tkdnd", platform_rep)
-            ):
-                dest_path = relpath(filename, module_directory)
-                yield self.makeDllEntryPoint(
-                    source_path=filename,
-                    dest_path=os.path.join("tkinterdnd2", dest_path),
-                    module_name="tkinterdnd2",
-                    package_name="tkinterdnd2",
-                    reason="tkinterdnd2 package DLL",
-                )
 
     def onModuleCompleteSet(self, module_set):
         if str is bytes:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -6988,6 +6988,27 @@
     - dirs:
         - 'tkdnd/osx64'
       when: 'use_tkinter and macos and version("tkinterdnd2") < (0,4)'
+    - dirs:
+        - 'tkdnd/win-arm64'
+      when: 'use_tkinter and win32 and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/win-x64'
+      when: 'use_tkinter and win32 and arch_amd64 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/win-x86'
+      when: 'use_tkinter and win32 and arch_x86 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/linux-arm64'
+      when: 'use_tkinter and linux and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/linux-x64'
+      when: 'use_tkinter and linux and arch_amd64 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/osx-arm64'
+      when: 'use_tkinter and macos and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - dirs:
+        - 'tkdnd/osx-x64'
+      when: 'use_tkinter and macos and arch_amd64 and version("tkinterdnd2") >= (0,4)'
   dlls:
     - from_filenames:
         relative_path: 'tkdnd/win64'
@@ -7004,6 +7025,42 @@
         prefixes:
           - ''
       when: 'use_tkinter and macos and version("tkinterdnd2") < (0,4)'
+
+    - from_filenames:
+        relative_path: 'tkdnd/win-arm64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and win32 and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/win-x64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and win32 and arch_amd64 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/win-x86'
+        prefixes:
+          - ''
+      when: 'use_tkinter and win32 and arch_x86 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/linux-arm64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and linux and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/linux-x64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and linux and arch_amd64 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/osx-arm64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and macos and arch_arm64 and version("tkinterdnd2") >= (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/osx-x64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and macos and arch_amd64 and version("tkinterdnd2") >= (0,4)'
 
 - module-name: 'tkinterweb' # checksum: 5de6ded8
   data-files:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -6977,6 +6977,34 @@
           - 'libextrafont'
       when: 'win32'
 
+- module-name: 'tkinterdnd2.TkinterDnD' # checksum: ac56a06b
+  data-files:
+    - dirs:
+        - 'tkdnd/win64'
+      when: 'use_tkinter and win32 and version("tkinterdnd2") < (0,4)'
+    - dirs:
+        - 'tkdnd/linux64'
+      when: 'use_tkinter and linux and version("tkinterdnd2") < (0,4)'
+    - dirs:
+        - 'tkdnd/osx64'
+      when: 'use_tkinter and macos and version("tkinterdnd2") < (0,4)'
+  dlls:
+    - from_filenames:
+        relative_path: 'tkdnd/win64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and win32 and version("tkinterdnd2") < (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/linux64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and linux and version("tkinterdnd2") < (0,4)'
+    - from_filenames:
+        relative_path: 'tkdnd/osx64'
+        prefixes:
+          - ''
+      when: 'use_tkinter and macos and version("tkinterdnd2") < (0,4)'
+
 - module-name: 'tkinterweb' # checksum: 5de6ded8
   data-files:
     - dirs:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/Nuitka/Nuitka/issues/3108. 

It appears tkinterdnd2 has changed the windows path name. This small change reflects an updated path name to allow compilation without the FATAL crash (FileNotFoundError).

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Fix the path for tkinterdnd2 on Windows to resolve a FileNotFoundError issue, ensuring successful compilation without crashes.

Bug Fixes:
- Correct the path for tkinterdnd2 on Windows to prevent a FileNotFoundError during compilation.