### PR TITLE
Add dependencies for pymediainfo

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4636,6 +4636,17 @@
     - dirs:
         - 'data'
 
+- module-name: 'pymediainfo' # checksum: 70f7a032
+  dlls:
+    - from_filenames:
+        prefixes:
+          - 'MediaInfo'
+      when: 'win32'
+    - from_filenames:
+        prefixes:
+          - 'libmediainfo'
+      when: 'linux'
+
 - module-name: 'pymoo.cython' # checksum: 158685c1
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?
This PR adds the required dependencies for the package pymedianinfo.
Tested on Windows and Linux.

# Why was it initiated? Any relevant Issues?
Fixes #3441

# PR Checklist
- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.

## Summary by Sourcery

Add configuration for pymediainfo dependencies to support cross-platform media information retrieval

New Features:
- Add configuration for pymediainfo module dependencies for Windows and Linux platforms

Bug Fixes:
- Resolve dependency configuration for pymediainfo (Issue #3441)