### PR TITLE
Fix PEP 695 generic types

### DIFF
--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -347,7 +347,10 @@ PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {
 
     PyObject *result = CALL_FUNCTION_WITH_ARGS2(tstate, called, args);
     Py_DECREF(unpacked_params);
-    return result;
+    PyObject *tuple = PyTuple_New(1);
+    CHECK_OBJECT(tuple);
+    PyTuple_SET_ITEM(tuple, 1, result);
+    return tuple;
 }
 
 #endif

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -354,11 +354,9 @@ PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {
     PyObject *called = (PyObject *)_getTypeGenericAliasType();
 
     PyObject *result = CALL_FUNCTION_WITH_ARGS2(tstate, called, args);
-    _PyObject_Dump(result);
     Py_DECREF(unpacked_params);
     PyObject *tuple = PyTuple_New(1);
     CHECK_OBJECT(tuple);
-    //_PyObject_Dump(result);
     PyTuple_SET_ITEM(tuple, 0, result);
     return tuple;
 }

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -280,10 +280,10 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
 
     if (type_generic_alias_type == NULL) {
 
-        PyObject *typing_module = PyImport_ImportModule("_typing");
-        CHECK_OBJECT(typing_module);
+        PyObject *types_module = PyImport_ImportModule("types");
+        CHECK_OBJECT(types_module);
 
-        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(typing_module, "_GenericAlias");
+        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "GenericAlias");
         CHECK_OBJECT(type_generic_alias_type);
     }
 
@@ -302,6 +302,7 @@ PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {
     CHECK_OBJECT(params);
     PyObject *unpacked_params = _Nuitka_unpack_typevartuples(params);
     CHECK_OBJECT(unpacked_params);
+    assert(PyTuple_CheckExact(unpacked_params));
 
     PyObject *args[2] = {(PyObject *)tstate->interp->cached_objects.generic_type, unpacked_params};
 

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -232,6 +232,10 @@ typedef struct {
     PyObject *evaluate_bound;
     PyObject *constraints;
     PyObject *evaluate_constraints;
+#if PYTHON_VERSION >= 0x3d0
+    PyObject *default_value;
+    PyObject *evaluate_default;
+#endif
     bool covariant;
     bool contravariant;
     bool infer_variance;
@@ -250,6 +254,10 @@ static typevarobject *_Nuitka_typevar_alloc(PyThreadState *tstate, PyObject *nam
     result->evaluate_bound = Py_XNewRef(evaluate_bound);
     result->constraints = Py_XNewRef(constraints);
     result->evaluate_constraints = Py_XNewRef(evaluate_constraints);
+#if PYTHON_VERSION >= 0x3d0
+    result->default_value = NULL;
+    result->evaluate_default = NULL;
+#endif
 
     result->covariant = covariant;
     result->contravariant = contravariant;
@@ -346,10 +354,12 @@ PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {
     PyObject *called = (PyObject *)_getTypeGenericAliasType();
 
     PyObject *result = CALL_FUNCTION_WITH_ARGS2(tstate, called, args);
+    _PyObject_Dump(result);
     Py_DECREF(unpacked_params);
     PyObject *tuple = PyTuple_New(1);
     CHECK_OBJECT(tuple);
-    PyTuple_SET_ITEM(tuple, 1, result);
+    //_PyObject_Dump(result);
+    PyTuple_SET_ITEM(tuple, 0, result);
     return tuple;
 }
 

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -298,9 +298,7 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
     return type_generic_alias_type;
 }
 
-static int
-_Nuitka_contains_typevartuple(PyTupleObject *params)
-{
+static int _Nuitka_contains_typevartuple(PyTupleObject *params) {
     Py_ssize_t n = PyTuple_GET_SIZE(params);
     PyTypeObject *tp = PyInterpreterState_Get()->cached_objects.typevartuple_type;
     for (Py_ssize_t i = 0; i < n; i++) {
@@ -331,14 +329,12 @@ static PyObject *_Nuitka_unpack_typevartuples(PyObject *params) {
                     return NULL;
                 }
                 PyTuple_SET_ITEM(new_params, i, unpacked);
-            }
-            else {
+            } else {
                 PyTuple_SET_ITEM(new_params, i, Py_NewRef(param));
             }
         }
         return new_params;
-    }
-    else {
+    } else {
         return Py_NewRef(params);
     }
 }

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -290,12 +290,49 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
     return type_generic_alias_type;
 }
 
+static int
+_Nuitka_contains_typevartuple(PyTupleObject *params)
+{
+    Py_ssize_t n = PyTuple_GET_SIZE(params);
+    PyTypeObject *tp = PyInterpreterState_Get()->cached_objects.typevartuple_type;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyObject *param = PyTuple_GET_ITEM(params, i);
+        if (Py_IS_TYPE(param, tp)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static PyObject *_Nuitka_unpack_typevartuples(PyObject *params) {
     assert(PyTuple_Check(params));
-
-    // TODO: Not implemented yet.
-
-    return Py_NewRef(params);
+    // TypeVarTuple must be unpacked when passed to Generic, so we do that here.
+    if (_Nuitka_contains_typevartuple((PyTupleObject *)params)) {
+        Py_ssize_t n = PyTuple_GET_SIZE(params);
+        PyObject *new_params = PyTuple_New(n);
+        if (new_params == NULL) {
+            return NULL;
+        }
+        PyTypeObject *tp = PyInterpreterState_Get()->cached_objects.typevartuple_type;
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyObject *param = PyTuple_GET_ITEM(params, i);
+            if (Py_IS_TYPE(param, tp)) {
+                PyObject *unpacked = _Nuitka_unpack_typevartuples(param);
+                if (unpacked == NULL) {
+                    Py_DECREF(new_params);
+                    return NULL;
+                }
+                PyTuple_SET_ITEM(new_params, i, unpacked);
+            }
+            else {
+                PyTuple_SET_ITEM(new_params, i, Py_NewRef(param));
+            }
+        }
+        return new_params;
+    }
+    else {
+        return Py_NewRef(params);
+    }
 }
 
 PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -288,8 +288,7 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
 
     if (type_generic_alias_type == NULL) {
 
-        PyObject *types_module = PyImport_ImportModule("types");
-        CHECK_OBJECT(types_module);
+        PyObject *types_module = IMPORT_HARD_TYPES();
 
         type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "GenericAlias");
         CHECK_OBJECT(type_generic_alias_type);

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -355,10 +355,8 @@ PyObject *MAKE_TYPE_GENERIC(PyThreadState *tstate, PyObject *params) {
 
     PyObject *result = CALL_FUNCTION_WITH_ARGS2(tstate, called, args);
     Py_DECREF(unpacked_params);
-    PyObject *tuple = PyTuple_New(1);
-    CHECK_OBJECT(tuple);
-    PyTuple_SET_ITEM(tuple, 0, result);
-    return tuple;
+
+    return MAKE_TUPLE1_0(tstate, result);
 }
 
 #endif

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -279,30 +279,6 @@ def buildClassNode3(provider, node, source_ref):
             )
         )
 
-    if type_params_expressions:
-        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
-        statements.append(
-            makeStatementAssignmentVariable(
-                variable=tmp_type_params,
-                source=makeExpressionMakeTuple(
-                    elements=type_params_expressions,
-                    source_ref=source_ref,
-                ),
-                source_ref=source_ref
-            )
-        )
-        statements.append(
-            StatementAssignmentVariableName(
-                provider=class_creation_function,
-                variable_name="__type_params__",
-                source=ExpressionTempVariableRef(
-                    variable=tmp_type_params,
-                    source_ref=source_ref
-                ),
-                source_ref=source_ref,
-            )
-        )
-
     if class_doc is not None:
         statements.append(
             StatementAssignmentVariableName(
@@ -462,6 +438,30 @@ def buildClassNode3(provider, node, source_ref):
         )
 
     statements = []
+
+    if type_params_expressions:
+        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
+        statements.append(
+            makeStatementAssignmentVariable(
+                variable=tmp_type_params,
+                source=makeExpressionMakeTuple(
+                    elements=type_params_expressions,
+                    source_ref=source_ref,
+                ),
+                source_ref=source_ref
+            )
+        )
+        statements.append(
+            StatementAssignmentVariableName(
+                provider=class_creation_function,
+                variable_name="__type_params__",
+                source=ExpressionTempVariableRef(
+                    variable=tmp_type_params,
+                    source_ref=source_ref
+                ),
+                source_ref=source_ref,
+            )
+        )
 
     if has_bases:
         bases_value = _buildBasesTupleCreationNode(

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -274,24 +274,20 @@ def buildClassNode3(provider, node, source_ref):
         statements.append(
             makeStatementAssignmentVariable(
                 variable=type_variable,
-                source=type_params_expression,
+                source=type_params_expression.makeClone(),
                 source_ref=source_ref,
             )
         )
 
     if type_params_expressions:
+        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
         statements.append(
             StatementAssignmentVariableName(
                 provider=class_creation_function,
                 variable_name="__type_params__",
-                source=makeExpressionMakeTuple(
-                    elements=tuple(
-                        ExpressionVariableRef(
-                            variable=type_variable, source_ref=source_ref
-                        )
-                        for type_variable in type_variables
-                    ),
-                    source_ref=source_ref,
+                source=ExpressionTempVariableRef(
+                    variable=tmp_type_params,
+                    source_ref=source_ref
                 ),
                 source_ref=source_ref,
             )
@@ -458,27 +454,33 @@ def buildClassNode3(provider, node, source_ref):
     statements = []
 
     if has_bases:
-        if node.bases:
-            bases_value = _buildBasesTupleCreationNode(
-                provider=provider, elements=node.bases, source_ref=source_ref
-            )
+        bases_value = _buildBasesTupleCreationNode(
+            provider=provider, elements=node.bases, source_ref=source_ref
+        )
 
-            if type_params_expressions:
-                bases_value = makeBinaryOperationNode(
-                    operator="Add",
-                    left=bases_value,
-                    right=ExpressionTypeMakeGeneric(
-                        type_params=ExpressionVariableNameRef(
-                            provider=class_creation_function,
-                            variable_name="__type_params__",
-                            source_ref=source_ref,
-                        ),
+        if type_params_expressions:
+            statements.append(
+                makeStatementAssignmentVariable(
+                    variable=tmp_type_params,
+                    source=makeExpressionMakeTuple(
+                        elements=type_params_expressions,
+                        source_ref=source_ref,
+                    ),
+                    source_ref=source_ref
+                )
+            )
+            bases_value = makeBinaryOperationNode(
+                operator="Add",
+                left=bases_value,
+                right=ExpressionTypeMakeGeneric(
+                    type_params=ExpressionTempVariableRef(
+                        variable=tmp_type_params,
                         source_ref=source_ref,
                     ),
                     source_ref=source_ref,
-                )
-        else:
-            assert False
+                ),
+                source_ref=source_ref,
+            )
 
         statements.append(
             makeStatementAssignmentVariable(
@@ -744,6 +746,8 @@ def buildClassNode3(provider, node, source_ref):
         tmp_variables.insert(0, tmp_bases)
         if needs_orig_bases:
             tmp_variables.insert(0, tmp_bases_orig)
+    if type_params_expressions:
+        tmp_variables.append(tmp_type_params)
 
     return makeTryFinallyReleaseStatement(
         provider=provider,

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -403,6 +403,32 @@ def buildClassNode3(provider, node, source_ref):
         StatementReturn(expression=class_variable_ref, source_ref=source_ref),
     )
 
+
+    new_statements = []
+    if type_params_expressions:
+        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
+        new_statements.append(
+            makeStatementAssignmentVariable(
+                variable=tmp_type_params,
+                source=makeExpressionMakeTuple(
+                    elements=type_params_expressions,
+                    source_ref=source_ref,
+                ),
+                source_ref=source_ref
+            )
+        )
+        statements.append(
+            StatementAssignmentVariableName(
+                provider=class_creation_function,
+                variable_name="__type_params__",
+                source=ExpressionTempVariableRef(
+                    variable=tmp_type_params,
+                    source_ref=source_ref
+                ),
+                source_ref=source_ref,
+            )
+        )
+
     # TODO: Is this something similar to makeTryFinallyReleaseStatement
     body = makeStatementsSequenceFromStatement(
         statement=makeTryFinallyStatement(
@@ -437,31 +463,8 @@ def buildClassNode3(provider, node, source_ref):
             source_ref=decorator.getSourceReference(),
         )
 
-    statements = []
 
-    if type_params_expressions:
-        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
-        statements.append(
-            makeStatementAssignmentVariable(
-                variable=tmp_type_params,
-                source=makeExpressionMakeTuple(
-                    elements=type_params_expressions,
-                    source_ref=source_ref,
-                ),
-                source_ref=source_ref
-            )
-        )
-        statements.append(
-            StatementAssignmentVariableName(
-                provider=class_creation_function,
-                variable_name="__type_params__",
-                source=ExpressionTempVariableRef(
-                    variable=tmp_type_params,
-                    source_ref=source_ref
-                ),
-                source_ref=source_ref,
-            )
-        )
+    statements = new_statements
 
     if has_bases:
         bases_value = _buildBasesTupleCreationNode(

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -282,6 +282,16 @@ def buildClassNode3(provider, node, source_ref):
     if type_params_expressions:
         tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
         statements.append(
+            makeStatementAssignmentVariable(
+                variable=tmp_type_params,
+                source=makeExpressionMakeTuple(
+                    elements=type_params_expressions,
+                    source_ref=source_ref,
+                ),
+                source_ref=source_ref
+            )
+        )
+        statements.append(
             StatementAssignmentVariableName(
                 provider=class_creation_function,
                 variable_name="__type_params__",
@@ -459,16 +469,6 @@ def buildClassNode3(provider, node, source_ref):
         )
 
         if type_params_expressions:
-            statements.append(
-                makeStatementAssignmentVariable(
-                    variable=tmp_type_params,
-                    source=makeExpressionMakeTuple(
-                        elements=type_params_expressions,
-                        source_ref=source_ref,
-                    ),
-                    source_ref=source_ref
-                )
-            )
             bases_value = makeBinaryOperationNode(
                 operator="Add",
                 left=bases_value,

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -403,10 +403,11 @@ def buildClassNode3(provider, node, source_ref):
         StatementReturn(expression=class_variable_ref, source_ref=source_ref),
     )
 
-
     new_statements = []
     if type_params_expressions:
-        tmp_type_params = provider.allocateTempVariable(temp_scope=temp_scope, name="type_params", temp_type="object")
+        tmp_type_params = provider.allocateTempVariable(
+            temp_scope=temp_scope, name="type_params", temp_type="object"
+        )
         new_statements.append(
             makeStatementAssignmentVariable(
                 variable=tmp_type_params,
@@ -414,7 +415,7 @@ def buildClassNode3(provider, node, source_ref):
                     elements=type_params_expressions,
                     source_ref=source_ref,
                 ),
-                source_ref=source_ref
+                source_ref=source_ref,
             )
         )
         statements.append(
@@ -422,8 +423,7 @@ def buildClassNode3(provider, node, source_ref):
                 provider=class_creation_function,
                 variable_name="__type_params__",
                 source=ExpressionTempVariableRef(
-                    variable=tmp_type_params,
-                    source_ref=source_ref
+                    variable=tmp_type_params, source_ref=source_ref
                 ),
                 source_ref=source_ref,
             )
@@ -462,7 +462,6 @@ def buildClassNode3(provider, node, source_ref):
             kw=None,
             source_ref=decorator.getSourceReference(),
         )
-
 
     statements = new_statements
 


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Fix support for PEP 695 generics including TypeVar default values and variadic type variable unpacking, update generic alias handling, and adjust class node rewriting to clone and pass type parameters via temporaries.

Enhancements:
- Clone type parameter expressions instead of reusing nodes and assign them via temporary variables during class creation
- Add default_value and evaluate_default fields for TypeVar objects and switch to using types.GenericAlias for PEP 695
- Implement recursive unpacking of TypeVarTuple parameters in MAKE_TYPE_GENERIC and return the result wrapped in a tuple
- Minor lint fix in Progress download bar attribute assignment