### PR TITLE
Fix, scons debug file syntax error

### DIFF
--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -307,7 +307,7 @@ import subprocess
 
 exit_code = subprocess.call(
     %(scons_command)r,
-    env={%(env)s}
+    env={%(env)s},
     shell=False
 )"""
         % {
@@ -339,7 +339,7 @@ cd "${0%/*}"
         contents="""\
 %(script_prelude)s
 
-'%(scons_python)s' '%(scons_debug_script_name)s'
+"%(scons_python)s" "%(scons_debug_script_name)s"
 """
         % {
             "script_prelude": script_prelude,


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
Fix scons-debug file syntax error.

# Why was it initiated? Any relevant Issues?
Trying to complie C files just by Scons (to find a way make compile faster), I noticed `scons-debug.py` and `scons-debug.bat`,try to recompile by `./scons-debug.bat`, obviously there are syntax error.
But, even I fix that, the compile result crash with segment fault.

reporduce: simply `nuitka debug.py --mingw` with hello world.
```
2.6
Commercial: None
Python: 3.12.8 (tags/v3.12.8:2dc476b, Dec  3 2024, 19:30:04) [MSC v.1942 64 bit (AMD64)]
Flavor: Unknown
Executable: ~\AppData\Local\pypoetry\Cache\virtualenvs\nuitka-test-riZrm3QV-py3.12\Scripts\python.exe
OS: Windows
Arch: x86_64
WindowsRelease: 11
Version C compiler: C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\cl.exe (cl 14.3).

```

tried `--devel-complie-c-only` but it generate some C sources again.

btw is nuitka designed to let user compile C sources by themselves？
# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Fixed a syntax error in the `scons-debug.py` and `scons-debug.bat` scripts that prevented them from being executed correctly.