### PR TITLE
MonolithPy Compatibility Fixes

### DIFF
--- a/nuitka/HardImportRegistry.py
+++ b/nuitka/HardImportRegistry.py
@@ -397,6 +397,16 @@ def addModuleDynamicHard(module_name):
         hard_modules_trust[module_name] = {}
 
 
+def addModuleDynamicBuiltinHard(module_name):
+    hard_modules.add(module_name)
+    hard_modules_stdlib.add(module_name)
+    hard_modules_dynamic.add(module_name)
+    hard_modules_trust_with_side_effects.add(module_name)
+
+    if module_name not in hard_modules_trust:
+        hard_modules_trust[module_name] = {}
+
+
 def isHardModuleDynamic(module_name):
     return module_name in hard_modules_dynamic
 

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -3,6 +3,11 @@
 #ifndef __NUITKA_PRELUDE_H__
 #define __NUITKA_PRELUDE_H__
 
+#ifdef _MONOLITHPY
+// MonolithPy VFS support needs to be included as early as possible.
+#include "mp_embed.h"
+#endif
+
 #ifdef __NUITKA_NO_ASSERT__
 #undef NDEBUG
 #define NDEBUG

--- a/nuitka/code_generation/ImportCodes.py
+++ b/nuitka/code_generation/ImportCodes.py
@@ -161,13 +161,30 @@ def generateImportModuleHardCode(to_name, expression, emit, context):
     with withObjectCodeTemporaryAssignment(
         to_name, "imported_value", expression, emit, context
     ) as value_name:
-        import_gives_ref, module_getter_code = getImportHardModuleGetterCode(
-            module_name=imported_module_name, context=context
-        )
-
         if imported_module_name == module_value_name:
+            import_gives_ref, module_getter_code = getImportHardModuleGetterCode(
+                module_name=imported_module_name, context=context
+            )
+
             emit("""%s = %s;""" % (value_name, module_getter_code))
+        elif not isHardModule(module_value_name):
+            # The imported module can be hard-imported while the value bound by
+            # "import package.submodule" is still only the top level package.
+            # In that case, use a normal fixed import to obtain that binding.
+            emit(
+                """%s = IMPORT_MODULE_FIXED(tstate, %s, %s);"""
+                % (
+                    value_name,
+                    context.getConstantCode(imported_module_name.asString()),
+                    context.getConstantCode(module_value_name.asString()),
+                )
+            )
+
+            import_gives_ref = True
         else:
+            import_gives_ref1, module_getter_code = getImportHardModuleGetterCode(
+                module_name=imported_module_name, context=context
+            )
             import_gives_ref, module_getter_code2 = getImportHardModuleGetterCode(
                 module_name=module_value_name, context=context
             )
@@ -188,7 +205,7 @@ def generateImportModuleHardCode(to_name, expression, emit, context):
                     value_name=value_name,
                     module_getter_code1=module_getter_code,
                     module_getter_code2=module_getter_code2,
-                    import_gives_ref=import_gives_ref,
+                    import_gives_ref=import_gives_ref1,
                 )
             )
 

--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -885,7 +885,9 @@ def _findModuleInPath(module_name, logger):
 
     # Free pass for built-in modules, they need not exist.
     if package_name is None and isBuiltinModuleName(module_name):
-        return module_name, None, "built-in"
+        return module_name, "built-in", "built-in"
+    if package_name is not None and isBuiltinModuleName(package_name + "." + module_name):
+        return package_name + "." + module_name, "built-in", "built-in"
 
     # These are existing in the standard library but are effectively inline
     # already and should be avoided to look at.
@@ -1009,7 +1011,17 @@ def locateModule(module_name, parent_package, level, logger=None):
         type(module_package) is ModuleName and module_package != ""
     ), ("Must not attempt to locate %r" % module_name)
 
-    if module_filename is not None:
+    if module_kind == "built-in":
+        from nuitka.HardImportRegistry import (
+            addModuleDynamicHard,
+            isHardModule,
+        )
+        if not isHardModule(found_module_name):
+            # If we encounter an unexpected builtin module,
+            # mark it as a dynamic hard import.
+            addModuleDynamicHard(found_module_name)
+
+    elif module_filename is not None:
         module_filename = getNormalizedPath(module_filename)
         module_name = found_module_name
 
@@ -1062,7 +1074,7 @@ def decideModuleSourceRef(filename, module_name, is_main, is_fake, logger):
     else:
         main_added = False
 
-    if is_fake:
+    if is_fake or filename == "built-in":
         source_filename = filename
 
         source_ref = makeSourceReferenceFromFilename(filename=filename)

--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -100,6 +100,18 @@ def setupImportingFromOptions():
     if states.is_debug and not isMonolithPy():
         _checkRaisingBuiltinComplete()
 
+    if isMonolithPy():
+        from nuitka.HardImportRegistry import (
+            addModuleDynamicBuiltinHard,
+            isHardModule,
+        )
+
+        for builtin_module_name in sorted(builtin_module_names):
+            builtin_module_name = ModuleName(builtin_module_name)
+
+            if not isHardModule(builtin_module_name):
+                addModuleDynamicBuiltinHard(builtin_module_name)
+
     if getOutputFolderName() is not None:
         source_dir = getSourceDirectoryPath(onefile=False, create=False)
     else:
@@ -885,9 +897,13 @@ def _findModuleInPath(module_name, logger):
 
     # Free pass for built-in modules, they need not exist.
     if package_name is None and isBuiltinModuleName(module_name):
-        return module_name, "built-in", "built-in"
-    if package_name is not None and isBuiltinModuleName(package_name + "." + module_name):
-        return package_name + "." + module_name, "built-in", "built-in"
+        return module_name, None, "built-in"
+
+    if package_name is not None:
+        candidate = package_name.getChildNamed(module_name)
+
+        if isBuiltinModuleName(candidate):
+            return candidate, None, "built-in"
 
     # These are existing in the standard library but are effectively inline
     # already and should be avoided to look at.
@@ -1012,15 +1028,7 @@ def locateModule(module_name, parent_package, level, logger=None):
     ), ("Must not attempt to locate %r" % module_name)
 
     if module_kind == "built-in":
-        from nuitka.HardImportRegistry import (
-            addModuleDynamicHard,
-            isHardModule,
-        )
-        if not isHardModule(found_module_name):
-            # If we encounter an unexpected builtin module,
-            # mark it as a dynamic hard import.
-            addModuleDynamicHard(found_module_name)
-
+        module_name = found_module_name
     elif module_filename is not None:
         module_filename = getNormalizedPath(module_filename)
         module_name = found_module_name
@@ -1074,7 +1082,7 @@ def decideModuleSourceRef(filename, module_name, is_main, is_fake, logger):
     else:
         main_added = False
 
-    if is_fake or filename == "built-in":
+    if is_fake:
         source_filename = filename
 
         source_ref = makeSourceReferenceFromFilename(filename=filename)


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Fix MonolithPy VFS integration. Make sure MonolithPy static modules properly get their implicit imports.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [ ] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Improve MonolithPy compatibility by adjusting hard import handling, builtin module discovery, and early VFS initialization.

Bug Fixes:
- Fix hard import resolution for cases where a hard-imported submodule differs from the bound top-level package name.
- Correct module location logic so built-in submodules within packages are recognized and attributed the proper module name.
- Ensure dynamically discovered builtin modules are registered as hard stdlib modules when running under MonolithPy.

Enhancements:
- Introduce an API to register dynamically detected builtin modules as trusted hard modules with side effects.
- Include MonolithPy VFS support headers at the earliest point in the C prelude to ensure proper initialization.