### PR TITLE
Fix PEP 695 type alias syntax

### DIFF
--- a/nuitka/code_generation/TypeAliasCodes.py
+++ b/nuitka/code_generation/TypeAliasCodes.py
@@ -47,7 +47,7 @@ def generateTypeAliasCode(to_name, expression, emit, context):
 
         getErrorExitCode(
             check_name=value_name,
-            release_names=(type_alias_name, compute_value_name),
+            release_names=(type_alias_name, compute_value_name, type_params_name),
             emit=emit,
             context=context,
             needs_check=expression.mayRaiseExceptionOperation(),

--- a/nuitka/code_generation/TypeAliasCodes.py
+++ b/nuitka/code_generation/TypeAliasCodes.py
@@ -26,10 +26,7 @@ def generateTypeAliasCode(to_name, expression, emit, context):
         expression=expression.subnode_value, emit=emit, context=context
     )
 
-    assert (
-        expression.getParent().isStatementAssignmentVariable()
-    ), expression.getParent()
-    type_alias_name = expression.getParent().getVariableName()
+    type_alias_name = expression.subnode_name.getVariableName()
 
     with withObjectCodeTemporaryAssignment(
         to_name, "type_alias_value", expression, emit, context

--- a/nuitka/nodes/AttributeNodesGenerated.py
+++ b/nuitka/nodes/AttributeNodesGenerated.py
@@ -10716,18 +10716,3 @@ class ExpressionAttributeLookupBytesZfill(
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupBytesZfill)
-
-#     Part of "Nuitka", an optimizing Python compiler that is compatible and
-#     integrates with CPython, but also works on its own.
-#
-#     Licensed under the Apache License, Version 2.0 (the "License");
-#     you may not use this file except in compliance with the License.
-#     You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.

--- a/nuitka/nodes/AttributeNodesGenerated.py
+++ b/nuitka/nodes/AttributeNodesGenerated.py
@@ -1,5 +1,6 @@
 #     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
 
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -10716,3 +10717,18 @@ class ExpressionAttributeLookupBytesZfill(
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupBytesZfill)
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
+++ b/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
@@ -7348,19 +7348,3 @@ class ExpressionBytesOperationZfillBase(
     @abstractmethod
     def mayRaiseExceptionOperation(self):
         """Does the operation part raise an exception possibly."""
-
-
-#     Part of "Nuitka", an optimizing Python compiler that is compatible and
-#     integrates with CPython, but also works on its own.
-#
-#     Licensed under the Apache License, Version 2.0 (the "License");
-#     you may not use this file except in compliance with the License.
-#     You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.

--- a/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
+++ b/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
@@ -1,5 +1,6 @@
 #     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
 
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -7348,3 +7349,19 @@ class ExpressionBytesOperationZfillBase(
     @abstractmethod
     def mayRaiseExceptionOperation(self):
         """Does the operation part raise an exception possibly."""
+
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/ChildrenHavingMixins.py
+++ b/nuitka/nodes/ChildrenHavingMixins.py
@@ -1,3 +1,6 @@
+#     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -21575,3 +21578,18 @@ class ChildHavingValuesTupleMixin(object):
 
 # Assign the names that are easier to import with a stable name.
 ChildrenExpressionStringConcatenationMixin = ChildHavingValuesTupleMixin
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/ChildrenHavingMixins.py
+++ b/nuitka/nodes/ChildrenHavingMixins.py
@@ -12583,6 +12583,161 @@ ChildrenExpressionImportlibImportModuleCallMixin = (
 )
 
 
+class ChildrenHavingNameTypeParamsTupleValueMixin(object):
+    # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
+    __slots__ = ()
+
+    # This is generated for use in
+    #   ExpressionTypeAlias
+
+    def __init__(
+        self,
+        name,
+        type_params,
+        value,
+    ):
+        name.parent = self
+
+        self.subnode_name = name
+
+        assert type(type_params) is tuple
+
+        for val in type_params:
+            val.parent = self
+
+        self.subnode_type_params = type_params
+
+        value.parent = self
+
+        self.subnode_value = value
+
+    def getVisitableNodes(self):
+        """The visitable nodes, with tuple values flattened."""
+
+        result = []
+        result.append(self.subnode_name)
+        result.extend(self.subnode_type_params)
+        result.append(self.subnode_value)
+        return tuple(result)
+
+    def getVisitableNodesNamed(self):
+        """Named children dictionary.
+
+        For use in cloning nodes, debugging and XML output.
+        """
+
+        return (
+            ("name", self.subnode_name),
+            ("type_params", self.subnode_type_params),
+            ("value", self.subnode_value),
+        )
+
+    def replaceChild(self, old_node, new_node):
+        value = self.subnode_name
+        if old_node is value:
+            new_node.parent = self
+
+            self.subnode_name = new_node
+
+            return
+
+        value = self.subnode_type_params
+        if old_node in value:
+            if new_node is not None:
+                new_node.parent = self
+
+                self.subnode_type_params = tuple(
+                    (val if val is not old_node else new_node) for val in value
+                )
+            else:
+                self.subnode_type_params = tuple(
+                    val for val in value if val is not old_node
+                )
+
+            return
+
+        value = self.subnode_value
+        if old_node is value:
+            new_node.parent = self
+
+            self.subnode_value = new_node
+
+            return
+
+        raise AssertionError("Didn't find child", old_node, "in", self)
+
+    def getCloneArgs(self):
+        """Get clones of all children to pass for a new node.
+
+        Needs to make clones of child nodes too.
+        """
+
+        values = {
+            "name": self.subnode_name.makeClone(),
+            "type_params": tuple(v.makeClone() for v in self.subnode_type_params),
+            "value": self.subnode_value.makeClone(),
+        }
+
+        values.update(self.getDetails())
+
+        return values
+
+    def finalize(self):
+        del self.parent
+
+        self.subnode_name.finalize()
+        del self.subnode_name
+        for c in self.subnode_type_params:
+            c.finalize()
+        del self.subnode_type_params
+        self.subnode_value.finalize()
+        del self.subnode_value
+
+    def computeExpressionRaw(self, trace_collection):
+        """Compute an expression.
+
+        Default behavior is to just visit the child expressions first, and
+        then the node "computeExpression". For a few cases this needs to
+        be overloaded, e.g. conditional expressions.
+        """
+
+        # First apply the sub-expressions, as they are evaluated before
+        # the actual operation.
+        for count, sub_expression in enumerate(self.getVisitableNodes()):
+            expression = trace_collection.onExpression(sub_expression)
+
+            if expression.willRaiseAnyException():
+                sub_expressions = self.getVisitableNodes()
+
+                wrapped_expression = wrapExpressionWithSideEffects(
+                    side_effects=sub_expressions[:count],
+                    old_node=sub_expression,
+                    new_node=expression,
+                )
+
+                return (
+                    wrapped_expression,
+                    "new_raise",
+                    lambda: "For '%s' the child expression '%s' will raise."
+                    % (self.getChildNameNice(), expression.getChildNameNice()),
+                )
+
+        # Then ask ourselves to work on it.
+        return self.computeExpression(trace_collection)
+
+    def collectVariableAccesses(self, emit_read, emit_write):
+        """Collect variable reads and writes of child nodes."""
+
+        self.subnode_name.collectVariableAccesses(emit_read, emit_write)
+        for element in self.subnode_type_params:
+            element.collectVariableAccesses(emit_read, emit_write)
+        self.subnode_value.collectVariableAccesses(emit_read, emit_write)
+
+
+# Assign the names that are easier to import with a stable name.
+ChildrenExpressionTypeAliasMixin = ChildrenHavingNameTypeParamsTupleValueMixin
+
+
 class ChildHavingOperandMixin(object):
     # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
     __slots__ = ()
@@ -20539,142 +20694,6 @@ class ChildHavingTypeParamsMixin(object):
 
 # Assign the names that are easier to import with a stable name.
 ChildrenExpressionTypeMakeGenericMixin = ChildHavingTypeParamsMixin
-
-
-class ChildrenHavingTypeParamsTupleValueMixin(object):
-    # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
-    __slots__ = ()
-
-    # This is generated for use in
-    #   ExpressionTypeAlias
-
-    def __init__(
-        self,
-        type_params,
-        value,
-    ):
-        assert type(type_params) is tuple
-
-        for val in type_params:
-            val.parent = self
-
-        self.subnode_type_params = type_params
-
-        value.parent = self
-
-        self.subnode_value = value
-
-    def getVisitableNodes(self):
-        """The visitable nodes, with tuple values flattened."""
-
-        result = []
-        result.extend(self.subnode_type_params)
-        result.append(self.subnode_value)
-        return tuple(result)
-
-    def getVisitableNodesNamed(self):
-        """Named children dictionary.
-
-        For use in cloning nodes, debugging and XML output.
-        """
-
-        return (
-            ("type_params", self.subnode_type_params),
-            ("value", self.subnode_value),
-        )
-
-    def replaceChild(self, old_node, new_node):
-        value = self.subnode_type_params
-        if old_node in value:
-            if new_node is not None:
-                new_node.parent = self
-
-                self.subnode_type_params = tuple(
-                    (val if val is not old_node else new_node) for val in value
-                )
-            else:
-                self.subnode_type_params = tuple(
-                    val for val in value if val is not old_node
-                )
-
-            return
-
-        value = self.subnode_value
-        if old_node is value:
-            new_node.parent = self
-
-            self.subnode_value = new_node
-
-            return
-
-        raise AssertionError("Didn't find child", old_node, "in", self)
-
-    def getCloneArgs(self):
-        """Get clones of all children to pass for a new node.
-
-        Needs to make clones of child nodes too.
-        """
-
-        values = {
-            "type_params": tuple(v.makeClone() for v in self.subnode_type_params),
-            "value": self.subnode_value.makeClone(),
-        }
-
-        values.update(self.getDetails())
-
-        return values
-
-    def finalize(self):
-        del self.parent
-
-        for c in self.subnode_type_params:
-            c.finalize()
-        del self.subnode_type_params
-        self.subnode_value.finalize()
-        del self.subnode_value
-
-    def computeExpressionRaw(self, trace_collection):
-        """Compute an expression.
-
-        Default behavior is to just visit the child expressions first, and
-        then the node "computeExpression". For a few cases this needs to
-        be overloaded, e.g. conditional expressions.
-        """
-
-        # First apply the sub-expressions, as they are evaluated before
-        # the actual operation.
-        for count, sub_expression in enumerate(self.getVisitableNodes()):
-            expression = trace_collection.onExpression(sub_expression)
-
-            if expression.willRaiseAnyException():
-                sub_expressions = self.getVisitableNodes()
-
-                wrapped_expression = wrapExpressionWithSideEffects(
-                    side_effects=sub_expressions[:count],
-                    old_node=sub_expression,
-                    new_node=expression,
-                )
-
-                return (
-                    wrapped_expression,
-                    "new_raise",
-                    lambda: "For '%s' the child expression '%s' will raise."
-                    % (self.getChildNameNice(), expression.getChildNameNice()),
-                )
-
-        # Then ask ourselves to work on it.
-        return self.computeExpression(trace_collection)
-
-    def collectVariableAccesses(self, emit_read, emit_write):
-        """Collect variable reads and writes of child nodes."""
-
-        for element in self.subnode_type_params:
-            element.collectVariableAccesses(emit_read, emit_write)
-        self.subnode_value.collectVariableAccesses(emit_read, emit_write)
-
-
-# Assign the names that are easier to import with a stable name.
-ChildrenExpressionTypeAliasMixin = ChildrenHavingTypeParamsTupleValueMixin
 
 
 class ChildHavingValueMixin(object):

--- a/nuitka/nodes/ExpressionBasesGenerated.py
+++ b/nuitka/nodes/ExpressionBasesGenerated.py
@@ -31,6 +31,7 @@ spell-checker: ignore winmode zfill
 
 # Loop unrolling over child names, pylint: disable=too-many-branches
 
+
 from abc import abstractmethod
 
 from .ExpressionBases import ExpressionBase
@@ -2209,153 +2210,17 @@ class ChildHavingValueFinalNoRaiseMixin(ExpressionBase):
 ExpressionBuiltinClassmethodBase = ChildHavingValueFinalNoRaiseMixin
 ExpressionBuiltinStaticmethodBase = ChildHavingValueFinalNoRaiseMixin
 
-
-class ChildrenHavingValueFormatSpecOptionalConversionStrValueMixin(ExpressionBase):
-    # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
-    __slots__ = ()
-
-    # This is generated for use in
-    #   ExpressionTemplateInterpolation
-
-    def __init__(self, value, format_spec, str_value, conversion, source_ref):
-        value.parent = self
-
-        self.subnode_value = value
-
-        if format_spec is not None:
-            format_spec.parent = self
-
-        self.subnode_format_spec = format_spec
-
-        self.str_value = str_value
-        self.conversion = conversion
-
-        ExpressionBase.__init__(self, source_ref)
-
-    def getDetails(self):
-        return {
-            "str_value": self.str_value,
-            "conversion": self.conversion,
-        }
-
-    def getVisitableNodes(self):
-        """The visitable nodes, with tuple values flattened."""
-
-        result = []
-        result.append(self.subnode_value)
-        value = self.subnode_format_spec
-        if value is None:
-            pass
-        else:
-            result.append(value)
-        return tuple(result)
-
-    def getVisitableNodesNamed(self):
-        """Named children dictionary.
-
-        For use in cloning nodes, debugging and XML output.
-        """
-
-        return (
-            ("value", self.subnode_value),
-            ("format_spec", self.subnode_format_spec),
-        )
-
-    def replaceChild(self, old_node, new_node):
-        value = self.subnode_value
-        if old_node is value:
-            new_node.parent = self
-
-            self.subnode_value = new_node
-
-            return
-
-        value = self.subnode_format_spec
-        if old_node is value:
-            if new_node is not None:
-                new_node.parent = self
-
-            self.subnode_format_spec = new_node
-
-            return
-
-        raise AssertionError("Didn't find child", old_node, "in", self)
-
-    def getCloneArgs(self):
-        """Get clones of all children to pass for a new node.
-
-        Needs to make clones of child nodes too.
-        """
-
-        values = {
-            "value": self.subnode_value.makeClone(),
-            "format_spec": (
-                self.subnode_format_spec.makeClone()
-                if self.subnode_format_spec is not None
-                else None
-            ),
-        }
-
-        values.update(self.getDetails())
-
-        return values
-
-    def finalize(self):
-        del self.parent
-
-        self.subnode_value.finalize()
-        del self.subnode_value
-        if self.subnode_format_spec is not None:
-            self.subnode_format_spec.finalize()
-        del self.subnode_format_spec
-
-    def computeExpressionRaw(self, trace_collection):
-        """Compute an expression.
-
-        Default behavior is to just visit the child expressions first, and
-        then the node "computeExpression". For a few cases this needs to
-        be overloaded, e.g. conditional expressions.
-        """
-
-        # First apply the sub-expressions, as they are evaluated before
-        # the actual operation.
-        for count, sub_expression in enumerate(self.getVisitableNodes()):
-            expression = trace_collection.onExpression(sub_expression)
-
-            if expression.willRaiseAnyException():
-                sub_expressions = self.getVisitableNodes()
-
-                wrapped_expression = wrapExpressionWithSideEffects(
-                    side_effects=sub_expressions[:count],
-                    old_node=sub_expression,
-                    new_node=expression,
-                )
-
-                return (
-                    wrapped_expression,
-                    "new_raise",
-                    lambda: "For '%s' the child expression '%s' will raise."
-                    % (self.getChildNameNice(), expression.getChildNameNice()),
-                )
-
-        # Then ask ourselves to work on it.
-        return self.computeExpression(trace_collection)
-
-    @abstractmethod
-    def computeExpression(self, trace_collection):
-        """Must be overloaded for non-final node."""
-
-    def collectVariableAccesses(self, emit_read, emit_write):
-        """Collect variable reads and writes of child nodes."""
-
-        self.subnode_value.collectVariableAccesses(emit_read, emit_write)
-        subnode_format_spec = self.subnode_format_spec
-
-        if subnode_format_spec is not None:
-            self.subnode_format_spec.collectVariableAccesses(emit_read, emit_write)
-
-
-# Assign the names that are easier to import with a stable name.
-ExpressionTemplateInterpolationBase = (
-    ChildrenHavingValueFormatSpecOptionalConversionStrValueMixin
-)
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/ExpressionBasesGenerated.py
+++ b/nuitka/nodes/ExpressionBasesGenerated.py
@@ -1,3 +1,6 @@
+#     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -2209,6 +2212,157 @@ class ChildHavingValueFinalNoRaiseMixin(ExpressionBase):
 # Assign the names that are easier to import with a stable name.
 ExpressionBuiltinClassmethodBase = ChildHavingValueFinalNoRaiseMixin
 ExpressionBuiltinStaticmethodBase = ChildHavingValueFinalNoRaiseMixin
+
+
+class ChildrenHavingValueFormatSpecOptionalConversionStrValueMixin(ExpressionBase):
+    # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
+    __slots__ = ()
+
+    # This is generated for use in
+    #   ExpressionTemplateInterpolation
+
+    def __init__(self, value, format_spec, str_value, conversion, source_ref):
+        value.parent = self
+
+        self.subnode_value = value
+
+        if format_spec is not None:
+            format_spec.parent = self
+
+        self.subnode_format_spec = format_spec
+
+        self.str_value = str_value
+        self.conversion = conversion
+
+        ExpressionBase.__init__(self, source_ref)
+
+    def getDetails(self):
+        return {
+            "str_value": self.str_value,
+            "conversion": self.conversion,
+        }
+
+    def getVisitableNodes(self):
+        """The visitable nodes, with tuple values flattened."""
+
+        result = []
+        result.append(self.subnode_value)
+        value = self.subnode_format_spec
+        if value is None:
+            pass
+        else:
+            result.append(value)
+        return tuple(result)
+
+    def getVisitableNodesNamed(self):
+        """Named children dictionary.
+
+        For use in cloning nodes, debugging and XML output.
+        """
+
+        return (
+            ("value", self.subnode_value),
+            ("format_spec", self.subnode_format_spec),
+        )
+
+    def replaceChild(self, old_node, new_node):
+        value = self.subnode_value
+        if old_node is value:
+            new_node.parent = self
+
+            self.subnode_value = new_node
+
+            return
+
+        value = self.subnode_format_spec
+        if old_node is value:
+            if new_node is not None:
+                new_node.parent = self
+
+            self.subnode_format_spec = new_node
+
+            return
+
+        raise AssertionError("Didn't find child", old_node, "in", self)
+
+    def getCloneArgs(self):
+        """Get clones of all children to pass for a new node.
+
+        Needs to make clones of child nodes too.
+        """
+
+        values = {
+            "value": self.subnode_value.makeClone(),
+            "format_spec": (
+                self.subnode_format_spec.makeClone()
+                if self.subnode_format_spec is not None
+                else None
+            ),
+        }
+
+        values.update(self.getDetails())
+
+        return values
+
+    def finalize(self):
+        del self.parent
+
+        self.subnode_value.finalize()
+        del self.subnode_value
+        if self.subnode_format_spec is not None:
+            self.subnode_format_spec.finalize()
+        del self.subnode_format_spec
+
+    def computeExpressionRaw(self, trace_collection):
+        """Compute an expression.
+
+        Default behavior is to just visit the child expressions first, and
+        then the node "computeExpression". For a few cases this needs to
+        be overloaded, e.g. conditional expressions.
+        """
+
+        # First apply the sub-expressions, as they are evaluated before
+        # the actual operation.
+        for count, sub_expression in enumerate(self.getVisitableNodes()):
+            expression = trace_collection.onExpression(sub_expression)
+
+            if expression.willRaiseAnyException():
+                sub_expressions = self.getVisitableNodes()
+
+                wrapped_expression = wrapExpressionWithSideEffects(
+                    side_effects=sub_expressions[:count],
+                    old_node=sub_expression,
+                    new_node=expression,
+                )
+
+                return (
+                    wrapped_expression,
+                    "new_raise",
+                    lambda: "For '%s' the child expression '%s' will raise."
+                    % (self.getChildNameNice(), expression.getChildNameNice()),
+                )
+
+        # Then ask ourselves to work on it.
+        return self.computeExpression(trace_collection)
+
+    @abstractmethod
+    def computeExpression(self, trace_collection):
+        """Must be overloaded for non-final node."""
+
+    def collectVariableAccesses(self, emit_read, emit_write):
+        """Collect variable reads and writes of child nodes."""
+
+        self.subnode_value.collectVariableAccesses(emit_read, emit_write)
+        subnode_format_spec = self.subnode_format_spec
+
+        if subnode_format_spec is not None:
+            self.subnode_format_spec.collectVariableAccesses(emit_read, emit_write)
+
+
+# Assign the names that are easier to import with a stable name.
+ExpressionTemplateInterpolationBase = (
+    ChildrenHavingValueFormatSpecOptionalConversionStrValueMixin
+)
 
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and
 #     integrates with CPython, but also works on its own.

--- a/nuitka/nodes/HardImportNodesGenerated.py
+++ b/nuitka/nodes/HardImportNodesGenerated.py
@@ -1,5 +1,6 @@
 #     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
 
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -3580,3 +3581,19 @@ class ExpressionTensorflowFunctionCallBase(
     @staticmethod
     def mayRaiseExceptionOperation():
         return True
+
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/HardImportNodesGenerated.py
+++ b/nuitka/nodes/HardImportNodesGenerated.py
@@ -3580,19 +3580,3 @@ class ExpressionTensorflowFunctionCallBase(
     @staticmethod
     def mayRaiseExceptionOperation():
         return True
-
-
-#     Part of "Nuitka", an optimizing Python compiler that is compatible and
-#     integrates with CPython, but also works on its own.
-#
-#     Licensed under the Apache License, Version 2.0 (the "License");
-#     you may not use this file except in compliance with the License.
-#     You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.

--- a/nuitka/nodes/StatementBasesGenerated.py
+++ b/nuitka/nodes/StatementBasesGenerated.py
@@ -1,3 +1,6 @@
+#     Copyright 2025, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
 # We are not avoiding these in generated code at all
 # pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
 # pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
@@ -3399,3 +3402,18 @@ StatementDictOperationSetBase = StatementChildrenHavingValueDictArgKeyOperationM
 StatementDictOperationSetKeyValueBase = (
     StatementChildrenHavingValueDictArgKeyOperationMixin
 )
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/nodes/TypeNodes.py
+++ b/nuitka/nodes/TypeNodes.py
@@ -334,11 +334,11 @@ class ExpressionSubtypeCheck(
 class ExpressionTypeAlias(ChildrenExpressionTypeAliasMixin, ExpressionBase):
     kind = "EXPRESSION_TYPE_ALIAS"
 
-    named_children = ("type_params|tuple", "value")
+    named_children = ("name", "type_params|tuple", "value")
 
-    def __init__(self, type_params, value, source_ref):
+    def __init__(self, name, type_params, value, source_ref):
         ChildrenExpressionTypeAliasMixin.__init__(
-            self, type_params=type_params, value=value
+            self, name=name, type_params=type_params, value=value
         )
 
         ExpressionBase.__init__(self, source_ref)

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -40,7 +40,10 @@ from nuitka.nodes.OperatorNodes import (
     makeBinaryOperationNode,
     makeExpressionOperationBinaryInplace,
 )
-from nuitka.nodes.OutlineNodes import ExpressionOutlineBody, ExpressionOutlineFunction
+from nuitka.nodes.OutlineNodes import (
+    ExpressionOutlineBody,
+    ExpressionOutlineFunction,
+)
 from nuitka.nodes.ReturnNodes import StatementReturn
 from nuitka.nodes.SliceNodes import (
     ExpressionSliceLookup,
@@ -1234,9 +1237,7 @@ def buildTypeAliasNode(provider, node, source_ref):
         helper_name = "create_type_expression"
 
         outline_body = ExpressionOutlineFunction(
-            provider=provider,
-            name=helper_name,
-            source_ref=source_ref
+            provider=provider, name=helper_name, source_ref=source_ref
         )
 
         assignments = []
@@ -1252,9 +1253,7 @@ def buildTypeAliasNode(provider, node, source_ref):
 
         type_alias_node = ExpressionTypeAlias(
             name=ExpressionVariableNameRef(
-                provider=provider,
-                variable_name=type_alias_name,
-                source_ref=source_ref
+                provider=provider, variable_name=type_alias_name, source_ref=source_ref
             ),
             type_params=buildNodeTuple(outline_body, node.type_params, source_ref),
             value=buildNode(outline_body, node.value, source_ref),

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -28,11 +28,6 @@ from nuitka.nodes.ConstantRefNodes import (
     makeConstantRefNode,
 )
 from nuitka.nodes.ContainerMakingNodes import makeExpressionMakeTupleOrConstant
-from nuitka.nodes.FunctionNodes import (
-    ExpressionFunctionRef,
-    makeExpressionFunctionCall,
-    makeExpressionFunctionCreation,
-)
 from nuitka.nodes.InjectCNodes import (
     StatementInjectCCode,
     StatementInjectCDecl,
@@ -70,11 +65,9 @@ from nuitka.nodes.VariableNameNodes import (
 from nuitka.nodes.VariableRefNodes import ExpressionTempVariableRef
 from nuitka.Options import isExperimental
 from nuitka.PythonVersions import python_version
-from nuitka.specs.ParameterSpecs import ParameterSpec
 from nuitka.Tracing import general
 
 from .FutureSpecState import getFutureSpec
-from .InternalModule import makeInternalHelperFunctionBody
 from .ReformulationTryFinallyStatements import makeTryFinallyReleaseStatement
 from .SyntaxErrors import raiseSyntaxError
 from .TreeHelpers import (

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -28,12 +28,15 @@ from nuitka.nodes.ConstantRefNodes import (
     makeConstantRefNode,
 )
 from nuitka.nodes.ContainerMakingNodes import makeExpressionMakeTupleOrConstant
-from nuitka.nodes.FunctionNodes import ExpressionFunctionRef, makeExpressionFunctionCall, makeExpressionFunctionCreation
+from nuitka.nodes.FunctionNodes import (
+    ExpressionFunctionRef,
+    makeExpressionFunctionCall,
+    makeExpressionFunctionCreation,
+)
 from nuitka.nodes.InjectCNodes import (
     StatementInjectCCode,
     StatementInjectCDecl,
 )
-from .InternalModule import makeInternalHelperFunctionBody
 from nuitka.nodes.ListOperationNodes import ExpressionListOperationPop1
 from nuitka.nodes.NodeMakingHelpers import (
     makeRaiseExceptionExpressionFromTemplate,
@@ -64,13 +67,14 @@ from nuitka.nodes.VariableNameNodes import (
     StatementAssignmentVariableName,
     StatementDelVariableName,
 )
-from nuitka.specs.ParameterSpecs import ParameterSpec
 from nuitka.nodes.VariableRefNodes import ExpressionTempVariableRef
 from nuitka.Options import isExperimental
 from nuitka.PythonVersions import python_version
+from nuitka.specs.ParameterSpecs import ParameterSpec
 from nuitka.Tracing import general
 
 from .FutureSpecState import getFutureSpec
+from .InternalModule import makeInternalHelperFunctionBody
 from .ReformulationTryFinallyStatements import makeTryFinallyReleaseStatement
 from .SyntaxErrors import raiseSyntaxError
 from .TreeHelpers import (
@@ -1247,7 +1251,6 @@ def buildTypeAliasNode(provider, node, source_ref):
             ),
         )
 
-
         assignments = []
         for type_param in node.type_params:
             type_var = ExpressionTypeVariable(type_param, source_ref=source_ref)
@@ -1255,7 +1258,7 @@ def buildTypeAliasNode(provider, node, source_ref):
                 provider=provider,
                 variable_name=type_param.name,
                 source=type_var,
-                source_ref=source_ref
+                source_ref=source_ref,
             )
             assignments.append(assign)
 
@@ -1265,8 +1268,7 @@ def buildTypeAliasNode(provider, node, source_ref):
             source_ref=source_ref,
         )
         body = makeStatementsSequenceFromStatements(
-            *assignments,
-            StatementReturn(type_alias_node, source_ref=source_ref)
+            *assignments, StatementReturn(type_alias_node, source_ref=source_ref)
         )
         result.setChildBody(body)
 
@@ -1278,8 +1280,7 @@ def buildTypeAliasNode(provider, node, source_ref):
         source=makeExpressionFunctionCall(
             function=makeExpressionFunctionCreation(
                 ExpressionFunctionRef(
-                    function_body=typeExpressionFunction(),
-                    source_ref=source_ref
+                    function_body=typeExpressionFunction(), source_ref=source_ref
                 ),
                 defaults=(),
                 kw_defaults=None,
@@ -1287,7 +1288,7 @@ def buildTypeAliasNode(provider, node, source_ref):
                 source_ref=source_ref,
             ),
             values=[],
-            source_ref=source_ref
+            source_ref=source_ref,
         ),
         source_ref=source_ref,
     )

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -1228,7 +1228,6 @@ def buildTypeVarNode(node, source_ref):
 def buildTypeAliasNode(provider, node, source_ref):
     """Python3.12 or higher, type alias statements."""
 
-    assert not node.type_params, node.type_params
     type_alias_node = ExpressionTypeAlias(
         type_params=buildNodeTuple(provider, node.type_params, source_ref),
         value=buildNode(provider, node.value, source_ref),

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -1263,8 +1263,8 @@ def buildTypeAliasNode(provider, node, source_ref):
                 variable_name=type_alias_name,
                 source_ref=source_ref
             ),
-            type_params=buildNodeTuple(provider, node.type_params, source_ref),
-            value=buildNode(provider, node.value, source_ref),
+            type_params=buildNodeTuple(outline_body, node.type_params, source_ref),
+            value=buildNode(outline_body, node.value, source_ref),
             source_ref=source_ref,
         )
         body = makeStatementsSequenceFromStatements(


### PR DESCRIPTION
# What does this PR do?

Fixes use of type variables in 3.12+ `type` assignments, e.g., `type A[T] = T | int`.

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Implement full PEP 695 type alias syntax support by extending the AST node model, refining the assignment transformation to handle type parameters in an outline helper, and updating code generation to emit correct alias code.

New Features:
- Add support for PEP 695 style type alias assignments with type parameters (e.g., type A[T] = ...).

Enhancements:
- Extend AST by introducing a mixin that carries the alias name, type parameters, and value and update ExpressionTypeAlias to use it.
- Refactor buildTypeAliasNode to generate an outline function that binds type variables before returning the alias.
- Adjust code generation logic in TypeAliasCodes to derive the alias name from the AST and correctly manage temporary variables.

Chores:
- Remove stale license headers from generated node files.