### PR TITLE
[Feature] Evaluate project variables

### DIFF
--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -2439,7 +2439,7 @@ def getNuitkaProjectOptions(logger, filename_arg, module_mode):
                         return sysexit(
                             line_number,
                             "Error, 'nuitka-project-set' expression %r (expanded to %r) failed to evaluate: %s"
-                            % (val_expr, expanded, e)
+                            % (val_expr, expanded, e),
                         )
 
                 # Likely mistakes, e.g. evaluating to a module object, class, or
@@ -2452,7 +2452,7 @@ def getNuitkaProjectOptions(logger, filename_arg, module_mode):
                         """\
 Error, 'nuitka-project-set' expression %r (expanded to %r) \
 yielded unsupported type '%s' (value: %r). Expected string, number, or boolean."""
-                        % (val_expr, expanded, type(r).__name__, r)
+                        % (val_expr, expanded, type(r).__name__, r),
                     )
 
                 custom_values[key] = r


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Implements the requested feature in #3773 by adding a `# nuitka-project-set: KEY = expression` directive. This allows users to use `{KEY}` in subsequent `# nuitka-project:` options, perfectly matching the existing `{OS}` and `{Arch}` syntax.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3773 

<!-- Link to the issue or explain the motivation. -->

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective.

### Used command:

<Input from Issue #3773> What would I need to change/add for option 2? Can you implement this?

--> I manually reviewed the code and made a few adjustments to the AI generated code.

### New feature overwiev:

This PR allows that something like this is now possible:

```python
# Compilation instructions
# nuitka-project: --standalone
# nuitka-project-set: MYPKGVERSION = __import__("mypkg").__version__
# nuitka-project: --file-version={MYPKGVERSION}
# nuitka-project: --company-name=MyTestCompany
# nuitka-project: --product-name=MyTestProduct

import mypkg

if __name__ == "__main__":
    print(f"Hello from compiled Nuitka! Package version is: {mypkg.__version__}")
```

This is just my vision of what I would really appreciate as a feature in Nuitka. I would really appreciate if you could take a look a this.

## Summary by Sourcery

Add support for user-defined project variables in Nuitka project options.

New Features:
- Introduce a `nuitka-project-set` directive to define project-scoped variables from evaluated Python expressions.
- Allow subsequently defined Nuitka project options to reference custom variables alongside existing built-in placeholders.

Enhancements:
- Extend project option expansion to accept and propagate a dictionary of custom variable values across directives.