### PR TITLE
Fix #3100 Regression

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4686,7 +4686,7 @@
     - dirs:
         - '.'
 
-- module-name: 'pygame' # checksum: 64efeec5
+- module-name: 'pygame' # checksum: db7d5ddb
   data-files:
     - patterns:
         - 'freesansbold.ttf'
@@ -4696,6 +4696,11 @@
     - patterns:
         - 'pygame_icon.bmp'
       when: 'not macos'
+  dlls:
+    - from_filenames:
+        relative_path: '.'
+        prefixes:
+          - ''
 
   anti-bloat:
     - no-auto-follow:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
#3100 has regressed and both pygame and pygame-ce are broken due to missing dlls at runtime

# Why was it initiated? Any relevant Issues?
#3100  #2947 fixed it at one point, but it appears the dll fix was removed at some point. I can assure you, the minimal set of dlls are already included in the library. We fight wheel size constantly, so if we don't absolutely need it, we don't have it. I don't know why nuitka isn't detecting runtime dll usage correctly, but we haven't been able to recommend nuitka for over a year to users because it hasn't been able to be used at all without manually copying dlls. User shouldn't have to go through that effort, especially when there are other tools that don't have that problem and it's more seamless for the user. In the case of pygame(-ce), it's just safest to include all the dlls. Yeah, in the absolute minimum examples, you'll have some bloat (when you don't load any images, you don't need libpng), but that's the literal best case scenario. Real use-cases use pretty much all of the dlls we include in our wheels.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Fix the regression from #3100 by re-adding missing DLL inclusion for the pygame plugin and updating its checksum.

Bug Fixes:
- Restore missing DLL inclusion in the pygame plugin configuration to prevent runtime failures.

Enhancements:
- Update the pygame module checksum to match the revised plugin configuration.