### PR TITLE
Fix double space in inclusion logs

### DIFF
--- a/nuitka/freezer/DllDependenciesWin32.py
+++ b/nuitka/freezer/DllDependenciesWin32.py
@@ -515,7 +515,7 @@ to be installed on target systems."""
         else:
             inclusion_logger.info(
                 """\
-Including Windows Runtime DLLs, which increases distribution  \
+Including Windows Runtime DLLs, which increases distribution \
 size. Use '--include-windows-runtime-dlls=no' to disable, or \
 make explicit with '--include-windows-runtime-dlls=yes'."""
             )


### PR DESCRIPTION
# Description
## ❓ What does this PR do?

Removes a double space in one of the nuitkla inclusion logs.

## 🧐 Why was it initiated? Any relevant Issues?

Just noticed it while compiling a program. :-)

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Correct a cosmetic spacing issue in the Windows Runtime DLL inclusion log output.