### PR TITLE
include dll of tensorrt_libs correctly on windows

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -7732,6 +7732,11 @@
         prefixes:
           - 'libnv'
       dest_path: '.'
+      when: 'not win32'
+    - from_filenames:
+        prefixes:
+          - 'nv'
+      when: 'win32'
 
 - module-name: 'text_unidecode' # checksum: db822b99
   data-files:


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?
on windows, tensorrt_libs dlls cannot be included

# Why was it initiated? Any relevant Issues?

fix #3438

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Include TensorRT DLLs prefixed with 'nv' on Windows in the standard plugin configuration