### PR TITLE
Rename to MonolithPy and fix recent changes to work with MPy.

### DIFF
--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -129,7 +129,7 @@ from nuitka.PythonFlavors import (
     isArchPackagePython,
     isDebianPackagePython,
     isFedoraPackagePython,
-    isNuitkaPython,
+    isMonolithPy,
     isPyenvPython,
 )
 from nuitka.PythonVersions import (
@@ -704,7 +704,7 @@ def runSconsBackend():
     scons_options["source_dir"] = OutputDirectories.getSourceDirectoryPath(
         onefile=False, create=False
     )
-    scons_options["nuitka_python"] = asBoolStr(isNuitkaPython())
+    scons_options["monolithpy"] = asBoolStr(isMonolithPy())
     scons_options["debug_mode"] = asBoolStr(states.is_debug)
     scons_options["debugger_mode"] = asBoolStr(shallRunInDebugger())
     scons_options["python_debug"] = asBoolStr(shallUsePythonDebug())

--- a/nuitka/PythonFlavors.py
+++ b/nuitka/PythonFlavors.py
@@ -40,15 +40,15 @@ from .PythonVersions import (
 )
 
 
-def isNuitkaPython():
-    """Is this our own fork of CPython named Nuitka-Python."""
+def isMonolithPy():
+    """Is this our own fork of CPython named MonolithPy."""
 
-    # spell-checker: ignore nuitkapython
+    # spell-checker: ignore monolithpy
 
     if python_version >= 0x300:
-        return sys.implementation.name == "nuitkapython"
+        return sys.implementation.name == "monolithpy"
     else:
-        return sys.subversion[0] == "nuitkapython"
+        return sys.subversion[0] == "monolithpy"
 
 
 _is_anaconda = None
@@ -389,7 +389,7 @@ def getPythonFlavorName():
     """For output to the user only."""
     # return driven, pylint: disable=too-many-branches,too-many-return-statements
 
-    if isNuitkaPython():
+    if isMonolithPy():
         return "MonolithPy"
     elif isAnacondaPython():
         return "Anaconda Python"

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -233,15 +233,13 @@ if env.trace_mode:
 applyPythonBuildSettings(env)
 
 # TODO: This ought to be decided outside of scons and per flavor maybe.
-if env.static_libpython and (
-    (not os.name == "nt" and not isMacOS()) or env.nuitka_python
-):
+if env.static_libpython and ((not os.name == "nt" and not isMacOS()) or env.monolithpy):
     env.Append(CPPDEFINES=["_NUITKA_USE_UNEXPOSED_API"])
 
 link_module_libs = addPythonHaclLib(env, link_module_libs=link_module_libs)
 
 if os.name == "nt":
-    if env.nuitka_python:
+    if env.monolithpy:
         link_data = loadJsonFromFilename(
             os.path.join(env.python_prefix_external, "link.json")
         )
@@ -274,7 +272,7 @@ elif env.exe_mode or env.dll_mode:
     # Any module libs that are for self-compiled Python to be static.
     env.Append(_LIBFLAGS=["-l" + lib_desc for lib_desc in link_module_libs])
 
-    if env.nuitka_python:
+    if env.monolithpy:
         link_data = loadJsonFromFilename(
             os.path.join(env.python_prefix_external, "link.json")
         )

--- a/nuitka/build/Offsets.scons
+++ b/nuitka/build/Offsets.scons
@@ -168,8 +168,8 @@ if os.name == "nt":
     if os.path.exists(python_header_path):
         env.Append(CPPPATH=[python_header_path])
 
-if env.nuitka_python:
-    env.Append(CPPDEFINES=["_NUITKA_PYTHON"])
+if env.monolithpy:
+    env.Append(CPPDEFINES=["_MONOLITHPY"])
 
 if env.static_libpython:
     env.Append(CPPDEFINES=["_NUITKA_STATIC_LIBPYTHON"])

--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -167,9 +167,9 @@ def _enableLtoSettings(
     elif env.msvc_mode and getMsvcVersion(env) >= (14,):
         lto_mode = True
         reason = "known to be supported"
-    elif env.nuitka_python:
+    elif env.monolithpy:
         lto_mode = True
-        reason = "known to be supported (Nuitka-Python)"
+        reason = "known to be supported (MonolithPy)"
     elif env.fedora_python:
         lto_mode = True
         reason = "known to be supported (Fedora Python)"
@@ -213,7 +213,7 @@ def _enableLtoSettings(
         orig_lto_mode == "auto"
         and lto_mode
         and env.compiled_module_count > compiled_module_count_threshold
-        and not env.nuitka_python
+        and not env.monolithpy
     ):
         lto_mode = False
         reason = (
@@ -885,7 +885,7 @@ def _enableOutputSettings(env):
         # want to bring a second file and MonolithPy requires it.
         force_static = (
             env.onefile_compile and env.onefile_windows_static_runtime
-        ) or env.nuitka_python
+        ) or env.monolithpy
 
         if force_static:
             env.Append(CCFLAGS=["/MT"])  # Multithreaded, static version of C run time.
@@ -1268,14 +1268,12 @@ def setupCCompiler(env, pgo_mode, exe_target, onefile_compile):
         else:
             # For LTO with static libpython combined, there are crashes with Python core
             # being inlined, so we must refrain from that. On Windows there is no such
-            # thing, and Nuitka-Python is not affected.
+            # thing, and MonolithPy is not affected.
             env.Append(
                 LINKFLAGS=[
                     (
                         "-O3"
-                        if env.nuitka_python
-                        or os.name == "nt"
-                        or not env.static_libpython
+                        if env.monolithpy or os.name == "nt" or not env.static_libpython
                         else "-O2"
                     )
                 ]
@@ -1299,9 +1297,7 @@ def setupCCompiler(env, pgo_mode, exe_target, onefile_compile):
                 CCFLAGS=[
                     (
                         "-O3"
-                        if env.nuitka_python
-                        or os.name == "nt"
-                        or not env.static_libpython
+                        if env.monolithpy or os.name == "nt" or not env.static_libpython
                         else "-O2"
                     )
                 ]

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -59,8 +59,8 @@ from nuitka.plugins.Hooks import (
 )
 from nuitka.PythonFlavors import (
     isAnacondaPython,
+    isMonolithPy,
     isMSYS2MingwPython,
-    isNuitkaPython,
     isSelfCompiledPythonUninstalled,
 )
 from nuitka.PythonVersions import (
@@ -675,7 +675,7 @@ def getCommonSconsOptions():
     if effective_version:
         env_values["NUITKA_VERSION_COMBINED"] = effective_version
 
-    if isNuitkaPython() and not isWin32OrPosixWindows():
+    if isMonolithPy() and not isWin32OrPosixWindows():
         # Override environment CC and CXX to match build compiler.
         import sysconfig
 

--- a/nuitka/build/SconsPythonBuild.py
+++ b/nuitka/build/SconsPythonBuild.py
@@ -86,8 +86,8 @@ not satisfied!"""
 def applyPythonBuildSettings(env):
     env.Append(CPPPATH=list(_detectPythonHeaderPath(env)))
 
-    if env.nuitka_python:
-        env.Append(CPPDEFINES=["_NUITKA_PYTHON"])
+    if env.monolithpy:
+        env.Append(CPPDEFINES=["_MONOLITHPY"])
 
     if env.static_libpython:
         env.Append(CPPDEFINES=["_NUITKA_STATIC_LIBPYTHON"])

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -352,7 +352,7 @@ def createEnvironment(
             env["CCVERSION"] = None
 
     # Various flavors could influence builds.
-    env.nuitka_python = getArgumentBool("nuitka_python", False)
+    env.monolithpy = getArgumentBool("monolithpy", False)
     env.debian_python = getArgumentBool("debian_python", False)
     env.fedora_python = getArgumentBool("fedora_python", False)
     env.arch_python = getArgumentBool("arch_python", False)

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -1527,7 +1527,7 @@ static int Nuitka_Main(int argc, native_command_line_argument_t **argv) {
     }
 #endif
 
-#ifdef NUITKA_PYTHON_STATIC
+#ifdef _MONOLITHPY
     NUITKA_PRINT_TIMING("main(): Preparing static modules.");
     Py_InitStaticModules();
 #endif

--- a/nuitka/freezer/DllDependenciesMacOS.py
+++ b/nuitka/freezer/DllDependenciesMacOS.py
@@ -17,7 +17,7 @@ from nuitka.PythonFlavors import (
     isAnacondaPython,
     isCPythonOfficialPackage,
     isHomebrewPython,
-    isNuitkaPython,
+    isMonolithPy,
     isPythonBuildStandalonePython,
 )
 from nuitka.PythonVersions import python_version
@@ -244,8 +244,8 @@ def _resolveBinaryPathDLLsMacOS(
         elif os.path.basename(path) == os.path.basename(binary_filename):
             # We ignore the references to itself coming from the library id.
             continue
-        elif isNuitkaPython() and not os.path.isabs(path) and not os.path.exists(path):
-            # Although Nuitka Python statically links all packages, some of them
+        elif isMonolithPy() and not os.path.isabs(path) and not os.path.exists(path):
+            # Although MonolithPy statically links all packages, some of them
             # have proprietary dependencies that cannot be statically built and
             # must instead be linked to the python executable. Due to how the
             # python executable is linked, we end up with relative paths to

--- a/nuitka/freezer/Standalone.py
+++ b/nuitka/freezer/Standalone.py
@@ -38,8 +38,8 @@ from nuitka.PythonFlavors import (
     isAnacondaPython,
     isCPythonOfficialPackage,
     isHomebrewPython,
+    isMonolithPy,
     isMSYS2MingwPython,
-    isNuitkaPython,
     isPythonBuildStandalonePython,
 )
 from nuitka.PythonVersions import getSystemPrefixPath
@@ -146,7 +146,7 @@ def _detectBinaryDLLs(
     "otool" (macOS) the list of used DLLs is retrieved.
     """
 
-    if is_main_executable and isNuitkaPython():
+    if is_main_executable and isMonolithPy():
         return OrderedSet()
     elif (
         getOS() in ("Linux", "NetBSD", "FreeBSD", "OpenBSD", "AIX") or isPosixWindows()

--- a/nuitka/importing/IgnoreListing.py
+++ b/nuitka/importing/IgnoreListing.py
@@ -6,7 +6,7 @@
 import sys
 
 from nuitka.Errors import NuitkaOptimizationError
-from nuitka.PythonFlavors import isNuitkaPython
+from nuitka.PythonFlavors import isMonolithPy
 
 
 def getModuleIgnoreList():
@@ -420,7 +420,7 @@ areallylongpackageandmodulenametotestreprtruncation""",
 
 
 def isIgnoreListedNotExistingModule(module_name):
-    if module_name in sys.builtin_module_names and not isNuitkaPython():
+    if module_name in sys.builtin_module_names and not isMonolithPy():
         raise NuitkaOptimizationError(
             """
 Your CPython version has a built-in module '%s', that is not ignore listed

--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -42,7 +42,7 @@ from nuitka.plugins.Hooks import (
     getPackageExtraScanPaths,
     suppressUnknownImportWarning,
 )
-from nuitka.PythonFlavors import isNuitkaPython
+from nuitka.PythonFlavors import isMonolithPy
 from nuitka.PythonVersions import python_version
 from nuitka.SourceCodeReferences import makeSourceReferenceFromFilename
 from nuitka.States import states
@@ -97,7 +97,7 @@ def setupImportingFromOptions():
     _safe_path = hasPythonFlagNoCurrentDirectoryInPath()
 
     # Lets try and have this complete, please report failures.
-    if states.is_debug and not isNuitkaPython():
+    if states.is_debug and not isMonolithPy():
         _checkRaisingBuiltinComplete()
 
     if getOutputFolderName() is not None:
@@ -318,7 +318,7 @@ def getModuleNameAndKindFromFilename(module_filename):
 
 
 def isIgnoreListedImportMaker(source_ref):
-    if isNuitkaPython():
+    if isMonolithPy():
         return True
 
     return isStandardLibraryPath(source_ref.getFilename())

--- a/nuitka/importing/StandardLibrary.py
+++ b/nuitka/importing/StandardLibrary.py
@@ -103,7 +103,8 @@ def getStandardLibraryPaths():
             except ImportError:
                 pass
             else:
-                if _ctypes.__file__ is not None:
+                # In MonolithPy, ctypes does nto have a __file__ attribute.
+                if hasattr(_ctypes, "__file__") and _ctypes.__file__ is not None:
                     stdlib_paths.add(os.path.dirname(_ctypes.__file__))
 
         getStandardLibraryPaths.result = tuple(

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -32,8 +32,8 @@ from nuitka.PythonFlavors import (
     isDebianPackagePython,
     isHomebrewPython,
     isManyLinuxPython,
+    isMonolithPy,
     isMSYS2MingwPython,
-    isNuitkaPython,
     isPyenvPython,
     isPythonBuildStandalonePython,
     isTermuxPython,
@@ -1962,9 +1962,9 @@ def _couldUseStaticLibPython():
     # many cases and return driven,
     # pylint: disable=too-many-branches,too-many-return-statements
 
-    # Nuitka-Python is good to to static linking.
-    if isNuitkaPython():
-        return True, "Nuitka-Python is unexpectedly broken."
+    # MonolithPy is good to to static linking.
+    if isMonolithPy():
+        return True, "MonolithPy is known to be good."
 
     if isHomebrewPython():
         return True, "Homebrew Python is unexpectedly broken."

--- a/nuitka/plugins/PluginBase.py
+++ b/nuitka/plugins/PluginBase.py
@@ -60,7 +60,7 @@ from nuitka.options.Options import (
 from nuitka.PythonFlavors import (
     isAnacondaPython,
     isDebianPackagePython,
-    isNuitkaPython,
+    isMonolithPy,
 )
 from nuitka.PythonVersions import (
     getTestExecutionPythonVersions,
@@ -162,7 +162,7 @@ def _getEvaluationContext():
             "anaconda": isAnacondaPython(),
             "is_conda_package": _isCondaPackage,
             "debian_python": isDebianPackagePython(),
-            "nuitka_python": isNuitkaPython(),
+            "monolithpy": isMonolithPy(),
             "standalone": isStandaloneMode(),
             "onefile": isOnefileMode(),
             "onefile_cached": not isOnefileTempDirMode(),
@@ -239,7 +239,7 @@ def _getEvaluationContext():
         _context_dict["before_python3"] = python_version < 0x300
         _context_dict["python3_or_higher"] = python_version >= 0x300
 
-        if not isNuitkaPython():
+        if not isMonolithPy():
             _context_dict["extension_std_suffix"] = getExtensionModuleSuffix(
                 preferred=True
             )

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -231,12 +231,12 @@
     - depends:
         - 'arcade.gl.backends.opengl.provider'
 
-- module-name: 'aspose' # checksum: 1ffc48f1
+- module-name: 'aspose' # checksum: e9831d48
   data-files:
     - patterns:
         - '"**/*"+extension_std_suffix'
         - '**/*.dll'
-      when: 'not nuitka_python'
+      when: 'not monolithpy'
   anti-bloat:
     - no-follow:
         'aspose.*': 'workaround for aspose needing to load its submodules'
@@ -960,7 +960,7 @@
       # Not necessary on Windows
       when: 'not win32'
 
-- module-name: 'cv2' # checksum: 743289ea
+- module-name: 'cv2' # checksum: 12151595
   variables:
     setup_code:
       - 'import cv2'
@@ -996,11 +996,11 @@
         'native_module = importlib.import_module("cv2.cv2")': '"import imp; native_module = imp.load_dynamic(\"cv2\", os.path.join(os.path.dirname(__file__), \"cv2%s\"))" % extension_suffix'
       # After OpenCV 4.6
         'native_module = importlib.import_module("cv2")': '"import imp; native_module = imp.load_dynamic(\"cv2\", os.path.join(os.path.dirname(__file__), \"cv2%s\"))" % extension_suffix'
-      when: 'standalone and before_python312 and not nuitka_python'
+      when: 'standalone and before_python312 and not monolithpy'
     - description: 'workaround for colliding native module import'
       replacements:
         'native_module = importlib.import_module("cv2")': '"from importlib.machinery import ExtensionFileLoader; from importlib.util import spec_from_file_location; from importlib._bootstrap import _load; __path = os.path.join(os.path.dirname(__file__), \"cv2%s\"); native_module = _load(spec_from_file_location(\"cv2\", __path, loader=ExtensionFileLoader(\"cv2\", __path)))" % extension_suffix'
-      when: 'standalone and python312_or_higher and not nuitka_python'
+      when: 'standalone and python312_or_higher and not monolithpy'
     - description: 'remove error hiding code'
       replacements_plain:
         "print('OpenCV bindings requires \"numpy\" package.')": 'raise'

--- a/nuitka/tools/specialize/SpecializeC.py
+++ b/nuitka/tools/specialize/SpecializeC.py
@@ -1137,7 +1137,7 @@ generate_builtin_type_operations = [
     # TODO: For these, we would need an implementation for adding/deleting dictionary values. That
     # has turned out to be too hard so far and these are very good friends, not doing hashing
     # multiple times when reading and writing, so can't do it unless we add something for the
-    # Nuitka-Python eventually.
+    # MonolithPy eventually.
     (
         "tshape_dict",
         dict_desc,

--- a/nuitka/utils/Importing.py
+++ b/nuitka/utils/Importing.py
@@ -94,7 +94,7 @@ def getExtensionModuleSuffixes():
         else:
             _extension_module_suffixes = list(importlib.machinery.EXTENSION_SUFFIXES)
 
-        # Nuitka-Python on Windows has that
+        # MonolithPy on Windows has that
         if "" in _extension_module_suffixes:
             _extension_module_suffixes.remove("")
 

--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -9,7 +9,7 @@ from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.PythonFlavors import (
     isAnacondaPython,
     isDebianPackagePython,
-    isNuitkaPython,
+    isMonolithPy,
     isPyenvPython,
     isPythonBuildStandalonePython,
     isRyePython,
@@ -113,8 +113,8 @@ def _getSystemStaticLibPythonPath():
     sys_prefix = getSystemPrefixPath()
     python_abi_version = python_version_str + getPythonABI()
 
-    if isNuitkaPython():
-        # Nuitka Python has this.
+    if isMonolithPy():
+        # MonolithPy has this.
         if isWin32Windows():
             return os.path.join(
                 sys_prefix,


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

This PR updates references to Nuitka-Python to the new name of MonolithPy.

We also fix various minor issues that were found in recent nuitka changes that are not compatible with MonolithPy.


## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [ ] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.


______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Rename the internal Nuitka-Python integration to MonolithPy and adjust build, importing, and plugin logic accordingly.

Bug Fixes:
- Update environment flags, plugin conditions, and platform-specific behaviors to recognize MonolithPy correctly instead of the old Nuitka-Python identifier.
- Fix static linking and DLL resolution handling for MonolithPy builds across platforms, including macOS and Windows.
- Guard standard library path detection against ctypes objects without a __file__ attribute to avoid crashes in some runtimes.

Enhancements:
- Expose a new isMonolithPy() flavor helper and use it throughout the codebase in place of the deprecated isNuitkaPython().
- Align Scons and C build-time defines and options with the new MonolithPy naming to keep backend behavior consistent.
- Refresh standard plugin configuration conditions (e.g., aspose, cv2) to use the new MonolithPy context flag.