### PR TITLE
Add support for Fast-SSIM package

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -1527,6 +1527,19 @@
     - depends:
         - '.response_helpers'
 
+- module-name: 'fast_ssim' # checksum: 2124d51b
+  dlls:
+    - from_filenames:
+        relative_path: 'resources'
+        prefixes:
+          - 'ssim'
+      when: 'win32'
+    - from_filenames:
+        relative_path: 'resources'
+        prefixes:
+          - 'libssim'
+      when: 'linux'
+
 - module-name: 'fastapi' # checksum: 583d2408
   implicit-imports:
     - depends:


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the Fast-SSIM package that can be installed via `pip install Fast-SSIM`.

# Why was it initiated? Any relevant Issues?

None

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [x] Ideally new features or fixed regressions ought to be covered via new tests.
- [x] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Add support for the Fast-SSIM package by including it in the standard Nuitka plugin configuration and bundling its platform-specific shared libraries.

New Features:
- Include Fast-SSIM as a module in the standard plugin config
- Bundle Fast-SSIM shared libraries from the 'resources' directory for Windows (ssim*) and Linux (libssim*)