### PR TITLE
Fix memory bloat when compiling SQLAlchemy

### DIFF
--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -784,6 +784,7 @@ According to Yaml 'overridden-environment-variables' configuration."""
         "tensorflow.**.test_util",  # Not performance relevant.
         "google.protobuf.*_pb2",  #  Too large generated code
         "sqlfluff.dialects.*",  #  Too large generated code
+        "sqlalchemy.dialects.oracle.dictionary",  #  Too large generated code
     )
 
     def decideCompilation(self, module_name):


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Fixes memory bloat when compiling SQLAlchemy by adding the problematic file to the internal unworty_modules list.
This dropped the memory usage from over 11GB to around 3.5GB.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3778 

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Prevent memory bloat during SQLAlchemy compilation by marking the Oracle dictionary dialect module as unworthy for compilation.