### PR TITLE
Add missing data file for `rfc3987_syntax` package

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -5527,6 +5527,11 @@
         - 'urllib.request'
         - 'urllib.response'
 
+- module-name: 'rfc3987_syntax' # checksum: 3c40bffc
+  data-files:
+    - patterns:
+        - 'syntax_rfc3987.lark'
+
 - module-name: 'rich.jupyter' # checksum: b346e77
   anti-bloat:
     - description: 'remove IPython reference'


### PR DESCRIPTION
# What does this PR do?

Adds the [`syntax_rfc3987.lark` file](https://github.com/willynilly/rfc3987-syntax/blob/main/src/rfc3987_syntax/syntax_rfc3987.lark) of the [`rfc3987-syntax`](https://github.com/willynilly/rfc3987-syntax/) package which is [imported dynamically](https://github.com/willynilly/rfc3987-syntax/blob/b818cbd023c05f968617606ec8af2fb5067e1b03/src/rfc3987_syntax/syntax_helpers.py#L8) and is not embedded naturally by Nuitka. Probably because it is not properly declared as a non-Python resource in the package metadata.

# Why was it initiated? Any relevant Issues?

I stumble upon this [issue while trying to make a standalone executable](https://github.com/kdeldycke/meta-package-manager/actions/runs/17094273072/job/48477036091#step:6:569) of my [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) project, which depends on [`cyclonedx`](cyclonedx-python-lib).

This library itself depends on [`jsonschema`](https://github.com/python-jsonschema/jsonschema), which added a new dependency on `rfc3987-syntax` last month. See:
- https://github.com/python-jsonschema/jsonschema/issues/1387
- https://github.com/python-jsonschema/jsonschema/pull/1388

When compiled with the `--onefile` option, the resulting binary always ends up with this traceback:
```pytb

  Traceback (most recent call last):
    File "/tmp/onefile_2174_1755683612_684632/__main__.py", line 26, in <module>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/meta_package_manager/cli.py", line 76, in <module meta_package_manager.cli>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/meta_package_manager/sbom.py", line 40, in <module meta_package_manager.sbom>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/cyclonedx/validation/json.py", line 38, in <module cyclonedx.validation.json>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/jsonschema/__init__.py", line 13, in <module jsonschema>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/jsonschema/_format.py", line 328, in <module jsonschema._format>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/rfc3987_syntax/__init__.py", line 1, in <module rfc3987_syntax>
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
    File "/tmp/onefile_2174_1755683612_684632/rfc3987_syntax/syntax_helpers.py", line 48, in <module rfc3987_syntax.syntax_helpers>
    File "/tmp/onefile_2174_1755683612_684632/rfc3987_syntax/utils.py", line 5, in load_grammar
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/onefile_2174_1755683612_684632/rfc3987_syntax/syntax_rfc3987.lark'
```

Which hints at missing static resources files `rfc3987-syntax` relies on. 

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

CC to `rfc3987-syntax` author and `jsonschema` contributor: @willynilly @jkowalleck

## Summary by Sourcery

Bug Fixes:
- Add a data-files entry for module rfc3987_syntax in standard.nuitka-package.config.yml to include syntax_rfc3987.lark