### PR TITLE
Fix ModuleNotFoundError for h5py

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2048,7 +2048,7 @@
         - '*.csv'
         - '*.jar'
 
-- module-name: 'h5py' # checksum: 5a8caf97
+- module-name: 'h5py' # checksum: a1a03058
   anti-bloat:
     - description: 'remove IPython reference'
       change_function:
@@ -2059,6 +2059,9 @@
         'from .tests import run_tests': ''
       change_function:
         'run_tests': "'(lambda args=None: None)'"
+  implicit-imports:
+    - depends:
+        - 'h5py._npystrings'
 
 - module-name: 'h5py.h5' # checksum: 4247d58a
   implicit-imports:


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Fixes the ModuleNotFoundError when using h5py with Nuitka in standalone mode

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3782.

<!-- Link to the issue or explain the motivation. -->

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Prevent ModuleNotFoundError for h5py in standalone mode by adding its missing implicit dependency on h5py._npystrings to the standard plugin configuration.