### PR TITLE
Fix: mode=app not working correct on macOS

### DIFF
--- a/nuitka/Options.py
+++ b/nuitka/Options.py
@@ -511,7 +511,7 @@ Error, the Python from Windows app store is not supported.""",
             options.module_mode = True
         elif options.compilation_mode == "app":
             if isMacOS():
-                options.create_app_bundle = True
+                options.macos_create_bundle = True
             else:
                 options.is_onefile = True
 


### PR DESCRIPTION
Fixes the issue where mode=app has no effect on macOS because options.create_app_bundle was not being used.

## Summary by Sourcery

Bug Fixes:
- Fix the issue where mode=app was not functioning correctly on macOS by ensuring the correct option is used to create an app bundle.