### PR TITLE
Fix ModuleNotFoundError for SciPy 1.17.0

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -5854,6 +5854,11 @@
     - depends:
         - 'scipy._lib.messagestream'
 
+- module-name: 'scipy._lib._ccallback' # checksum: 41e6ce11
+  implicit-imports:
+    - depends:
+        - 'scipy._cyutility'
+
 - module-name: 'scipy._lib._docscrape' # checksum: e4a58ca7
   anti-bloat:
     - description: 'remove sphinx reference'


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Adds support for SciPy 1.17.0

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3780.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Include scipy._lib._ccallback and its dependency on scipy._cyutility in the standard plugin configuration to prevent ModuleNotFoundError with SciPy 1.17.0.