### PR TITLE
Allow disabling nuitka in pyproject.toml builds.

### DIFF
--- a/nuitka/distutils/Build.py
+++ b/nuitka/distutils/Build.py
@@ -23,16 +23,16 @@ class NuitkaBuildMetaBackend(setuptools.build_meta._BuildMetaBackend):
     def build_wheel(
         self, wheel_directory, config_settings=None, metadata_directory=None
     ):
-        # Allow falling back to setuptools when the `no-nuitka` configuration setting is set to true.
+        # Allow falling back to setuptools when the `build_with_nuitka` configuration setting is set to true.
         if config_settings:
-            no_nuitka = config_settings.pop("no-nuitka", "false").lower()
+            build_with_nuitka = config_settings.pop("build_with_nuitka", "true").lower()
 
-            if no_nuitka not in {"true", "false"}:
+            if build_with_nuitka not in ("true", "false"):
                 raise ValueError(
-                    f"When passing the  `no-nuitka` setting, it must either be `true` or `false`."
+                    "When passing the 'build_with_nuitka' setting, it must either be 'true' or 'false'."
                 )
 
-            if no_nuitka == "true":
+            if build_with_nuitka == "false":
                 return super().build_wheel(
                     wheel_directory, config_settings, metadata_directory
                 )

--- a/nuitka/distutils/Build.py
+++ b/nuitka/distutils/Build.py
@@ -23,6 +23,20 @@ class NuitkaBuildMetaBackend(setuptools.build_meta._BuildMetaBackend):
     def build_wheel(
         self, wheel_directory, config_settings=None, metadata_directory=None
     ):
+        # Allow falling back to setuptools when the `no-nuitka` configuration setting is set to true.
+        if config_settings:
+            no_nuitka = config_settings.pop("no-nuitka", "false").lower()
+
+            if no_nuitka not in {"true", "false"}:
+                raise ValueError(
+                    f"When passing the  `no-nuitka` setting, it must either be `true` or `false`."
+                )
+
+            if no_nuitka == "true":
+                return super().build_wheel(
+                    wheel_directory, config_settings, metadata_directory
+                )
+
         os.environ["NUITKA_TOML_FILE"] = os.path.join(os.getcwd(), "pyproject.toml")
 
         with suppress_known_deprecation():

--- a/nuitka/distutils/DistutilCommands.py
+++ b/nuitka/distutils/DistutilCommands.py
@@ -218,6 +218,9 @@ class build(distutils.command.build.build):
 
     @staticmethod
     def _parseOptionsEntry(option, value):
+        if option == "build_with_nuitka":
+            return
+
         option = "--" + option.lstrip("-")
 
         if type(value) is tuple and len(value) == 2 and value[0] == "setup.py":


### PR DESCRIPTION
# What does this PR do?

When using `pyproject.toml` it is sometimes helpful to be able to switch between `setuptools`-based build and a Nuitka build without modifying the `pyproject.toml`.

Here, a configuration setting `no-nuitka` is added, which can be set to `true`, resulting in a bypass of nuitka during build.

This mechanism also works for the `build` package, using the `--config-setting` command line option.

Fixes #1600.

## Summary by Sourcery

New Features:
- Introduce a configuration setting 'no-nuitka' in pyproject.toml to allow bypassing Nuitka during the build process.