### PR TITLE
Fix variable collision between nuitka-project-set and runtime variable names

### DIFF
--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -2423,6 +2423,14 @@ def getNuitkaProjectOptions(logger, filename_arg, module_mode):
                         % key,
                     )
 
+                if key in run_time_variable_names:
+                    return sysexit(
+                        line_number,
+                        "Error, 'nuitka-project-set' cannot overwrite reserved runtime variable '%s'. "
+                        "Reserved names are: %s."
+                        % (key, ", ".join(run_time_variable_names)),
+                    )
+
                 expanded = _expandProjectArg(
                     arg=val_expr,
                     filename_arg=filename_arg,


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR fixes a variable collision between nuitka-project-set and runtime variable names. 

The actual reported error message in Issue #3791 happens because the runtime variables are added after the custom values and are overwriting them:

https://github.com/Nuitka/Nuitka/blob/e84d50e159ce8fc6d028a942fd557f6619835eb8/nuitka/options/OptionParsing.py#L2282-L2291

But switching this around does not seem like a good idea, because even though unlikely that a user will do it, PID and similar variable names should not be allowed to be overwritten, so we can't switch this around.
I added a validation step that explicitly rejects variable names that are used as run_time_variable_names.
With this check it doesn't fail silently anymore and the user is informed about reserved variable names.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3791.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Prevent custom nuitka-project-set variables from silently overriding reserved runtime variables by validating and rejecting conflicting names.