### PR TITLE
🐛 Bug fix: filter libHacl_Hash_SHA2 from link libs unconditionally

### DIFF
--- a/nuitka/build/SconsPythonBuild.py
+++ b/nuitka/build/SconsPythonBuild.py
@@ -15,7 +15,6 @@ def _detectPythonHeaderPath(env):
     # Many cases to deal with due to flavor peculiarities, pylint: disable=too-many-branches
 
     if os.name == "nt":
-
         candidates = [
             # On Windows, the CPython official installation layout is relatively fixed,
             os.path.join(env.python_prefix_external, "include"),
@@ -209,13 +208,13 @@ def addPythonHaclLib(env, link_module_libs):
             # env.Append(CPPDEFINES=["HACL_CAN_COMPILE_VEC128"])
             env.Append(CPPDEFINES=["HACL_CAN_COMPILE_VEC256"])
 
-        # Remove it from static link libraries as well, if present, so far they are
-        # bugs and do not exist.
-        link_module_libs = [
-            link_module_lib
-            for link_module_lib in link_module_libs
-            if "libHacl_Hash_SHA2" not in link_module_lib
-        ]
+    # Remove it from static link libraries unconditionally — libHacl_Hash_SHA2
+    # is an internal CPython build artifact, never shipped as a standalone .a file.
+    link_module_libs = [
+        link_module_lib
+        for link_module_lib in link_module_libs
+        if "libHacl_Hash_SHA2" not in link_module_lib
+    ]
 
     return link_module_libs
 


### PR DESCRIPTION
# Summary:
The libHacl_Hash_SHA2 filter was inside the `if env.static_libpython` block, so it was skipped when no static libpython was available (e.g., Python Build Standalone via uv). Since libHacl_Hash_SHA2.a is an internal CPython build artifact never shipped as a standalone library, the filter must run regardless of static_libpython to prevent linker failures.


# Bug Description
When compiling with --standalone using Python Build Standalone (e.g., via uv), the C linking stage fails because the linker cannot find libHacl_Hash_SHA2.a:
/usr/bin/ld: cannot find -l:libHacl_Hash_SHA2.a: No such file or directory
collect2: error: ld returned 1 exit status

The root cause is in SconsPythonBuild.py:addPythonHaclLib(). The code that filters out libHacl_Hash_SHA2 from link_module_libs is inside the if env.static_libpython guard block. When using Python Build Standalone, static_libpython is falsy (no libpython*.a is available), so the filter is skipped entirely. However, sysconfig.get_config_var("MODLIBS") still returns -l:libHacl_Hash_SHA2.a, which gets passed to the linker — and the library doesn't exist as a standalone file on any system. It's an internal CPython build artifact that is never shipped.

# Environment
Nuitka Version: 4.0.3
Python: 3.12.3 (Python Build Standalone, via uv)
OS: Linux x86_64
GCC: 15.2.1
Install method: uv add nuitka (virtualenv managed by uv)

## To Reproduce
1. Use a Python Build Standalone distribution (e.g., installed via uv or rye) — these do not ship libpython3.12.a
2. Compile any program with --standalone:
```
# hello.py
print("hello world")
python -m nuitka --standalone hello.py
```
4. The build will fail at the linking stage with:
/usr/bin/ld: cannot find -l:libHacl_Hash_SHA2.a: No such file or directory
The issue is specific to Python distributions that don't include a static libpython*.a (like Python Build Standalone). System Python or Anaconda typically have the static lib, so the if env.static_libpython branch is entered and the filter works correctly.

##Expected Behavior
Compilation succeeds. libHacl_Hash_SHA2 should always be filtered from link_module_libs since it is never a valid standalone linkable library — it's compiled into CPython itself.

## Actual Behavior
Linker fails with cannot find -l:libHacl_Hash_SHA2.a.

# Fix
In nuitka/build/SconsPythonBuild.py, the libHacl_Hash_SHA2 filter (lines 198-202) must be moved outside the if env.static_libpython block so it runs unconditionally. The filter was only wrong by indentation level — it needs to be dedented one level so it runs regardless of static_libpython.