### PR TITLE
Multidist binaries now use __compiled__.original_argv0

### DIFF
--- a/nuitka/tree/ReformulationMultidist.py
+++ b/nuitka/tree/ReformulationMultidist.py
@@ -36,7 +36,7 @@ def createMultidistMainSourceCode():
     source_code = renderTemplateFromString(
         r"""
 import sys, re, os
-main_basename = re.sub(r'(.pyw?|\.exe|\.bin)?$', '', os.path.normcase(os.path.basename(sys.argv[0])))
+main_basename = re.sub(r'(.pyw?|\.exe|\.bin)?$', '', os.path.normcase(os.path.basename(__compiled__.original_argv0)))
 {% for main_module_name, main_basename in zip(main_module_names, main_basenames) %}
 if main_basename == "{{main_basename}}":
     __import__("{{main_module_name.asString()}}")


### PR DESCRIPTION
so that multiple entrypoint can be invoked from a single binary

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
Use `__compiled__.original_argv0` instead of `sys.argv[0]`to allow multidist binaries to invoke from the original argv0 entrypoint.

# Why was it initiated? Any relevant Issues?
See https://github.com/Nuitka/Nuitka/issues/3303. 

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where multidist binaries could not invoke the correct entrypoint when called with different names.