### PR TITLE
Add missing dlls section for openvino in standard config

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3693,10 +3693,15 @@
       replacements_plain:
         'opentelemetry.util._importlib_metadata': 'importlib_metadata'
 
-- module-name: 'openvino' # checksum: 4e2c2404
+- module-name: 'openvino' # checksum: 3c2ae57e
   data-files:
     - dirs:
         - 'libs'
+  dlls:
+    - from_filenames:
+        relative_path: 'libs'
+        prefixes:
+          - ''
 
 - module-name: 'openvino.inference_engine' # checksum: 9100f948
   dlls:


### PR DESCRIPTION
# Description

Add missing dlls section for openvino in standard config
Fixes #3493 
Fixes #1699

## ❓ What does this PR do?

It fixes the openvino error of not being able to load any models because the DLLs are missing and openvino.dll was placed in the root by dependency walker by mistake.

## 🧐 Why was it initiated? Any relevant Issues?

#3493 , #1699

## 🧱 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🏗️ Build / CI System

## ✅ PR Checklist

- [X] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## Summary by Sourcery

Add configuration to ensure OpenVINO DLLs are collected from the standard libs directory so OpenVINO models can be loaded correctly.

Bug Fixes:
- Resolve OpenVINO failing to load models due to missing DLLs in the packaged application.

Build:
- Update standard Nuitka package configuration to include DLLs from the OpenVINO libs directory.