### PR TITLE
Mark nodes as escaped in a del subscript

### DIFF
--- a/nuitka/nodes/VariableRefNodes.py
+++ b/nuitka/nodes/VariableRefNodes.py
@@ -300,7 +300,9 @@ Subscript del to dictionary lowered to dictionary del."""
         # By default, an subscript may change everything about the lookup
         # source.
         # Any code could be run, note that.
-        trace_collection.onControlFlowEscape(self)
+        for node in (self, del_node, subscript):
+            trace_collection.onControlFlowEscape(node)
+            trace_collection.removeKnowledge(node)
 
         # Any exception might be raised.
         if del_node.mayRaiseException(BaseException):

--- a/tests/basics/AssignmentsTest.py
+++ b/tests/basics/AssignmentsTest.py
@@ -257,6 +257,14 @@ def globalErrors():
         print("Del on unassigned global gives", repr(e))
 
 
+def testLenEscapeDel():
+    lst = [0, 0]
+    del lst[0]
+    assert len(lst) == 1
+    assert lst == [0]
+    assert repr(lst) == "[0]"
+
+
 someFunction()
 varargsFunction(1, 2, 3, 4)
 otherFunction()
@@ -268,6 +276,7 @@ optimizableTargets()
 complexDel()
 sliceDel()
 globalErrors()
+testLenEscapeDel()
 
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Adds missing `removeKnowledge` and `onControlFlowEscape` calls to `computeExpressionDelSubscript`.

## 🧐 Why was it initiated? Any relevant Issues?

Found while working on the 3.11 test suite.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

## Summary by Sourcery

Ensure subscript deletion correctly marks involved nodes as escaped in control flow analysis.

Bug Fixes:
- Mark the container, delete node, and subscript as causing control flow escape and clear related knowledge during subscript deletion.

Tests:
- Add a regression test verifying list length, contents, and repr after deleting an indexed element.