### PR TITLE
update nuitka/Progress.py

### DIFF
--- a/nuitka/Progress.py
+++ b/nuitka/Progress.py
@@ -114,8 +114,6 @@ class NuitkaProgressBarRich(object):
 
         self.min_total = min_total
         self.item = None
-        self._cached_postfix = ""  # Cache for postfix to avoid redundant updates
-        self._cached_item_str = None  # Cache string representation of current item
 
         self.rich_progress = _rich_progress.Progress(
             _rich_progress.TextColumn("[bold blue]{task.description}", justify="right"),
@@ -126,11 +124,13 @@ class NuitkaProgressBarRich(object):
                 "{task.completed:>0.0f}/{task.total:>0.0f} {task.fields[unit_label]}"
             ),
             _rich_progress.TextColumn("\u2022"),
-            _rich_progress.TextColumn("[bold blue]{task.fields[postfix]}"),  # Made postfix blue
-            refresh_per_second=20,
+            _rich_progress.TextColumn(
+                "[bold blue]{task.fields[postfix]}"
+            ),  # Made postfix blue
+            refresh_per_second=10000,
             transient=True,
-            redirect_stdout=False,  # Theses should allow us to do keyboard inputs without breaking
-            redirect_stderr=False,  #
+            redirect_stdout=False,
+            redirect_stderr=False,
         )
         self.rich_progress.start()
 
@@ -174,23 +174,9 @@ class NuitkaProgressBarRich(object):
     def setCurrent(self, item):
         if item != self.item:
             self.item = item
-            # Use cached string representation if item hasn't changed
-            if item is None:
-                new_postfix = ""
-            elif item == self._cached_item_str:
-                new_postfix = self._cached_postfix
-            else:
-                new_postfix = str(item)
-                self._cached_item_str = item
-
-            # Only update if postfix actually changed
-            if new_postfix != self._cached_postfix:
-                self._cached_postfix = new_postfix
-                try:
-                    self.rich_progress.update(self.task_id, postfix=new_postfix)
-                except (KeyError, IndexError):
-                    # Handle potential Rich internal changes gracefully
-                    pass
+            self.rich_progress.update(
+                self.task_id, postfix=str(item) if item is not None else ""
+            )
 
     def update(self):
         self.rich_progress.update(self.task_id, advance=1)
@@ -203,18 +189,26 @@ class NuitkaProgressBarRich(object):
     def close(self):
         if self.rich_progress.live.is_started:
             # Ensure task is marked as finished if not already
-            try:
-                if (
-                    self.task_id in self.rich_progress.task_ids
-                    and not self.rich_progress.tasks[
-                        self.rich_progress.task_ids.index(self.task_id)
-                    ].finished
-                ):
+            if (
+                self.task_id in self.rich_progress.task_ids
+                and not self.rich_progress.tasks[
+                    self.rich_progress.task_ids.index(self.task_id)
+                ].finished
+            ):
+
+                try:
                     self.rich_progress.stop_task(self.task_id)
+                except (KeyError, IndexError, ValueError):
+                    # Handle potential Rich internal state issues gracefully
+                    pass
+
+            # TODO: Add a context manager that handles non-critical errors,
+            # like not RuntimeError, allowing us to ignore things more general.
+            try:
+                self.rich_progress.stop()
             except (KeyError, IndexError, ValueError):
                 # Handle potential Rich internal state issues gracefully
                 pass
-            self.rich_progress.stop()
 
     @contextmanager
     def withExternalWritingPause(self):
@@ -421,18 +415,14 @@ def withNuitkaDownloadProgressBar(*args, **kwargs):
             _rich_progress.TimeRemainingColumn(),
             transient=True,
             disable=not is_tty,
-            refresh_per_second=10,  # Reduced from default for better performance during downloads
         )
 
         with _rich_progress_cm as rich_p_instance:
             task_id = rich_p_instance.add_task(
                 description, total=total_size_bytes or None
             )
-            last_completed = 0  # Cache to avoid redundant updates
 
             def onProgressRich(block_num=1, block_size=1, total_size=None):
-                nonlocal last_completed
-
                 if total_size is not None:
                     rich_p_instance.update(task_id, total=total_size)
 

--- a/nuitka/tools/quality/auto_format/__main__.py
+++ b/nuitka/tools/quality/auto_format/__main__.py
@@ -154,7 +154,7 @@ Defaults to off.""",
         result = 0
 
         if options.progress_bar:
-            enableProgressBar()
+            enableProgressBar(progress_bar="auto")
 
         for filename in wrapWithProgressBar(
             filenames, stage="Auto format", unit="files"


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
- Added _cached_postfix and _cached_item_str to cache string representations
- Only update Rich display when postfix content actually changes
- Added graceful exception handling for Rich internal API changes
- Protected against KeyError, IndexError, and ValueError in task operations
- Made the `task.fields` bold blue for a prettier look :)
- Reduced the refresh per seconds from 10000hz -> 20hz
- Fixed keyboard inputs not working when downloading `.dlls`

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [No] Correct base branch selected? Should be `develop` branch.
- [No idea :D] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [I didn't touch anything else :)] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [I just ran the command you gave me on Discord] Ideally new features or fixed regressions ought to be covered via new tests.
- [I added comments and explained what everything does above.] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Improve performance and resilience of the Rich-based progress bars by caching and conditional updates, reducing refresh rates, enhancing styling, handling internal API changes gracefully, and restoring keyboard input during downloads.

Bug Fixes:
- Fix keyboard input not working when downloading .dlls
- Prevent crashes by catching KeyError, IndexError, and ValueError from Rich internal changes

Enhancements:
- Cache postfix and item string representations to avoid redundant updates
- Reduce refresh rates to 20 Hz for main progress and 10 Hz for download progress
- Style task description and postfix in bold blue
- Only update progress when content actually changes