### PR TITLE
Fix/ignore f trace

### DIFF
--- a/nuitka/build/static_src/CompiledFrameType.c
+++ b/nuitka/build/static_src/CompiledFrameType.c
@@ -268,11 +268,20 @@ static int _Nuitka_Frame_set_trace(PyObject *self, PyObject *value, void *data) 
     assert(Nuitka_Frame_CheckExact(self));
     CHECK_OBJECT(self);
     assert(_PyObject_GC_IS_TRACKED(self));
+#if !defined(_NUITKA_DEPLOYMENT_MODE) && !defined(_NUITKA_NO_DEPLOYMENT_FRAME_USELESS_SET_TRACE)
+    if (value == Py_None) {
+        return 0;
+    } else {
+        PyThreadState *tstate = PyThreadState_GET();
 
-    PyThreadState *tstate = PyThreadState_GET();
-
-    SET_CURRENT_EXCEPTION_TYPE0_STR(tstate, PyExc_RuntimeError, "f_trace is not writable in Nuitka");
-    return -1;
+        SET_CURRENT_EXCEPTION_TYPE0_STR(
+            tstate, PyExc_RuntimeError,
+            "f_trace is not writable in Nuitka, ignore with '--no-deployment-flag=frame-useless-set-trace'");
+        return -1;
+    }
+#else
+    return 0;
+#endif
 }
 
 #if PYTHON_VERSION >= 0x370


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

It is part 1 of an effort to make Nuitka play well with debuggers. The scenario that we try to enable is to debug through compiled frames.

It fixes the error:

```
  File "/home/container_user/.local/share/code-server/extensions/ms-python.debugpy-2024.8.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/pydevd.py", line 2246, in set_trace_for_frame_and_parents frame.f_trace = self.trace_dispatch RuntimeError: f_trace is not writable in Nuitka
```

With this change, the debugger can step through compiled frames. At least in some cases. However, stopping at a breakpoint still doesn't work.

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Fixed a RuntimeError that prevented debuggers from setting f_trace on compiled frames, enabling stepping through compiled frames in some cases.