### PR TITLE
Fix missing av.opaque implicit import in pyav >= 13.1.0

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -345,10 +345,11 @@
     - depends:
         - 'av.filter.pad'
 
-- module-name: 'av.frame' # checksum: e8ab2d30
+- module-name: 'av.frame' # checksum: 121c2594
   implicit-imports:
     - depends:
         - 'av.buffer'
+        - 'av.opaque'
 
 - module-name: 'av.logging' # checksum: 7da91901
   implicit-imports:
@@ -361,11 +362,12 @@
         - 'av.enum'
         - 'av.utils'
 
-- module-name: 'av.packet' # checksum: 13e9006a
+- module-name: 'av.packet' # checksum: 3bd21471
   implicit-imports:
     - depends:
         - 'av.dictionary'
         - 'av.sidedata.sidedata'
+        - 'av.opaque'
 
 - module-name: 'av.sidedata.sidedata' # checksum: 6adb0fe2
   implicit-imports:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

pyav >= 13.1.0 adds `av.opaque` which is imported by `av.frame` and `av.packet`. The missing implicit import causes programs that use pyav to crash with `No module named "av.opaque"`

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
