### PR TITLE
Fix generic type variables in classes

### DIFF
--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -296,7 +296,7 @@ def buildClassNode3(provider, node, source_ref):
 
     for type_params_expression in type_params_expressions:
         assign = StatementAssignmentVariableName(
-            provider=provider,
+            provider=class_creation_function,
             variable_name=type_params_expression.name,
             source=type_params_expression.makeClone(),
             source_ref=source_ref,

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -102,7 +102,6 @@ from .ReformulationTryFinallyStatements import (
 )
 from .TreeHelpers import (
     buildFrameNode,
-    buildNode,
     buildNodeTuple,
     extractDocFromBody,
     getKind,

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -279,6 +279,9 @@ def buildClassNode3(provider, node, source_ref):
         )
     )
 
+    if python_version >= 0x300:
+        qualname_assign = statements[-1]
+
     if python_version >= 0x3C0:
         type_param_nodes = node.type_params
     else:
@@ -299,9 +302,6 @@ def buildClassNode3(provider, node, source_ref):
             source_ref=source_ref,
         )
         statements.append(assign)
-
-    if python_version >= 0x300:
-        qualname_assign = statements[-1]
 
     if python_version >= 0x360 and class_creation_function.needsAnnotationsDictionary():
         statements.append(


### PR DESCRIPTION
# What does this PR do?

This expands the scope of type variables in classes.

# Why was it initiated? Any relevant Issues?

- #3700

# PR Checklist

- [x] Correct base branch selected? Should be `develop` branch.
- [x] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] All tests still pass. Check the Developer Manual about `Running the Tests`. There are GitHub
  Actions tests that cover the most important things however, and you are welcome to rely on those,
  but they might not cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.

## Summary by Sourcery

Extend the handling of generic type parameters in class definitions so their variables are created in the surrounding scope instead of being limited to the class-local outline body.

Bug Fixes:
- Ensure type parameter variables declared on classes are visible in the appropriate outer scope rather than only within the class body.

Enhancements:
- Simplify and centralize construction and assignment of class type parameter expressions for Python 3.12+ class definitions.