### PR TITLE
implement #3634 --linux-console-mode=force

### DIFF
--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -23,9 +23,9 @@ from nuitka.options.Options import (
     getFcfProtectionMode,
     getFileVersion,
     getJobLimit,
+    getLinuxConsoleMode,
     getLtoMode,
     getMacOSTargetArch,
-    getLinuxConsoleMode,
     getMsvcVersion,
     getNoDeploymentIndications,
     getOnefileChildGraceTime,
@@ -106,10 +106,10 @@ from nuitka.utils.SharedLibraries import detectBinaryMinMacOS
 from nuitka.utils.Utils import (
     getArchitecture,
     isElfUsingPlatform,
+    isLinux,
     isMacOS,
     isWin32OrPosixWindows,
     isWin32Windows,
-    isLinux
 )
 
 from .SconsCaching import checkCachingSuccess

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -25,6 +25,7 @@ from nuitka.options.Options import (
     getJobLimit,
     getLtoMode,
     getMacOSTargetArch,
+    getLinuxConsoleMode,
     getMsvcVersion,
     getNoDeploymentIndications,
     getOnefileChildGraceTime,
@@ -749,6 +750,10 @@ def getCommonSconsOptions():
     # for accelerated mode still.
     if shallCreateAppBundle():
         scons_options["macos_bundle_mode"] = asBoolStr(True)
+
+
+        # Pass macOS console mode setting
+        scons_options["linux_app_console_mode"] = getLinuxConsoleMode()
 
     return scons_options, env_values
 

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -109,6 +109,7 @@ from nuitka.utils.Utils import (
     isMacOS,
     isWin32OrPosixWindows,
     isWin32Windows,
+    isLinux
 )
 
 from .SconsCaching import checkCachingSuccess
@@ -751,8 +752,7 @@ def getCommonSconsOptions():
     if shallCreateAppBundle():
         scons_options["macos_bundle_mode"] = asBoolStr(True)
 
-
-        # Pass macOS console mode setting
+    if isLinux():
         scons_options["linux_app_console_mode"] = getLinuxConsoleMode()
 
     return scons_options, env_values

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -463,6 +463,15 @@ def createEnvironment(
     if env.onefile_dll_mode:
         env.Append(CPPDEFINES=["_NUITKA_ONEFILE_DLL_MODE"])
 
+
+    linux_app_console_mode = getArgumentDefaulted(
+        "linux_app_console_mode", "disable"
+        )
+    if linux_app_console_mode == "force":
+        env.Append(CPPDEFINES=["_NUITKA_LINUX_CONSOLE_MODE_FORCE"])
+    elif linux_app_console_mode == "detect":
+        env.Append(CPPDEFINES=["_NUITKA_LINUX_CONSOLE_MODE_DETECT"])
+
     env.forced_stdout_path = getArgumentDefaulted("forced_stdout_path", None)
     env.forced_stderr_path = getArgumentDefaulted("forced_stderr_path", None)
 

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -463,10 +463,7 @@ def createEnvironment(
     if env.onefile_dll_mode:
         env.Append(CPPDEFINES=["_NUITKA_ONEFILE_DLL_MODE"])
 
-
-    linux_app_console_mode = getArgumentDefaulted(
-        "linux_app_console_mode", "detect"
-        )
+    linux_app_console_mode = getArgumentDefaulted("linux_app_console_mode", "detect")
     if linux_app_console_mode == "force":
         env.Append(CPPDEFINES=["_NUITKA_LINUX_CONSOLE_MODE_FORCE"])
     elif linux_app_console_mode == "detect":

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -465,7 +465,7 @@ def createEnvironment(
 
 
     linux_app_console_mode = getArgumentDefaulted(
-        "linux_app_console_mode", "disable"
+        "linux_app_console_mode", "detect"
         )
     if linux_app_console_mode == "force":
         env.Append(CPPDEFINES=["_NUITKA_LINUX_CONSOLE_MODE_FORCE"])

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1393,7 +1393,7 @@ void setLANGSystemLocaleMacOS(void) {
 
 static int Nuitka_Main(int argc, native_command_line_argument_t **argv) {
 
-#if(defined(_NUITKA_LINUX_CONSOLE_MODE_FORCE) || defined(_NUITKA_LINUX_CONSOLE_MODE_DETECT)) && !defined(_WIN32) && !defined(__APPLE__)
+#if(defined(_NUITKA_LINUX_CONSOLE_MODE_FORCE) || defined(_NUITKA_LINUX_CONSOLE_MODE_DETECT)) && defined(__linux__)
 
 if (!isatty(STDIN_FILENO)) {
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #endif
 
- #if !defined(_WIN32) && !defined(__APPLE__)
+ #if defined(__linux__)
  #include <errno.h>
  #include <limits.h>
  #include <spawn.h>

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -20,17 +20,17 @@
 #include <unistd.h>
 #endif
 
- #if defined(__linux__)
- #include <errno.h>
- #include <limits.h>
- #include <spawn.h>
- #include <stdio.h>
- #include <stdlib.h>
- #include <string.h>
- #include <sys/types.h>
- #include <sys/wait.h>
- #include <unistd.h>
- #endif
+#if defined(__linux__)
+#include <errno.h>
+#include <limits.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 #include "nuitka/prelude.h"
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1447,7 +1447,14 @@ if (!isatty(STDIN_FILENO)) {
 
         
         int status;
-        waitpid(pid, & status, 0);
+        int wait_result;
+        do {
+            wait_result = waitpid(pid, &status, 0);
+        } while (wait_result == -1 && errno == EINTR); // Was interrupted by signal
+
+        if (wait_result == -1) {
+              fprintf(stderr, "Error: waitpid failed for terminal process %d: %s\n", (int)pid, strerror(errno));
+        }
 
         
         exit(0);

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1517,68 +1517,6 @@ if (!isatty(STDIN_FILENO)) {
     }
 #endif
 
-
-#if defined(_NUITKA_LINUX_CONSOLE_MODE_FORCE) || defined(_NUITKA_LINUX_CONSOLE_MODE_DETECT)
-     // Check if we should relaunch in a terminal on Linux.
-     // The logic is: if we are not attached to a terminal, we should probably relaunch.
-     if (!isatty(STDIN_FILENO)) {
-         // Use an environment variable to prevent an infinite loop of relaunches.
-         char const *already_relaunched = getenv("NUITKA_TERMINAL_RELAUNCH");
-         if (already_relaunched == NULL) {
-             // Set the variable for the child process.
-             setenv("NUITKA_TERMINAL_RELAUNCH", "1", 1);
-
-             // The command to launch is ourselves. Nuitka provides a helper for this.
-             char const *binary_path = getBinaryFilenameHostEncoded(true);
-
-             // We need to build a new argv for the posix_spawn call.
-             // It will be: "xdg-terminal-exec", "/path/to/our/binary", "arg1", "arg2", ..., NULL
-             char **spawn_argv = (char **)malloc(sizeof(char *) * (argc + 2));
-             spawn_argv[0] = "xdg-terminal-exec";
-             spawn_argv[1] = (char *)binary_path;
-             for (int i = 1; i < argc; i++) {
-                 spawn_argv[i + 1] = argv[i];
-             }
-             spawn_argv[argc + 1] = NULL;
-
-             // Use posix_spawn for security, just like the macOS version.
-             pid_t pid;
-             extern char **environ;
-             int spawn_result = posix_spawn(&pid, "/usr/bin/xdg-terminal-exec", NULL, NULL, spawn_argv, environ);
-
-             free(spawn_argv);
-
-             if (spawn_result != 0) {
-                 // Fallback for when xdg-terminal-exec is not in /usr/bin
-                 char **fallback_spawn_argv = (char **)malloc(sizeof(char *) * (argc + 3));
-                 fallback_spawn_argv[0] = "x-terminal-emulator";
-                 fallback_spawn_argv[1] = "-e";
-                 fallback_spawn_argv[2] = (char *)binary_path;
-                  for (int i = 1; i < argc; i++) {
-                     fallback_spawn_argv[i + 2] = argv[i];
-                 }
-                 fallback_spawn_argv[argc + 2] = NULL;
-
-                 spawn_result = posix_spawn(&pid, "/usr/bin/x-terminal-emulator", NULL, NULL, fallback_spawn_argv, environ);
-                 free(fallback_spawn_argv);
-
-                 if (spawn_result != 0) {
-                     fprintf(stderr, "Error: Failed to spawn terminal: %s\n", strerror(spawn_result));
-                     exit(1);
-                 }
-             }
-
-
-             // Wait for the terminal process to complete.
-             int status;
-             waitpid(pid, &status, 0);
-
-             // Exit this parent process.
-             exit(0);
-         }
-     }
-#endif
-
     // Set up stdout/stderr according to user specification.
 #if NUITKA_STANDARD_HANDLES_EARLY == 1
 #if defined(NUITKA_FORCED_STDOUT_PATH)

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -21,6 +21,7 @@
 #endif
 
 #if defined(__linux__)
+#define _GNU_SOURCE 
 #include <errno.h>
 #include <limits.h>
 #include <spawn.h>
@@ -29,7 +30,9 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/time.h>
 #include <unistd.h>
+#include <signal.h>
 #endif
 
 #include "nuitka/prelude.h"

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -1988,12 +1988,12 @@ linux_group.add_option(
     default="detect",
     help="""\
 Select console mode for Linux app bundles. 'force' always opens Terminal
-if not already running in one, useful for console/TUI applications launched
-from Finder. 'detect' (default) opens Terminal when no terminal is detected
+if not already running in one, useful for console/TUI applications launched. 
+'detect' (default) opens Terminal when no terminal is detected
 (currently behaves the same as 'force', with smarter heuristics planned for
 future releases). 'disable' never opens Terminal automatically. This helps
-console applications work correctly when launched from GUI contexts like DMG
-files or Finder. Default is "detect".""",
+console applications work correctly when launched from GUI contexts. 
+Default is "detect".""",
 )
 
 del linux_group

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -1978,6 +1978,24 @@ linux_group.add_option(
     help="Add executable icon for onefile binary to use. Can be given only one time. Defaults to Python icon if available.",
 )
 
+
+linux_group.add_option(
+    "--linux-app-console-mode",
+    action="store",
+    dest="linux_app_console_mode",
+    choices=("force", "detect", "disable"),
+    metavar="MODE",
+    default="detect",
+    help="""\
+Select console mode for Linux app bundles. 'force' always opens Terminal
+if not already running in one, useful for console/TUI applications launched
+from Finder. 'detect' (default) opens Terminal when no terminal is detected
+(currently behaves the same as 'force', with smarter heuristics planned for
+future releases). 'disable' never opens Terminal automatically. This helps
+console applications work correctly when launched from GUI contexts like DMG
+files or Finder. Default is "detect".""",
+)
+
 del linux_group
 
 version_group = parser.add_option_group("Binary Version Information")

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -1987,7 +1987,7 @@ linux_group.add_option(
     metavar="MODE",
     default="detect",
     help="""\
-Select console mode for Linux app bundles. 'force' always opens Terminal
+Select console mode for Linux. 'force' always opens Terminal
 if not already running in one, useful for console/TUI applications launched. 
 'detect' (default) opens Terminal when no terminal is detected
 (currently behaves the same as 'force', with smarter heuristics planned for

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -2549,6 +2549,11 @@ def getLinuxIconPaths():
     return _checkedIconPaths(result)
 
 
+def getLinuxConsoleMode():
+    """*str* console mode for Linux app bundles, derived from ``--linux-app-console-mode`` value"""
+    return options.linux_app_console_mode
+
+
 def getMacOSIconPaths():
     """*list of str*, values of ``--macos-app-icon``"""
     return _checkedIconPaths(


### PR DESCRIPTION
Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Add configurable Linux app bundle console mode and relaunch compiled binaries in a terminal when appropriate.

New Features:
- Introduce the --linux-app-console-mode option to control terminal behavior for Linux app bundles with modes force, detect, and disable.
- Add a Linux-only startup path that relaunches the binary inside a terminal emulator when no TTY is attached, based on the selected console mode.

Enhancements:
- Plumb the linux_app_console_mode option through Scons to define compile-time flags used by the runtime startup logic.