### PR TITLE
fix: support tkinter 9.0

### DIFF
--- a/nuitka/plugins/standard/TkinterPlugin.py
+++ b/nuitka/plugins/standard/TkinterPlugin.py
@@ -76,7 +76,7 @@ class NuitkaPluginTkinter(NuitkaPluginBase):
             self.sysexit("Error, it seems 'tk-inter' is not installed.")
 
         # Only ever saw these 2 in use.
-        assert self.tk_inter_version in ("8.5", "8.6"), self.tk_inter_version
+        assert self.tk_inter_version in ("8.5", "8.6", "9.0"), self.tk_inter_version
 
         return None
 


### PR DESCRIPTION
# What does this PR do?

support TKinter version 9.0

# Why was it initiated? Any relevant Issues?

```sh
$ python --version                                                                
Python 3.13.1
```

```sh
$ python -c 'import tkinter;print(tkinter.TkVersion)'                             
9.0
```

```sh
$ uv run nuitka --onefile --standalone --enable-plugin=tk-inter python/src/main.py
Nuitka-Options: Used command line options: --onefile --standalone --enable-plugin=tk-inter python/src/main.py
Traceback (most recent call last):
  File "/Users/yabuta/misc/dev/git/digeon/ajino-chinuya-production-plan/app/.venv/lib/python3.13/site-packages/nuitka/plugins/Plugins.py", line 70, in withPluginProblemReporting
    yield
  File "/Users/yabuta/misc/dev/git/digeon/ajino-chinuya-production-plan/app/.venv/lib/python3.13/site-packages/nuitka/plugins/Plugins.py", line 111, in _addActivePlugin
    plugin_instance = plugin_class(**plugin_args)
  File "/Users/yabuta/misc/dev/git/digeon/ajino-chinuya-production-plan/app/.venv/lib/python3.13/site-packages/nuitka/plugins/standard/TkinterPlugin.py", line 79, in __init__
    assert self.tk_inter_version in ("8.5", "8.6"), self.tk_inter_version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 9.0
FATAL: tk-inter: Plugin issue while working on 'plugin initialization'. Please report the bug with the above traceback included.
```

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
