### PR TITLE
Handle `imageio_ffmpeg` executables for MacOS and Linux as data files

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -1977,13 +1977,18 @@
         - 'imageio.plugins.simpleitk'
         - 'imageio.plugins.pillow'
 
-- module-name: 'imageio_ffmpeg' # checksum: cbcd4133
+- module-name: 'imageio_ffmpeg' # checksum: c9b04528
+  data-files:
+    - dirs:
+        - 'binaries'
+      when: 'macos or linux'
   dlls:
     - from_filenames:
         relative_path: 'binaries'
         prefixes:
           - 'ffmpeg'
         executable: 'yes'
+      when: 'win32'
 
 - module-name: 'imageio_ffmpeg._utils' # checksum: 77b155b9
   anti-bloat:


### PR DESCRIPTION
# What does this PR do?

The PR adds `data-files` to imageio_ffmpeg standard plugin for MacOS and Linux, handling their FFMPEG executable as data-file, which solves `failed to update rpath` error.

# Why was it initiated? Any relevant Issues?

The PR addresses a bug discovered in the standard plugin (`imageio_ffmpeg`, [L1980](https://github.com/Nuitka/Nuitka/blob/b289ee4f9d55172ed5165dab262d49bfa9cb2586/nuitka/plugins/standard/standard.nuitka-package.config.yml#L1980)). Specifically, when trying to build an application using this library and trying to include binaries (FFMPEG executable), the process fails on Linux with message

```
FATAL: Error, failed to update rpath for 'project.dist/imageio_ffmpeg/binaries/ffmpeg-linux-x86_64-v7.0.2'.
```

When inspecting how Nuitka discovers executables, it fails to identify the executable as DLL:

```
❯ python -m nuitka --list-package-dlls=imageio_ffmpeg
Nuitka-Tools: Checking package directory '/home/user/project/nuitka-build/.venv/lib/python3.12/site-packages/imageio_ffmpeg' ..
Nuitka-Tools: Found 0 DLLs.
```

But discovers them successfully as data files:

```
❯ python -m nuitka --list-package-data=imageio_ffmpeg
Nuitka-Tools: Checking package directory '/home/user/project/nuitka-build/.venv/lib/python3.12/site-packages/imageio_ffmpeg' ..
/home/user/project/nuitka-build/.venv/lib/python3.12/site-packages/imageio_ffmpeg
/home/user/project/nuitka-build/.venv/lib/python3.12/site-packages/imageio_ffmpeg/binaries/README.md
/home/user/project/nuitka-build/.venv/lib/python3.12/site-packages/imageio_ffmpeg/binaries/ffmpeg-linux-x86_64-v7.0.2
Nuitka-Tools: Found 2 data files.
```

Therefore, I modified the plugin to treat MacOS and Linux executables with the `data-file` option.

# PR Checklist

- [X] Correct base branch selected? Should be `develop` branch.
- [X] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Modify the Nuitka standard plugin configuration to handle `imageio_ffmpeg` executables for MacOS and Linux as data files to resolve rpath update issues during application building.

Bug Fixes:
- Fix rpath update error when including FFMPEG executables from imageio_ffmpeg for MacOS and Linux platforms by treating them as data files instead of DLLs

Enhancements:
- Update package configuration to conditionally handle imageio_ffmpeg binaries differently based on platform