### PR TITLE
Update standard.nuitka-package.config.yml

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3662,6 +3662,7 @@
     - dest_path: '.'
       dirs:
         - 'etc'
+        - 'models'
 
   dlls:
     - from_filenames:
@@ -8603,7 +8604,10 @@
 - module-name: 'ursina' # checksum: e8b5dd34
   data-files:
     - dirs:
+        - 'audio'
+        - 'fonts'
         - 'models_compressed'
+        - 'textures'
 
 - module-name: 'usb1' # checksum: 5cbb45ba
   dlls:


### PR DESCRIPTION
Include additional directories for `ursina` and `panda3d`

## Summary by Sourcery

Update the standard Nuitka package configuration to include missing asset directories for the panda3d and ursina modules.

Enhancements:
- Add the 'models' directory to the panda3d package data files
- Include 'audio', 'fonts', and 'textures' directories in ursina's package data files