### PR TITLE
Fix various issues with Nuitka-Python build

### DIFF
--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -683,13 +683,6 @@ if env.static_libpython and python_version >= (3, 12):
 
 if os.name == "nt":
     if env.nuitka_python:
-        env.Append(
-            LINKFLAGS=[
-                "/LTCG",
-                "/USEPROFILE:PGD=" + os.path.join(python_prefix_external, "python.pgd"),
-            ]
-        )
-
         link_data = loadJsonFromFilename(
             os.path.join(python_prefix_external, "link.json")
         )

--- a/nuitka/freezer/Standalone.py
+++ b/nuitka/freezer/Standalone.py
@@ -33,6 +33,7 @@ from nuitka.PythonFlavors import (
     isAnacondaPython,
     isHomebrewPython,
     isMSYS2MingwPython,
+    isNuitkaPython,
 )
 from nuitka.PythonVersions import getSystemPrefixPath
 from nuitka.Tracing import general, inclusion_logger
@@ -126,7 +127,9 @@ def _detectBinaryDLLs(
     "otool" (macOS) the list of used DLLs is retrieved.
     """
 
-    if getOS() in ("Linux", "NetBSD", "FreeBSD", "OpenBSD") or isPosixWindows():
+    if isNuitkaPython():
+        return OrderedSet()
+    elif getOS() in ("Linux", "NetBSD", "FreeBSD", "OpenBSD") or isPosixWindows():
         return detectBinaryPathDLLsPosix(
             dll_filename=original_filename,
             package_name=package_name,


### PR DESCRIPTION
# What does this PR do?
This commit fixes some new issues that came up either from the Nuitka-Python or the Nuitka side.

The first commit removes the link options that are hardcoded in Nuitka code. Instead, we should be relying on Nuitka-Python to include all the necessary flags in link.json.

The second bypasses all DLL dependency lookups since Nuitka-Python should not have any dependencies (which was causing otool to crash out on mac).

# Why was it initiated? Any relevant Issues?


# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Remove hardcoded link options and bypass DLL dependency lookups for Nuitka-Python builds.

Bug Fixes:
- Resolve issues arising from Nuitka-Python integration.

Build:
- Update Nuitka build process to handle Nuitka-Python dependencies correctly.