### PR TITLE
remove assertion for docstring even when no assert is not set

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -8638,12 +8638,13 @@
         prefixes:
           - 'xgboost'
 
-- module-name: 'xgboost.sklearn' # checksum: 5480616e
+- module-name: 'xgboost.sklearn' # checksum: d0a963f4
   anti-bloat:
     - description: 'remove docstring dependency'
       replacements_plain:
         'fit.__doc__ = XGBModel.fit.__doc__.replace(': 'fit.__doc__ = "Fit gradient boosting model".replace('
-      when: 'no_docstrings and no_asserts'
+        'assert XGBModel.fit.__doc__ is not None': ''
+      when: 'no_docstrings'
 
 - module-name: 'Xlib.display' # checksum: 3b1d6e64
   implicit-imports:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
This PR removes the assertion for docstring to exists when docstring is removed even when assertion is not disabled for xgboost. See also #3258


# Why was it initiated? Any relevant Issues?
Currently xgboost checks for docstring with assertion, but the standard package config only fix the case when both assertion is disabled and docstring is removed, not when only docstring is removed

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Remove assertion for docstring existence in xgboost when only docstring is removed.