### PR TITLE
Add extra dependency group for Nuitka build-backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -495,6 +495,7 @@ Python compiler with full language support and CPython compatibility""",
         "console_scripts": console_scripts,
     },
     install_requires=install_requires,
+    extras_require={"build": ["setuptools>=42", "toml", "wheel"]},
     # As we do version specific hacks for installed inline copies, make the
     # wheel version and platform specific.
     distclass=BinaryDistribution,


### PR DESCRIPTION
# What does this PR do?
Add a new optional dependency group to include build dependencies when using Nuitka as a build backend. Dependencies taken from [this section](https://nuitka.net/user-documentation/use-cases.html#setuptools-wheels). Asides from being slightly cleaner for users, this would help avoid downstream breaks if the minimum version of setuptools ever needs to be bumped.

Before
```toml
[build-system]
build-backend = 'nuitka.distutils.Build'
requires = ['nuitka', 'setuptools>=42', 'toml', 'wheel']
```

After
```toml
[build-system]
build-backend = 'nuitka.distutils.Build'
requires = ['nuitka[build]']
```

# PR Checklist
- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.
