### PR TITLE
Scons: Add rpath for relocatable Python installations

### DIFF
--- a/nuitka/PythonFlavors.py
+++ b/nuitka/PythonFlavors.py
@@ -220,6 +220,19 @@ def isUninstalledPython():
     return isAnacondaPython() or "WinPython" in sys.version
 
 
+def isRelocatable():
+    """Is libpython not in the system global library directory."""
+    import sysconfig
+
+    if sysconfig.get_config_var("PYTHON_BUILD_STANDALONE") == 1:
+        return True
+
+    if isSelfCompiledPythonUninstalled():
+        return True
+
+    return False
+
+
 _is_win_python = None
 
 

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -812,6 +812,8 @@ elif env.exe_mode:
     # For NetBSD the rpath is required, on FreeBSD it's warned as unused.
     if isNetBSD():
         env.Append(LINKFLAGS=["-rpath=" + python_lib_path])
+    elif env.relocatable:
+        env.Append(LINKFLAGS=["-Wl,-rpath=" + python_lib_path])
 
 if isMacOS():
     if env.module_mode or env.dll_mode:

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -34,6 +34,7 @@ from nuitka.PythonFlavors import (
     isAnacondaPython,
     isMSYS2MingwPython,
     isNuitkaPython,
+    isRelocatable,
     isSelfCompiledPythonUninstalled,
 )
 from nuitka.PythonVersions import (
@@ -544,6 +545,9 @@ def getCommonSconsOptions():
 
     if isSelfCompiledPythonUninstalled():
         scons_options["self_compiled_python_uninstalled"] = asBoolStr(True)
+
+    if isRelocatable():
+        scons_options["relocatable"] = asBoolStr(True)
 
     cpp_defines = Plugins.getPreprocessorSymbols()
     if cpp_defines:

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -250,6 +250,7 @@ def createEnvironment(
     env.self_compiled_python_uninstalled = getArgumentBool(
         "self_compiled_python_uninstalled", False
     )
+    env.relocatable = getArgumentBool("relocatable", False)
 
     # Non-elf binary, important for linker settings.
     env.noelf_mode = getArgumentBool("noelf_mode", False)


### PR DESCRIPTION
Relocatable installations are not installed to a system-wide path and therefore compiling against their libpython requires using an rpath. At the moment the heuristic is whether the installation comes from python-build-standalone.

Fixes #3325.