### PR TITLE
Windows: fix DLL search path selection in _attemptToFindNotFoundDLL

### DIFF
--- a/nuitka/freezer/DependsExe.py
+++ b/nuitka/freezer/DependsExe.py
@@ -72,7 +72,7 @@ def _attemptToFindNotFoundDLL(dll_filename):
     # Lets try the Windows system, spell-checker: ignore systemroot
     dll_filename = os.path.join(
         os.environ["SYSTEMROOT"],
-        "SysWOW64" if getArchitecture() == "x86_64" else "System32",
+        "System32" if getArchitecture() == "x86_64" else "SysWOW64",
         dll_filename,
     )
     dll_filename = os.path.normcase(dll_filename)


### PR DESCRIPTION
# What does this PR do?

Corrects the directory choice for DLL lookup on Windows: System32 for x86_64, SysWOW64 for x86.

# Why was it initiated? Any relevant Issues?

While investigating #3583 I noticed that this was inverted.

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Bug Fixes:
- Use System32 for x86_64 and SysWOW64 for x86 in _attemptToFindNotFoundDLL on Windows instead of the reverse mapping