### PR TITLE
Improve stubgen for generics, missing typing import and more

### DIFF
--- a/nuitka/build/inline_copy/stubgen/stubgen.py
+++ b/nuitka/build/inline_copy/stubgen/stubgen.py
@@ -8,8 +8,36 @@ if sys.version_info < (3, 9):
 
     ast.unparse = unparse
 
-def generate_stub_from_source(source_code, output_file_path, text_only=False):
+
+class MainBlockRemover(ast.NodeTransformer):
+    """AST transformer that removes 'if __name__ == "__main__":' blocks."""
+
+    def visit_If(self, node):
+        if (
+            isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and (node.test.left.id == "__name__")
+            and (len(node.test.ops) == 1)
+            and isinstance(node.test.ops[0], ast.Eq)
+            and (len(node.test.comparators) == 1)
+            and isinstance(node.test.comparators[0], ast.Constant)
+            and (node.test.comparators[0].value == "__main__")
+        ):
+            return None
+        return self.generic_visit(node)
+
+
+def preprocess_source(source_code):
     tree = ast.parse(source_code)
+    transformer = MainBlockRemover()
+    transformed_tree = transformer.visit(tree)
+    ast.fix_missing_locations(transformed_tree)
+    return ast.unparse(transformed_tree)
+
+
+def generate_stub_from_source(source_code, output_file_path, text_only=False):
+    preprocessed_code = preprocess_source(source_code)
+    tree = ast.parse(preprocessed_code)
 
     class StubGenerator(ast.NodeVisitor):
         def __init__(self):
@@ -17,8 +45,11 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
             self.imports_helper_dict = {}
             self.imports_output = set()
             self.typing_imports = typing.__all__
+            self.in_class = False
+            self.indentation_level = 0
+            self.typevars = set()
 
-        def visit_Import(self, node: ast.Import):
+        def visit_Import(self, node):
             for alias in node.names:
                 self.imports_output.add(f"import {alias.name}")
 
@@ -26,18 +57,24 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
             module = node.module if node.module is not None else "."
             for alias in node.names:
                 name = alias.name
-
-                if module not in self.imports_helper_dict:
-                    self.imports_helper_dict[module] = set()
-                self.imports_helper_dict[module].add(name)
+                if module:
+                    if module not in self.imports_helper_dict:
+                        self.imports_helper_dict[module] = set()
+                    self.imports_helper_dict[module].add(name)
 
         def visit_FunctionDef(self, node):
-            if any(isinstance(n, ast.ClassDef) for n in ast.walk(tree)):
-                if self.is_method(node):
-                    self.visit_MethodDef(node)
-                else:
-                    self.visit_RegularFunctionDef(node)
+            if self.in_class:
+                self.visit_MethodDef(node)
             else:
+                for parent_node in ast.walk(tree):
+                    if isinstance(parent_node, ast.ClassDef):
+                        for child_node in parent_node.body:
+                            if (
+                                isinstance(child_node, ast.FunctionDef)
+                                and child_node.name == node.name
+                                and (child_node.lineno == node.lineno)
+                            ):
+                                return
                 self.visit_RegularFunctionDef(node)
 
         def visit_Assign(self, node):
@@ -45,34 +82,54 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
                 if isinstance(target, ast.Name):
                     target_name = target.id
                     target_type = ast.unparse(node.value).strip()
+                    if (
+                        isinstance(node.value, ast.Call)
+                        and isinstance(node.value.func, ast.Name)
+                        and (node.value.func.id == "TypeVar")
+                    ):
+                        if "typing" not in self.imports_helper_dict:
+                            self.imports_helper_dict["typing"] = set()
+                        self.imports_helper_dict["typing"].add("TypeVar")
+                        self.typevars.add(target_name)
+                        if node.value.args:
+                            typevar_def = f"{target_name} = TypeVar({', '.join([ast.unparse(arg) for arg in node.value.args])})"
+                            self.stubs.append(typevar_def + "\n\n")
+                        else:
+                            self.stubs.append(
+                                f'{target_name} = TypeVar("{target_name}")\n\n'
+                            )
+                        continue
                     if target_type in self.typing_imports:
                         self.imports_output.add(target_type)
                     if target_type in self.typing_imports:
                         stub = f"{target_name}: {target_type}\n"
                         self.stubs.append(stub)
-                    else:
-                        if isinstance(node.value, ast.Call):
-                            if isinstance(node.value.func, ast.Name):
-                                if node.value.func.id == "frozenset":
-                                    stub = f"{target_name} = frozenset({', '.join([ast.unparse(arg).strip() for arg in node.value.args])})\n"
-                                    self.stubs.append(stub)
-                                elif node.value.func.id == "namedtuple":
-                                    tuple_name = ast.unparse(node.value.args[0]).strip()
-
-                                    stub = f"{target_name} =  namedtuple({tuple_name}, {', '.join([ast.unparse(arg).strip() for arg in node.value.args[1:]])})\n"
-                                    self.stubs.append(stub)
-                        elif isinstance(node.value, ast.Subscript):
-                            if isinstance(node.value.value, ast.Name):
-                                target_name = node.value.value.id
-                            target_type = ast.unparse(node.value).strip()
-                            if "typing_extensions" not in self.imports_helper_dict:
-                                self.imports_helper_dict["typing_extensions"] = set()
-                            self.imports_helper_dict["typing_extensions"].add(
-                                "TypeAlias"
-                            )
-                            stub = f"{target_name}: TypeAlias = {target_type}\n"
-                            self.stubs.append(stub)
-
+                    elif isinstance(node.value, ast.Call):
+                        if isinstance(node.value.func, ast.Name):
+                            if node.value.func.id == "frozenset":
+                                stub = f"{target_name} = frozenset({', '.join([ast.unparse(arg).strip() for arg in node.value.args])})\n"
+                                self.stubs.append(stub)
+                            elif node.value.func.id == "namedtuple":
+                                tuple_name = ast.unparse(node.value.args[0]).strip()
+                                stub = f"{target_name} =  namedtuple({tuple_name}, {', '.join([ast.unparse(arg).strip() for arg in node.value.args[1:]])})\n"
+                                self.stubs.append(stub)
+                            elif node.value.func.id == "TypeVar":
+                                if "typing" not in self.imports_helper_dict:
+                                    self.imports_helper_dict["typing"] = set()
+                                self.imports_helper_dict["typing"].add("TypeVar")
+                                self.typevars.add(target_name)
+                    elif isinstance(node.value, ast.Subscript):
+                        if isinstance(node.value.value, ast.Name):
+                            target_name = target.id
+                        target_type = ast.unparse(node.value).strip()
+                        if "typing_extensions" not in self.imports_helper_dict:
+                            self.imports_helper_dict["typing_extensions"] = set()
+                        self.imports_helper_dict["typing_extensions"].add("TypeAlias")
+                        stub = f"{target_name}: TypeAlias = {target_type}\n"
+                        self.stubs.append(stub)
+                    elif not self.in_class:
+                        stub = f"{target_name} = {target_type}\n"
+                        self.stubs.append(stub)
                 elif isinstance(target, ast.Subscript):
                     if isinstance(target.value, ast.Name):
                         target_name = target.value.id
@@ -82,17 +139,6 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
                     stub = f"{target_name}: {target_type}\n"
                     self.stubs.append(stub)
 
-        def is_method(self, node):
-            for parent_node in ast.walk(tree):
-                if isinstance(parent_node, ast.ClassDef):
-                    for child_node in parent_node.body:
-                        if (
-                            isinstance(child_node, ast.FunctionDef)
-                            and child_node.name == node.name
-                        ):
-                            return True
-            return False
-
         def visit_MethodDef(self, node):
             args_list = []
             for arg in node.args.args:
@@ -101,11 +147,11 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
             if node.returns:
                 return_type = self.get_return_type(node.returns)
             else:
-                return_type = "typing.Any"
-
-            if return_type in self.typing_imports:
-                self.imports_output.add(return_type)
-            # handle the case where the node.name is __init__, __init__ is a special case which always returns None
+                return_type = "Any"
+                if "typing" not in self.imports_helper_dict:
+                    self.imports_helper_dict["typing"] = set()
+                self.imports_helper_dict["typing"].add("Any")
+            indent = "    " * (self.indentation_level + 1)
             if node.name == "__init__":
                 return_type = "None"
             if node.decorator_list:
@@ -113,22 +159,18 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
                     if isinstance(decorator, ast.Name):
                         if decorator.id == "classmethod":
                             args_list = args_list[1:]
-                            stub = f"    @classmethod\n    def {node.name}(cls, {', '.join(args_list)}) -> {return_type}: ...\n"
-
+                            stub = f"{indent}@classmethod\n{indent}def {node.name}(cls, {', '.join(args_list)}) -> {return_type}: ...\n"
                             self.stubs.append(stub)
                             return
-
                         elif decorator.id == "staticmethod":
-                            stub = f"    @staticmethod\n    def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
+                            stub = f"{indent}@staticmethod\n{indent}def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
                             self.stubs.append(stub)
                             return
                         else:
-                            stub = f"    def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
+                            stub = f"{indent}def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
                             self.stubs.append(stub)
                             return
-            stub = (
-                f"    def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
-            )
+            stub = f"{indent}def {node.name}({', '.join(args_list)}) -> {return_type}: ...\n"
             self.stubs.append(stub)
 
         def visit_RegularFunctionDef(self, node):
@@ -139,18 +181,53 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
             if node.returns:
                 return_type = self.get_return_type(node.returns)
             else:
-                return_type = "typing.Any"
+                return_type = "Any"
+                if "typing" not in self.imports_helper_dict:
+                    self.imports_helper_dict["typing"] = set()
+                self.imports_helper_dict["typing"].add("Any")
             stub = (
                 f"def {node.name}({', '.join(args_list)}) -> {return_type}:\n    ...\n"
             )
             self.stubs.append(stub)
+            self.stubs.append("\n")
 
         def visit_ClassDef(self, node):
+            previous_in_class = self.in_class
+            self.in_class = True
+            previous_indent = self.indentation_level
+            if previous_in_class:
+                self.indentation_level += 1
             class_name = node.name
+            indent = "    " * self.indentation_level
             stub = ""
             case = self.special_cases(node)
+            class_has_generic = False
+            generic_types = []
+            for base in node.bases:
+                if (
+                    isinstance(base, ast.Subscript)
+                    and isinstance(base.value, ast.Name)
+                    and (base.value.id == "Generic")
+                ):
+                    class_has_generic = True
+                    if "typing" not in self.imports_helper_dict:
+                        self.imports_helper_dict["typing"] = set()
+                    self.imports_helper_dict["typing"].add("Generic")
+                    if isinstance(base.slice, ast.Tuple):
+                        for elt in base.slice.elts:
+                            if isinstance(elt, ast.Name):
+                                generic_types.append(elt.id)
+                    elif isinstance(base.slice, ast.Name):
+                        generic_types.append(base.slice.id)
+                    for type_name in generic_types:
+                        if type_name in self.typevars:
+                            continue
+                        self.typevars.add(type_name)
+                        if "typing" not in self.imports_helper_dict:
+                            self.imports_helper_dict["typing"] = set()
+                        self.imports_helper_dict["typing"].add("TypeVar")
             if case == "TypedDict":
-                stub = f"class {class_name}(TypedDict):\n"
+                stub = f"{indent}class {class_name}(TypedDict):\n"
                 if "typing" not in self.imports_helper_dict:
                     self.imports_helper_dict["typing"] = set()
                 self.imports_helper_dict["typing"].add("TypedDict")
@@ -160,55 +237,88 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
                             if isinstance(target, ast.Name):
                                 target_name = target.id
                                 target_type = ast.unparse(key.value).strip()
-                                stub += f"    {target_name}: {target_type}\n"
+                                stub += f"{indent}    {target_name}: {target_type}\n"
                             elif isinstance(target, ast.Subscript):
                                 if isinstance(target.value, ast.Name):
                                     target_name = target.value.id
                                 target_type = ast.unparse(key.value).strip()
-                                stub += f"    {target_name}: {target_type}\n"
+                                stub += f"{indent}    {target_name}: {target_type}\n"
                     elif isinstance(key, ast.AnnAssign):
                         target = key.target
                         if isinstance(target, ast.Name):
                             target_name = target.id
                             target_type = ast.unparse(key.annotation).strip()
-                            stub += f"    {target_name}: {target_type}\n"
+                            stub += f"{indent}    {target_name}: {target_type}\n"
                         elif isinstance(target, ast.Subscript):
                             if isinstance(target.value, ast.Name):
                                 target_name = target.value.id
                             target_type = ast.unparse(key.annotation).strip()
-                            stub += f"    {target_name}: {target_type}\n"
-                stub += "\n"
+                            stub += f"{indent}    {target_name}: {target_type}\n"
             elif case == "Exception":
-                if not any(isinstance(n, ast.FunctionDef) for n in node.body):
-                    stub = f"\nclass {class_name}(Exception): ..."
+                if not any((isinstance(n, ast.FunctionDef) for n in node.body)):
+                    stub = f"{indent}class {class_name}(Exception): ..."
                 else:
-                    stub = f"\nclass {class_name}(Exception):"
+                    stub = f"{indent}class {class_name}(Exception):"
             elif case == "NamedTuple":
-                stub = f"class {class_name}(NamedTuple):\n"
+                stub = f"{indent}class {class_name}(NamedTuple):\n"
                 self.imports_output.add("from typing import NamedTuple")
             else:
-                is_dataclass = any(isinstance(n, ast.AnnAssign) for n in node.body)
+                is_dataclass = any((isinstance(n, ast.AnnAssign) for n in node.body))
                 if is_dataclass:
-                    stub = "@dataclass\n"
+                    stub = f"{indent}@dataclass\n"
                     self.imports_output.add("from dataclasses import dataclass")
-                stub += f"class {class_name}:"
-
+                class_def = f"{indent}class {class_name}"
+                bases = []
+                for base in node.bases:
+                    if isinstance(base, ast.Name):
+                        bases.append(base.id)
+                    elif isinstance(base, ast.Subscript):
+                        if (
+                            isinstance(base.value, ast.Name)
+                            and base.value.id == "Generic"
+                        ):
+                            continue
+                        base_name = ast.unparse(base).strip()
+                        bases.append(base_name)
+                if class_has_generic:
+                    bases.append(f"Generic[{', '.join(generic_types)}]")
+                if bases:
+                    class_def += f"({', '.join(bases)})"
+                class_def += ":"
+                stub += class_def
             self.stubs.append(stub)
-            methods = [n for n in node.body if isinstance(n, ast.FunctionDef)]
-            if methods:
+            methods_or_classes = [
+                n for n in node.body if isinstance(n, (ast.FunctionDef, ast.ClassDef))
+            ]
+            if methods_or_classes:
                 self.stubs.append("\n")
-                for method in methods:
-                    self.visit_FunctionDef(method)
+                class_nodes = []
+                method_nodes = []
+                for child in methods_or_classes:
+                    if isinstance(child, ast.ClassDef):
+                        class_nodes.append(child)
+                    else:
+                        method_nodes.append(child)
+                for class_node in class_nodes:
+                    self.visit(class_node)
+                if class_nodes and method_nodes:
+                    self.stubs.append("\n")
+                for method_node in method_nodes:
+                    self.visit(method_node)
+            self.indentation_level = previous_indent
+            self.in_class = previous_in_class
+            if not previous_in_class:
+                self.stubs.append("\n")
 
         def special_cases(self, node):
             for obj in node.bases:
                 ob_instance = isinstance(obj, ast.Name)
                 if ob_instance:
-                    if obj.id == "TypedDict":  # type: ignore
+                    if obj.id == "TypedDict":
                         return "TypedDict"
-                    elif obj.id == "Exception":  # type: ignore
+                    elif obj.id == "Exception":
                         return "Exception"
-                    elif obj.id == "NamedTuple":  # type: ignore
+                    elif obj.id == "NamedTuple":
                         return "NamedTuple"
                     else:
                         return False
@@ -217,22 +327,53 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
         def get_arg_type(self, arg_node):
             selfs = ["self", "cls"]
             if arg_node.arg in selfs:
-                if "typing_extensions" not in self.imports_helper_dict:
+                if (
+                    arg_node.arg == "self"
+                    and "typing_extensions" not in self.imports_helper_dict
+                ):
                     self.imports_helper_dict["typing_extensions"] = set()
-                self.imports_helper_dict["typing_extensions"].add("Self")
-                return "Self"
+                    self.imports_helper_dict["typing_extensions"].add("Self")
+                return "Self" if arg_node.arg == "self" else arg_node.arg
             elif arg_node.annotation:
                 unparsed = ast.unparse(arg_node.annotation).strip()
+                if (
+                    isinstance(arg_node.annotation, ast.Name)
+                    and arg_node.annotation.id in self.typevars
+                ):
+                    return arg_node.annotation.id
+                if unparsed.startswith("typing."):
+                    type_name = unparsed.split(".")[-1]
+                    if "typing" not in self.imports_helper_dict:
+                        self.imports_helper_dict["typing"] = set()
+                    self.imports_helper_dict["typing"].add(type_name)
+                    return type_name
                 return unparsed
             else:
-                return "typing.Any"
+                if "typing" not in self.imports_helper_dict:
+                    self.imports_helper_dict["typing"] = set()
+                self.imports_helper_dict["typing"].add("Any")
+                return "Any"
 
         def get_return_type(self, return_node):
             if return_node:
                 unparsed = ast.unparse(return_node).strip()
+                if (
+                    isinstance(return_node, ast.Name)
+                    and return_node.id in self.typevars
+                ):
+                    return return_node.id
+                if unparsed.startswith("typing."):
+                    type_name = unparsed.split(".")[-1]
+                    if "typing" not in self.imports_helper_dict:
+                        self.imports_helper_dict["typing"] = set()
+                    self.imports_helper_dict["typing"].add(type_name)
+                    return type_name
                 return unparsed
             else:
-                return "typing.Any"
+                if "typing" not in self.imports_helper_dict:
+                    self.imports_helper_dict["typing"] = set()
+                self.imports_helper_dict["typing"].add("Any")
+                return "Any"
 
         def visit_AnnAssign(self, node):
             target = node.target
@@ -240,63 +381,89 @@ def generate_stub_from_source(source_code, output_file_path, text_only=False):
                 target_type = node.annotation.id
             else:
                 target_type = ast.unparse(node.annotation).strip()
-
-            if isinstance(node.annotation, ast.Subscript):
+                if target_type.startswith("typing."):
+                    type_name = target_type.split(".")[-1]
+                    if "typing" not in self.imports_helper_dict:
+                        self.imports_helper_dict["typing"] = set()
+                    self.imports_helper_dict["typing"].add(type_name)
+                    target_type = type_name
+            if not self.in_class:
                 if isinstance(target, ast.Name):
-                    stub = f"{target.id}: {target_type}\n"
-                elif isinstance(target, ast.Name):
-                    stub = f"{target.id}: {target_type}\n"
-            elif isinstance(node.annotation, ast.Name):
-                if isinstance(target, ast.Name):
-                    stub = f"{target.id}: {target_type}\n"
-                elif isinstance(target, ast.Subscript):
-                    if isinstance(target.value, ast.Name):
-                        target_name = target.value.id
-                    stub = f"{target_name}: {target_type}\n"
-            else:
-                raise NotImplementedError(
-                    f"Type {type(node.annotation)} not implemented, report this issue"
-                )
-
-            self.stubs.append(stub)
+                    target_name = target.id
+                    if node.value is not None:
+                        value_str = ast.unparse(node.value).strip()
+                        stub = f"{target_name}: {target_type} = {value_str}\n"
+                    else:
+                        stub = f"{target_name}: {target_type}\n"
+                    self.stubs.append(stub)
+                    return
+            if self.in_class:
+                indent = "    " * (self.indentation_level + 1)
+                if isinstance(node.annotation, ast.Subscript):
+                    if isinstance(target, ast.Name):
+                        stub = f"{indent}{target.id}: {target_type}\n"
+                    elif isinstance(target, ast.Subscript):
+                        if isinstance(target.value, ast.Name):
+                            target_name = target.value.id
+                        stub = f"{indent}{target_name}: {target_type}\n"
+                elif isinstance(node.annotation, ast.Name):
+                    if isinstance(target, ast.Name):
+                        stub = f"{indent}{target.id}: {target_type}\n"
+                    elif isinstance(target, ast.Subscript):
+                        if isinstance(target.value, ast.Name):
+                            target_name = target.value.id
+                        stub = f"{indent}{target_name}: {target_type}\n"
+                elif isinstance(node.annotation, ast.BinOp):
+                    if isinstance(target, ast.Name):
+                        stub = f"{indent}{target.id}: {target_type}\n"
+                    elif isinstance(target, ast.Subscript):
+                        if isinstance(target.value, ast.Name):
+                            target_name = target.value.id
+                            stub = f"{indent}{target_name}: {target_type}\n"
+                        else:
+                            stub = f"{indent}{ast.unparse(target)}: {target_type}\n"
+                    else:
+                        stub = f"{indent}{ast.unparse(target)}: {target_type}\n"
+                else:
+                    raise NotImplementedError(
+                        f"Type {type(node.annotation)} not implemented, report this issue"
+                    )
+                self.stubs.append(stub)
 
         def generate_imports(self):
-            imports_helper = set()
+            imports = []
+            imports.append("from __future__ import annotations\n")
             sorted_items = sorted(self.imports_helper_dict.items())
             for module, names in sorted_items:
-                imports_helper.add(f"from {module} import {', '.join(sorted(names))}")
-
-            imports_helper.update(self.imports_output)
-
-            self.imports_output.add("from __future__ import annotations")
-
-            imports = "".join([f"{imp}\n" for imp in imports_helper])
-
-            return imports + "\n"
+                if names:
+                    imports.append(f"from {module} import {', '.join(sorted(names))}\n")
+            for imp in sorted(self.imports_output):
+                if imp != "from __future__ import annotations":
+                    imports.append(f"{imp}\n")
+            return "".join(imports) + "\n" if imports else ""
 
     stub_generator = StubGenerator()
     stub_generator.visit(tree)
     out_str = ""
-    sempt = stub_generator.generate_imports()
-    if sempt:
-        out_str += sempt
+    imports_str = stub_generator.generate_imports()
+    if imports_str:
+        out_str += imports_str
     for stub in stub_generator.stubs:
         out_str += stub
-
     if text_only:
         return out_str
     else:
-
         with open(output_file_path, "w") as output_file:
             output_file.write(out_str)
-
         return None
+
 
 def generate_stub(source_file_path, output_file_path, text_only=False):
     with open(source_file_path, "r", encoding="utf-8") as source_file:
         source_code = source_file.read()
-
-    return generate_stub_from_source(source_code=source_code, output_file_path=output_file_path, text_only=text_only)
+    return generate_stub_from_source(
+        source_code=source_code, output_file_path=output_file_path, text_only=text_only
+    )
 
 
 def generate_text_stub(source_file_path):

--- a/nuitka/build/inline_copy/stubgen/stubgen.py
+++ b/nuitka/build/inline_copy/stubgen/stubgen.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import ast
 import sys
 import typing


### PR DESCRIPTION
made it upstream as well: https://github.com/Nuitka/Nuitka-Stubgen/pull/2

## Summary by Sourcery

Improves stub generation by removing main blocks, handling TypeVar assignments, and adding support for generics and class methods. It also fixes issues with missing typing imports and improves RPATH handling on macOS.

Enhancements:
- Improves stub generation for generics, class methods, and TypeVar assignments.
- Improves RPATH handling on macOS by ensuring it is updated correctly and avoids potential errors.
- Adds a preprocessor to remove 'if __name__ == "__main__"' blocks from the source code before generating stubs.
- Adds more cases for type hinting
- Adds more cases for imports