### PR TITLE
Refactor async generator yield handling for proper exception cleanup

### DIFF
--- a/nuitka/build/static_src/CompiledAsyncgenType.c
+++ b/nuitka/build/static_src/CompiledAsyncgenType.c
@@ -632,23 +632,21 @@ static PyObject *_Nuitka_Asyncgen_throw2(PyThreadState *tstate, struct Nuitka_As
         }
 
         if (unlikely(ret == NULL)) {
+            // Return value or exception, not to continue with yielding from.
+            if (asyncgen->m_yield_from != NULL) {
+                CHECK_OBJECT(asyncgen->m_yield_from);
+#if _DEBUG_ASYNCGEN
+                PRINT_ASYNCGEN_STATUS("Null return, yield from removal:", asyncgen);
+                PRINT_COROUTINE_VALUE("yield_from", asyncgen->m_yield_from);
+#endif
+                Py_DECREF(asyncgen->m_yield_from);
+                asyncgen->m_yield_from = NULL;
+            }
+
             PyObject *val;
 
             if (Nuitka_PyGen_FetchStopIterationValue(tstate, &val)) {
                 CHECK_OBJECT(val);
-
-                asyncgen->m_yield_from = NULL;
-
-                // Return value, not to continue with yielding from.
-                if (asyncgen->m_yield_from != NULL) {
-                    CHECK_OBJECT(asyncgen->m_yield_from);
-#if _DEBUG_ASYNCGEN
-                    PRINT_ASYNCGEN_STATUS("Yield from removal:", asyncgen);
-                    PRINT_COROUTINE_VALUE("yield_from", asyncgen->m_yield_from);
-#endif
-                    Py_DECREF(asyncgen->m_yield_from);
-                    asyncgen->m_yield_from = NULL;
-                }
 
 #if _DEBUG_ASYNCGEN
                 PRINT_ASYNCGEN_STATUS("Sending return value into ourselves", asyncgen);
@@ -663,7 +661,6 @@ static PyObject *_Nuitka_Asyncgen_throw2(PyThreadState *tstate, struct Nuitka_As
             } else {
 #if _DEBUG_ASYNCGEN
                 PRINT_ASYNCGEN_STATUS("Sending exception value into ourselves", asyncgen);
-                PRINT_COROUTINE_VALUE("yield_from", asyncgen->m_yield_from);
                 PRINT_CURRENT_EXCEPTION();
                 PRINT_NEW_LINE();
 #endif


### PR DESCRIPTION
 ❓ What does this PR do?
                                                                                                                                                                                                                     
  Fixes m_yield_from cleanup ordering in _Nuitka_Asyncgen_throw2 to match the correct pattern already used by _Nuitka_Generator_throw2 and _Nuitka_Coroutine_throw2.                                               

  When an inner awaitable returns NULL with a non-StopIteration exception (e.g., asyncio.CancelledError), m_yield_from is now cleared before the StopIteration check, ensuring the exception is properly sent to the
  generator body rather than re-entering the (now-closed) yield_from mechanism.

  🧐 Why was it initiated? Any relevant Issues?

  In production use (agent-framework / semantic-kernel), cancelling an async workflow backed by Nuitka-compiled async generators required 3 cancellation attempts and produced AttributeError: 'NoneType' object has
  no attribute 'type' errors.

  Root cause: In _Nuitka_Asyncgen_throw2 (CompiledAsyncgenType.c, lines 634–674), when yield_from returns NULL with a CancelledError (a BaseException, not StopIteration), m_yield_from was not cleaned up. This
  caused _Nuitka_Asyncgen_send to re-enter the yield_from mechanism. Since the yield_from (asend) was already CLOSED, its throw() returned StopIteration, silently replacing CancelledError. This made async for
  loops exit normally instead of propagating the cancellation, causing:

  - Code after async for to execute when it shouldn't
  - Bogus None values yielded from the generator
  - CancelledError silently swallowed and replaced by StopIteration

  Both _Nuitka_Generator_throw2 and _Nuitka_Coroutine_throw2 already handle this correctly by clearing m_yield_from before the StopIteration check. This PR aligns the async generator to the same pattern.

  🧱 Type of Change

  - 🐛 Bug fix (non-breaking change which fixes an issue)
  - 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - 🧹 Refactoring (no functional changes, no api changes)
  - 🏗️  Build / CI System

  ✅ PR Checklist

  - Correct base branch selected: Should be develop branch.
  - Formatting: Enabled commit hook or executed ./bin/autoformat-nuitka-source.
  - Tests: All tests still pass. (See https://nuitka.net/doc/developer-manual.html#running-the-tests).
    - CI actions cover the basics, but manual verification is encouraged.
  - New Coverage: New features or fixed regressions are covered via new tests.
    - 6 test cases covering: cancellation fallthrough, nested generators, except Exception interaction, asyncio.timeout, normal iteration regression, and regular exception regression.
    - Tests confirmed to fail without the fix (AFTER_LOOP sentinel reached, results: [0, 1, None, 'AFTER_LOOP']) and pass with the fix.
  - Documentation: Documentation updates are included for new or changed features.

  🤖 AI Generated Code Policy

  - Detection: This PR contains AI generated code.
    - Issue First: I have created an issue explaining the problem before using AI to generate a fix, ensuring the direction is correct.
    - Documentation: I have provided the prompts used to generate the code (non-optional).
    - Verification: I have manually verified the AI generated code.
    Note: AI generated code is welcome, but it must be peer-reviewed and understood by the submitter. Blindly copying AI output without understanding is not acceptable.
    - Evidence: I have included test evidence that the change is effective.

  Test Evidence

  Without fix (Nuitka-compiled): Test 1 fails:
  AssertionError: BUG: Code after 'async for' executed during cancellation!
  CancelledError was swallowed and replaced by StopIteration.
  Got results: [0, 1, None, 'AFTER_LOOP']

  With fix (Nuitka-compiled): All 6 tests pass:
  Test 1: PASS – no code after async for on cancel
  Test 2: PASS – no fallthrough in nested generators
  Test 3: PASS – except Exception did not catch CancelledError
  Test 4: PASS – timeout did not cause fallthrough
  Test 5: PASS – normal iteration works correctly: [0, 1, 2, 999]
  Test 6: PASS – regular exceptions still caught: [1, 'caught:ValueError']

  CPython 3.12 (baseline): All 6 tests pass.
