### PR TITLE
Add missing dlls section for openvino in standard config

### DIFF
--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -495,7 +495,16 @@ def getExecutablePath(filename, env):
     # Variable substitution from environment is needed, because this can contain
     # "$CC" which should be looked up too.
     while filename.startswith("$"):
-        filename = env[filename[1:]]
+        variable_name = filename[1:]
+
+        filename = env[variable_name]
+
+        if filename is None:
+            scons_logger.sysexit(
+                """\
+Error, scons environment variable '%s' is not set, this ought to never happen. Please report the bug."""
+                % variable_name
+            )
 
     # Append ".exe" suffix  on Windows if not already present.
     if os.name == "nt" and not filename.lower().endswith(".exe"):

--- a/nuitka/nodes/GlobalsLocalsNodes.py
+++ b/nuitka/nodes/GlobalsLocalsNodes.py
@@ -171,7 +171,11 @@ class ExpressionBuiltinLocalsCopy(ExpressionBuiltinLocalsBase):
             pairs=_sorted(pairs), source_ref=self.source_ref
         )
 
-        return result, "new_expression", "Statically predicted locals dictionary."
+        return (
+            result,
+            "changed_variable_usage" if pairs else "new_expression",
+            "Statically predicted locals dictionary.",
+        )
 
 
 class ExpressionBuiltinDir1(ExpressionBuiltinSingleArgBase):

--- a/nuitka/nodes/LocalsDictNodes.py
+++ b/nuitka/nodes/LocalsDictNodes.py
@@ -169,32 +169,7 @@ class ExpressionLocalsVariableRefOrFallback(ChildHavingFallbackMixin, Expression
         ):
             variable_name = self.variable.getName()
 
-            # Create a cloned node with the locals variable.
-            call_node_clone = call_node.makeClone()
-            call_node_clone.setChildCalled(
-                ExpressionLocalsVariableRef(
-                    locals_scope=self.locals_scope,
-                    variable_name=variable_name,
-                    source_ref=self.source_ref,
-                )
-            )
-
-            # Make the original one for the fallback
-            call_node = call_node.makeCloneShallow()
-            call_node.setChildCalled(self.subnode_fallback)
-
-            result = ExpressionConditional(
-                condition=ExpressionLocalsVariableCheck(
-                    locals_scope=self.locals_scope,
-                    variable_name=variable_name,
-                    source_ref=self.source_ref,
-                ),
-                expression_yes=call_node_clone,
-                expression_no=call_node,
-                source_ref=self.source_ref,
-            )
-
-            if self.variable.getName() in (
+            if variable_name in (
                 "dir",
                 "eval",
                 "exec",
@@ -205,11 +180,37 @@ class ExpressionLocalsVariableRefOrFallback(ChildHavingFallbackMixin, Expression
                 # Just inform the collection that all escaped.
                 trace_collection.onLocalsUsage(self.getLocalsDictScope())
 
-            return (
-                result,
-                "new_expression",
-                "Moved call of uncertain dict variable '%s' to inside." % variable_name,
-            )
+                # Create a cloned node with the locals variable.
+                call_node_clone = call_node.makeClone()
+                call_node_clone.setChildCalled(
+                    ExpressionLocalsVariableRef(
+                        locals_scope=self.locals_scope,
+                        variable_name=variable_name,
+                        source_ref=self.source_ref,
+                    )
+                )
+
+                # Make the original one for the fallback
+                call_node = call_node.makeCloneShallow()
+                call_node.setChildCalled(self.subnode_fallback)
+
+                result = ExpressionConditional(
+                    condition=ExpressionLocalsVariableCheck(
+                        locals_scope=self.locals_scope,
+                        variable_name=variable_name,
+                        source_ref=self.source_ref,
+                    ),
+                    expression_yes=call_node_clone,
+                    expression_no=call_node,
+                    source_ref=self.source_ref,
+                )
+
+                return (
+                    result,
+                    "new_expression",
+                    "Moved call of uncertain dict variable '%s' to inside."
+                    % variable_name,
+                )
 
         return call_node, None, None
 

--- a/nuitka/optimizations/Optimization.py
+++ b/nuitka/optimizations/Optimization.py
@@ -88,6 +88,9 @@ def optimizeCompiledPythonModule(module):
     while True:
         micro_pass += 1
 
+        # Indicator that new variables or changed were added in the previous
+        # pass, will require another pass to fully propagate.
+        added_variables = "changed_variable_usage" in tag_set
         tag_set.clear()
 
         try:
@@ -100,8 +103,9 @@ def optimizeCompiledPythonModule(module):
             general.info("Interrupted while working on '%s'." % module)
             raise
 
-        if scopes_were_incomplete:
+        if scopes_were_incomplete or added_variables:
             tag_set.add("var_usage")
+        added_variables = False
 
         Graphs.onModuleOptimizationStep(module)
 

--- a/nuitka/optimizations/OptimizeBuiltinCalls.py
+++ b/nuitka/optimizations/OptimizeBuiltinCalls.py
@@ -1526,7 +1526,7 @@ def _describeNewNode(new_node):
         tags = "new_expression"
         message = "call"
     elif new_node.isExpressionOutlineBody():
-        tags = "new_expression"
+        tags = "changed_variable_usage"
         message = "outlined function"
     elif new_node.isExpressionConstantRef():
         tags = "new_expression"

--- a/nuitka/optimizations/Tags.py
+++ b/nuitka/optimizations/Tags.py
@@ -21,7 +21,7 @@ allowed_tags = (
     "new_expression",
     # Loop analysis is incomplete, or only just now completed.
     "loop_analysis",
-    # TODO: A bit unclear what this it, potentially a changed variable.
+    # Changed variable usage
     "var_usage",
     # Detected module variable to be read only.
     "read_only_module_variable",
@@ -35,6 +35,8 @@ allowed_tags = (
     "new_raise",
     # New constant introduced.
     "new_constant",
+    # New variable introduced or variable references removed.
+    "changed_variable_usage",
 )
 
 

--- a/nuitka/plugins/standard/ImplicitImports.py
+++ b/nuitka/plugins/standard/ImplicitImports.py
@@ -323,7 +323,7 @@ class NuitkaPluginImplicitImports(NuitkaYamlPluginBase):
 
                     if module_name.matchesToShellPattern(
                         "*__mypyc"
-                    ):  # spell-checker: ignore mypyc
+                    )[0]:  # spell-checker: ignore mypyc
                         yield module_name
 
         if full_name == "pkg_resources.extern":

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3699,7 +3699,7 @@
         - 'libs'
 
   dlls:
-    - from_filesnames:
+    - from_filenames:
         relative_path: 'libs'
         prefixes:
           - ''

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3698,6 +3698,12 @@
     - dirs:
         - 'libs'
 
+  dlls:
+    - from_filesnames:
+        relative_path: 'libs'
+        prefixes:
+          - ''
+
 - module-name: 'openvino.inference_engine' # checksum: 9100f948
   dlls:
     - from_filenames:

--- a/tests/reflected/compile_itself.py
+++ b/tests/reflected/compile_itself.py
@@ -258,7 +258,6 @@ def executePASS1():
         os.environ["PYTHON"],
         nuitka_main_path,
         "--nofollow-imports",
-        "--enable-plugin=pylint-warnings",
         "--output-dir=.",
         "--python-flag=no_site",
         "nuitka-runner.py",
@@ -352,7 +351,6 @@ def compileAndCompareWith(nuitka, pass_number):
                 command = [
                     nuitka,
                     "--mode=module",
-                    "--enable-plugin=pylint-warnings",
                     "--output-dir=%s" % tmp_dir,
                     "--no-pyi-file",
                     "--nofollow-imports",
@@ -492,7 +490,6 @@ def executePASS5():
     command = [
         os.environ["PYTHON"],
         nuitka_main_path,
-        "--enable-plugin=pylint-warnings",
         "--output-dir=%s" % tmp_dir,
         "--include-plugin-dir=%s" % path,
         "--nofollow-import-to=nuitka.build.inline_copy",


### PR DESCRIPTION
# Description

Add missing dlls section for openvino in standard config
Fixes #3493 
Fixes #1699

## ❓ What does this PR do?

It fixes the openvino error of not being able to load any models because the DLLs are missing and openvino.dll was placed in the root by dependency walker by mistake.

## 🧐 Why was it initiated? Any relevant Issues?

#3493 , #1699

## 🧱 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🏗️ Build / CI System

## Summary by Sourcery

Add configuration for OpenVINO DLL discovery in the standard Nuitka package config.

Bug Fixes:
- Resolve OpenVINO runtime failures caused by missing DLLs in packaged applications.

Build:
- Extend the standard Nuitka package configuration to include DLL collection from the OpenVINO libs directory.