### PR TITLE
Add missing data file for `cyclonedx` package

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -988,6 +988,11 @@
       replacements_plain:
         'key[i].step': '(key[i].step if key[i].step is not None else 1)'
 
+- module-name: 'cyclonedx' # checksum: f0f71611
+  data-files:
+    - dirs:
+        - 'schema/_res'
+
 - module-name: 'cytoolz.functoolz' # checksum: e6faf7b7
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?

Adds the [`schema/_res` subfolder](https://github.com/CycloneDX/cyclonedx-python-lib/tree/main/cyclonedx/schema/_res) of the [`cyclonedx`](https://github.com/CycloneDX/cyclonedx-python-lib) package which are imported dynamically and are not embedded naturally by Nuitka.

# Why was it initiated? Any relevant Issues?

I stumble upon this issue while trying to make a standalone executable of my [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) project, which depends on `cyclonedx` to [produce an SBOM exports](https://github.com/kdeldycke/meta-package-manager/blob/5814e4cfa6947fd226b3ff221072d03d74c116ad/meta_package_manager/sbom.py#L28-L40).

When compiled with the `--onefile` option, the resulting binary always ends up with this traceback:
```pytb
Traceback (most recent call last):
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/__main__.py", line 49, in <module>
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/__main__.py", line 45, in main
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click/core.py", line 1161, in __call__
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click_extra/commands.py", line 360, in main
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click/core.py", line 1082, in main
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click_extra/commands.py", line 390, in invoke
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click/core.py", line 1697, in invoke
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click_extra/commands.py", line 390, in invoke
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click/core.py", line 1443, in invoke
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/click/core.py", line 788, in invoke
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/cloup/_context.py", line 47, in new_func
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/meta_package_manager/cli.py", line 1548, in sbom
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/meta_package_manager/sbom.py", line 393, in export
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/cyclonedx/validation/json.py", line 67, in validate_str
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/cyclonedx/validation/json.py", line 71, in _validata_data
  File "/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/cyclonedx/validation/json.py", line 86, in _validator
FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/gr/1frk79j52flczzs2rrpfnkl80000gn/T/onefile_17140_1745657828_495078/cyclonedx/schema/_res/bom-1.5.SNAPSHOT.schema.json'
```

Which hints at missing static resources files `cyclonedx` relies on. 

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Include `cyclonedx.schema._res` data files required by the package at runtime, fixing `FileNotFoundError` in compiled executables.