### PR TITLE
Treat shared library dependencies with paths as like rpaths

### DIFF
--- a/nuitka/freezer/DllDependenciesPosix.py
+++ b/nuitka/freezer/DllDependenciesPosix.py
@@ -12,7 +12,7 @@ from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.PythonFlavors import isAnacondaPython
 from nuitka.Tracing import inclusion_logger
 from nuitka.utils.Execution import executeProcess, withEnvironmentPathAdded
-from nuitka.utils.SharedLibraries import getSharedLibraryRPATHS
+from nuitka.utils.SharedLibraries import getSharedLibraryRPATHs
 from nuitka.utils.Utils import (
     isAlpineLinux,
     isAndroidBasedLinux,
@@ -43,7 +43,7 @@ def detectBinaryPathDLLsPosix(dll_filename, package_name, original_dir):
     # on Travis. pylint: disable=global-statement
     global _detected_python_rpath
     if _detected_python_rpath is None and not isPosixWindows():
-        _detected_python_rpath = getSharedLibraryRPATHS(sys.executable) or []
+        _detected_python_rpath = getSharedLibraryRPATHs(sys.executable) or []
 
         if _detected_python_rpath:
             # Need to resolve a potential symlink.

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -246,19 +246,15 @@ def _getSharedLibraryRPATHsElf(filename):
             rpaths.append(result)
         elif b"NEEDED" in line:
             # If the Python binary has a library dependency like
-            # $ORIGIN/../lib/libpython.so, then treat it like it has an
-            # rpath of $ORIGIN/../lib. This is needed for
-            # python-build-standalone (used by uv).
+            # $ORIGIN/../lib/libpython.so, then treat it like it has an rpath of
+            # $ORIGIN/../lib. This is needed for python-build-standalone (used
+            # by UV-Python).
             result = line[line.find(b"[") + 1 : line.rfind(b"]")]
-            directory, slash, filename = result.rpartition(b"/")
 
-            if slash:
-                if str is not bytes:
-                    directory = directory.decode("utf8")
-                if directory == "":
-                    directory = "/"
+            if str is not bytes:
+                result = result.decode("utf8")
 
-                rpaths.append(directory)
+            rpaths.append(os.path.dirname(result))
 
     return rpaths
 

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -254,7 +254,9 @@ def _getSharedLibraryRPATHsElf(filename):
             if str is not bytes:
                 result = result.decode("utf8")
 
-            rpaths.append(os.path.dirname(result))
+            path_part = os.path.dirname(result)
+            if path_part:
+                rpaths.append(path_part)
 
     return rpaths
 

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -481,7 +481,7 @@ def _setSharedLibraryRPATHDarwin(filename, rpath):
     old_rpaths = getSharedLibraryRPATHs(filename)
 
     with withMadeWritableFileMode(filename):
-        _removeSharedLibraryRPATHDarwin(filename=filename, rpath=old_rpaths)
+        _removeSharedLibraryRPATHDarwin(filename=filename, rpaths=old_rpaths)
 
         executeToolChecked(
             logger=postprocessing_logger,

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -471,21 +471,21 @@ def _filterInstallNameToolErrorOutput(stderr):
 _install_name_tool_usage = "The 'install_name_tool' is used to make binaries portable on macOS and required to be found."
 
 
-def _removeSharedLibraryRPATHDarwin(filename, rpath):
-    executeToolChecked(
-        logger=postprocessing_logger,
-        command=("install_name_tool", "-delete_rpath", rpath, filename),
-        absence_message=_install_name_tool_usage,
-        stderr_filter=_filterInstallNameToolErrorOutput,
-    )
+def _removeSharedLibraryRPATHDarwin(filename, rpaths):
+    for rpath in rpaths:
+        executeToolChecked(
+            logger=postprocessing_logger,
+            command=("install_name_tool", "-delete_rpath", rpath, filename),
+            absence_message=_install_name_tool_usage,
+            stderr_filter=_filterInstallNameToolErrorOutput,
+        )
 
 
 def _setSharedLibraryRPATHDarwin(filename, rpath):
-    old_rpath = getSharedLibraryRPATH(filename)
+    old_rpaths = getSharedLibraryRPATHs(filename)
 
     with withMadeWritableFileMode(filename):
-        if old_rpath is not None:
-            _removeSharedLibraryRPATHDarwin(filename=filename, rpath=old_rpath)
+        _removeSharedLibraryRPATHDarwin(filename=filename, rpath=old_rpaths)
 
         executeToolChecked(
             logger=postprocessing_logger,

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -227,7 +227,7 @@ def _getDLLVersionWindows(filename):
 _readelf_usage = "The 'readelf' is used to analyse dependencies on ELF using systems and required to be found."
 
 
-def _getSharedLibraryRPATHSElf(filename):
+def _getSharedLibraryRPATHsElf(filename):
     rpaths = []
     output = executeToolChecked(
         logger=postprocessing_logger,
@@ -368,7 +368,7 @@ def _getDLLVersionMacOS(filename):
     return None
 
 
-def _getSharedLibraryRPATHSDarwin(filename):
+def _getSharedLibraryRPATHsDarwin(filename):
     rpaths = []
     output = getOtoolListing(filename)
 
@@ -395,11 +395,11 @@ def _getSharedLibraryRPATHSDarwin(filename):
     return rpaths
 
 
-def getSharedLibraryRPATHS(filename):
+def getSharedLibraryRPATHs(filename):
     if isMacOS():
-        return _getSharedLibraryRPATHSDarwin(filename)
+        return _getSharedLibraryRPATHsDarwin(filename)
     else:
-        return _getSharedLibraryRPATHSElf(filename)
+        return _getSharedLibraryRPATHsElf(filename)
 
 
 def _filterPatchelfErrorOutput(stderr):


### PR DESCRIPTION
This fixes builds using python-build-standalone (the Python distribution installed by uv), which have an $ORIGIN-relative libpython dependency that should be treated like an $ORIGIN-relative rpath.

Fixes #3325.

## Summary by Sourcery

Treat shared library dependencies with paths relative to `$ORIGIN` as rpaths. This change ensures that dependencies are correctly resolved, even when the Python binary is installed in a non-standard location.

Bug Fixes:
- Fix builds using `python-build-standalone`, which have an `$ORIGIN`-relative `libpython` dependency that should be treated like an `$ORIGIN`-relative rpath.  Fixes #3325

Build:
- Treat shared library dependencies with paths as like rpaths when detecting binary path DLLs on POSIX systems.
- Handle multiple rpaths correctly when processing shared libraries on Darwin and ELF systems.