### PR TITLE
fix flag `--experimental=force-accept-windows-gcc`

### DIFF
--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -383,9 +383,9 @@ For Python version %s MSVC %s or later is required, not %s which is too old."""
                         % (compiler_path,)
                     )
 
-                # This also will trigger using it to use our own gcc in branch below.
-                compiler_path = None
-                env["CC"] = None
+                    # This also will trigger using it to use our own gcc in branch below.
+                    compiler_path = None
+                    env["CC"] = None
 
         if compiler_path is None and msvc_version is None:
             scons_details_logger.info(


### PR DESCRIPTION
Without the indentation the `force-accept-windows-gcc` flag would have no effect.


# What does this PR do?
This PR makes the `--experimental=force-accept-windows-gcc` parameter functional.

# Why was it initiated? Any relevant Issues?
The aforementioned option did not have any effect. The user was not able to provide their own variant of GCC on their own responsibility, although an experimental option for this has been stipulated before.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Fix the indentation issue that prevented the `--experimental=force-accept-windows-gcc` flag from functioning.