### PR TITLE
Scons: Fix compilation failure when paths contain parentheses

### DIFF
--- a/nuitka/build/SconsSpawn.py
+++ b/nuitka/build/SconsSpawn.py
@@ -8,6 +8,7 @@ progress, and gives warnings about things taking very long.
 """
 
 import os
+import shlex
 import sys
 import threading
 
@@ -372,7 +373,7 @@ class SpawnThread(threading.Thread):
         sh, _cmd, args, os_env = args
 
         self.process = Process(
-            command=[sh, "-c", " ".join(args)],
+            command=[sh, "-c", " ".join(shlex.quote(arg) for arg in args)],
             env=os_env,
             rusage=True,
         )


### PR DESCRIPTION
Fixes #3664

## What does this PR do?

This PR fixes a shell syntax error that occurs when compiling projects located in directories whose paths contain parentheses (e.g., `/home/user/(1)/project`).

The fix adds proper shell quoting using `shlex.quote()` for arguments passed to the shell when spawning C compiler processes during the Scons build phase.

## Why was it initiated? Any relevant Issues?

Issue #3664 reported that Nuitka fails to compile when the project path contains parentheses. The shell interprets unquoted parentheses as subshell syntax, causing errors like:

```
sh: 1: Syntax error: "(" unexpected
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] **Correct base branch selected**: `develop` branch.
- [x] **Formatting**: Change follows existing code style.
- [x] **Tests**: The fix is minimal and self-contained. Manual verification was performed.
- [x] **New Coverage**: This is a simple fix for a specific edge case with path handling.

## Technical Details

The issue was in `nuitka/build/SconsSpawn.py` in the `SpawnThread.spawnSubprocess()` method. When building the shell command, arguments were joined with simple space separation:

```python
command=[sh, "-c", " ".join(args)]
```

This doesn't properly handle paths with special shell characters like parentheses. The fix uses `shlex.quote()` to properly escape each argument:

```python
command=[sh, "-c", " ".join(shlex.quote(arg) for arg in args)]
```

## Diff Stats

```
 nuitka/build/SconsSpawn.py | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Summary by Sourcery

Bug Fixes:
- Prevent compilation failures when project or file paths containing shell-special characters like parentheses are passed to the compiler during Scons builds.