### PR TITLE
Fix, respect PYTHONHOME environment variable in accelerate mode and uninstalled python detected

### DIFF
--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -176,9 +176,6 @@ pgo_mode = getArgumentDefaulted("pgo_mode", "no")
 # Console mode specified
 console_mode = getArgumentDefaulted("console_mode", "attach")
 
-# Windows might be running a Python whose DLL we have to use.
-uninstalled_python = getArgumentBool("uninstalled_python", False)
-
 # Unstripped mode: Do not remove debug symbols.
 unstripped_mode = getArgumentBool("unstripped_mode", False)
 
@@ -954,10 +951,6 @@ if job_count:
 
 def createBuildDefinitionsFile():
     build_definitions = {}
-
-    if uninstalled_python and not env.static_libpython:
-        # Use the non-external one, so it's not a short path.
-        build_definitions["PYTHON_HOME_PATH"] = python_prefix
 
     build_definitions["NO_PYTHON_WARNINGS"] = 1 if no_python_warnings else 0
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1509,19 +1509,6 @@ static int Nuitka_Main(int argc, native_command_line_argument_t **argv) {
     NUITKA_PRINT_TRACE("main(): Calling setCommandLineParameters.");
     setCommandLineParameters(argc, argv);
 
-    /* For Python installations that need the home set, we inject it back here. */
-#if defined(PYTHON_HOME_PATH)
-#if PYTHON_VERSION < 0x300
-    NUITKA_PRINT_TRACE("main(): Prepare run environment '" PYTHON_HOME_PATH "'.");
-    Py_SetPythonHome(PYTHON_HOME_PATH);
-#else
-    NUITKA_PRINTF_TRACE("main(): Prepare run environment '%S'.\n", L"" PYTHON_HOME_PATH);
-    Py_SetPythonHome(L"" PYTHON_HOME_PATH);
-    // Make sure the above Py_SetPythonHome call has effect already.
-    Py_GetPath();
-#endif
-#endif
-
 #if PYTHON_VERSION >= 0x300 && SYSFLAG_NO_RANDOMIZATION == 1
     environment_char_t const *old_env_hash_seed = getEnvironmentVariable("PYTHONHASHSEED");
     setEnvironmentVariable("PYTHONHASHSEED", makeEnvironmentLiteral("0"));


### PR DESCRIPTION
since for uninstalled python,script file is created to set environment variable, there is no need to set PYTHON_HOME_PATH in MainProgram.c.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

I noticed that, when `uninstalled_python` detected, scons backend generate PYTHON_HOME_PATH in `build_definition.h`, and set PYTHONHOME in MainProgram.c,which will cover PYTHONHOME environment variable. But when `uninstalled_python` detected, there also must be a script file for execution,so it's not necessary and I can custom PYTHON_HOME in accelerate mode

# Why was it initiated? Any relevant Issues?

I want to make compiling faster by do not compile pypi packages, and just copy CPython interpreter and site_packages, I know it's not offical supported but I really need this.
https://github.com/Nuitka/Nuitka/issues/3283

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Respect the PYTHONHOME environment variable when running in accelerate mode with an uninstalled Python. This change removes the forced setting of PYTHONHOME in MainProgram.c, allowing users to customize it.