### PR TITLE
AppImage packaging

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     container: debian:stable-slim
     name: AppImage Linux x86_64
+    env:
+      PIP_ROOT_USER_ACTION: ignore
     steps:
       - name: Install system dependencies
         run: |
@@ -61,9 +63,12 @@ jobs:
           filter: blob:none
         id: checkout_retry_2
 
+      - name: Fix pip cache directory
+        run: mkdir -p /github/home/.cache/pip
+
       - name: Install Nuitka Python dependencies
         run: |
-          pip3 install --break-system-packages --root-user-action=ignore --no-cache-dir \
+          pip3 install --break-system-packages \
             appdirs tqdm "zstandard>=0.15" pyyaml "Jinja2>=2.10.2" ordered-set
 
       - name: Determine version

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -117,7 +117,13 @@ jobs:
               "${api}/releases" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
           }
 
-          # Upload asset
+          # Delete existing asset if present, then upload
+          asset_name=$(basename "${file}")
+          asset_id=$(curl -sf -H "$auth" "${api}/releases/${release_id}/assets" | \
+            python3 -c "import sys,json; assets=json.load(sys.stdin); print(next((a['id'] for a in assets if a['name']=='${asset_name}'),''))" 2>/dev/null) || true
+          if [ -n "$asset_id" ]; then
+            curl -sf -X DELETE -H "$auth" "${api}/releases/assets/${asset_id}"
+          fi
           curl -sf -X POST -H "$auth" -H "Content-Type: application/octet-stream" \
             --data-binary "@${file}" \
-            "https://uploads.github.com/repos/${repo}/releases/${release_id}/assets?name=$(basename "${file}")"
+            "https://uploads.github.com/repos/${repo}/releases/${release_id}/assets?name=${asset_name}"

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -3,7 +3,7 @@ name: AppImage
 on:
   push:
     tags:
-      - "[0-9]*"
+      - "[0-9]*.[0-9]*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,118 @@
+name: AppImage
+
+on:
+  push:
+    tags:
+      - "[0-9]*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  appimage-linux-x86_64:
+    runs-on: ubuntu-24.04
+    container: debian:stable-slim
+    name: AppImage Linux x86_64
+    steps:
+      - name: Install system dependencies
+        run: |
+          apt-get update && apt-get install -y --no-install-recommends \
+            git \
+            python3 python3-dev python3-venv python3-pip \
+            gcc patchelf ccache \
+            squashfs-tools curl file ca-certificates
+
+      - name: Checkout (Attempt 1)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
+
+      - name: Install Nuitka Python dependencies
+        run: |
+          pip3 install --break-system-packages \
+            appdirs tqdm "zstandard>=0.15" pyyaml "Jinja2>=2.10.2" ordered-set
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(python3 -c "from nuitka.Version import getNuitkaVersion; print(getNuitkaVersion())")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build AppImage
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+        run: |
+          python3 misc/make-appimage.py \
+            --output "Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage"
+
+      - name: Verify AppImage
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+        run: |
+          ./Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage --version
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
+          path: Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
+
+      - name: Attach to release
+        if: github.ref_type == 'tag'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ github.ref_name }}"
+          file="Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage"
+          repo="${{ github.repository }}"
+          api="https://api.github.com/repos/${repo}"
+          auth="Authorization: Bearer ${GITHUB_TOKEN}"
+
+          # Get or create release for this tag
+          release_id=$(curl -sf -H "$auth" "${api}/releases/tags/${tag}" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) || {
+            release_id=$(curl -sf -X POST -H "$auth" \
+              -d "{\"tag_name\":\"${tag}\",\"name\":\"Nuitka ${tag}\",\"generate_release_notes\":true}" \
+              "${api}/releases" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+          }
+
+          # Upload asset
+          curl -sf -X POST -H "$auth" -H "Content-Type: application/octet-stream" \
+            --data-binary "@${file}" \
+            "https://uploads.github.com/repos/${repo}/releases/${release_id}/assets?name=$(basename "${file}")"

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,10 +21,10 @@ jobs:
             git \
             python3 python3-dev python3-venv python3-pip \
             gcc patchelf ccache \
-            squashfs-tools curl file ca-certificates
+            squashfs-tools curl file ca-certificates gpg
 
       - name: Checkout (Attempt 1)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: false
@@ -39,7 +39,7 @@ jobs:
 
       - name: Checkout (Attempt 2)
         if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: false
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout (Attempt 3)
         if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: false
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Nuitka Python dependencies
         run: |
-          pip3 install --break-system-packages \
+          pip3 install --break-system-packages --root-user-action=ignore --no-cache-dir \
             appdirs tqdm "zstandard>=0.15" pyyaml "Jinja2>=2.10.2" ordered-set
 
       - name: Determine version
@@ -89,7 +89,7 @@ jobs:
           ./Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage --version
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage
           path: Nuitka-${{ steps.version.outputs.version }}-linux-x86_64.AppImage

--- a/misc/Dockerfile.appimage
+++ b/misc/Dockerfile.appimage
@@ -1,0 +1,38 @@
+FROM debian:stable-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Allow appimagetool (which is itself an AppImage) to run without FUSE.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    gcc \
+    patchelf \
+    ccache \
+    squashfs-tools \
+    curl \
+    file \
+    ca-certificates \
+    && rm -rf -- /var/lib/apt/lists/*
+
+# Install Nuitka's Python dependencies for the build.
+RUN pip3 install --break-system-packages \
+    appdirs tqdm "zstandard>=0.15" pyyaml "Jinja2>=2.10.2" ordered-set
+
+WORKDIR /src
+COPY . /src/
+
+RUN mkdir -p -- /out && \
+    python3 /src/misc/make-appimage.py --output /out/Nuitka-x86_64.AppImage
+
+# Verify it works (extract since no FUSE in container)
+RUN /out/Nuitka-x86_64.AppImage --appimage-extract > /dev/null 2>&1 && \
+    squashfs-root/AppRun --version && \
+    rm -rf -- squashfs-root
+
+# Output stage
+FROM scratch
+COPY --from=builder /out/Nuitka-x86_64.AppImage /Nuitka-x86_64.AppImage

--- a/misc/Dockerfile.appimage
+++ b/misc/Dockerfile.appimage
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     file \
     ca-certificates \
+    gpg \
     && rm -rf -- /var/lib/apt/lists/*
 
 # Install Nuitka's Python dependencies for the build.

--- a/misc/Dockerfile.appimage
+++ b/misc/Dockerfile.appimage
@@ -25,14 +25,17 @@ RUN pip3 install --break-system-packages \
 WORKDIR /src
 COPY . /src/
 
+ARG APPIMAGE_FILENAME=Nuitka-x86_64.AppImage
+
 RUN mkdir -p -- /out && \
-    python3 /src/misc/make-appimage.py --output /out/Nuitka-x86_64.AppImage
+    python3 /src/misc/make-appimage.py --output "/out/${APPIMAGE_FILENAME}"
 
 # Verify it works (extract since no FUSE in container)
-RUN /out/Nuitka-x86_64.AppImage --appimage-extract > /dev/null 2>&1 && \
+RUN "/out/${APPIMAGE_FILENAME}" --appimage-extract > /dev/null 2>&1 && \
     squashfs-root/AppRun --version && \
     rm -rf -- squashfs-root
 
 # Output stage
 FROM scratch
-COPY --from=builder /out/Nuitka-x86_64.AppImage /Nuitka-x86_64.AppImage
+ARG APPIMAGE_FILENAME=Nuitka-x86_64.AppImage
+COPY --from=builder /out/${APPIMAGE_FILENAME} /${APPIMAGE_FILENAME}

--- a/misc/Dockerfile.appimage
+++ b/misc/Dockerfile.appimage
@@ -1,0 +1,41 @@
+FROM debian:stable-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Allow appimagetool (which is itself an AppImage) to run without FUSE.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    gcc \
+    patchelf \
+    ccache \
+    squashfs-tools \
+    curl \
+    file \
+    ca-certificates \
+    && rm -rf -- /var/lib/apt/lists/*
+
+# Install Nuitka's Python dependencies for the build.
+RUN pip3 install --break-system-packages \
+    appdirs tqdm "zstandard>=0.15" pyyaml "Jinja2>=2.10.2" ordered-set
+
+WORKDIR /src
+COPY . /src/
+
+ARG APPIMAGE_FILENAME=Nuitka-x86_64.AppImage
+
+RUN mkdir -p -- /out && \
+    python3 /src/misc/make-appimage.py --output "/out/${APPIMAGE_FILENAME}"
+
+# Verify it works (extract since no FUSE in container)
+RUN "/out/${APPIMAGE_FILENAME}" --appimage-extract > /dev/null 2>&1 && \
+    squashfs-root/AppRun --version && \
+    rm -rf -- squashfs-root
+
+# Output stage
+FROM scratch
+ARG APPIMAGE_FILENAME=Nuitka-x86_64.AppImage
+COPY --from=builder /out/${APPIMAGE_FILENAME} /${APPIMAGE_FILENAME}

--- a/misc/make-appimage.py
+++ b/misc/make-appimage.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+#     Copyright 2026, Simon Robin Lehn, MIT license, see end of file
+#
+# Build a self-contained Nuitka AppImage for Linux.
+#
+# Requirements on the build host:
+#   - python3, python3-dev, python3-venv
+#   - patchelf, ccache
+#   - mksquashfs (squashfs-tools)
+#   - gcc
+#   - Internet access (downloads appimagetool runtime)
+#
+# The resulting AppImage bundles Python, dev headers, patchelf, ccache,
+# and all Nuitka dependencies. Only a C compiler ($CC) is needed on the
+# target system.
+#
+# Usage:
+#   python3 misc/make-appimage.py [--python /path/to/python3]
+
+import argparse
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(*args, **kwargs):
+    """Run a command, raising on failure."""
+    kwargs.setdefault("check", True)
+    return subprocess.run(*args, **kwargs)
+
+
+def capture(*args, **kwargs):
+    """Run a command and return stripped stdout."""
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(*args, **kwargs).stdout.strip()
+
+
+def python_query(python, code):
+    """Run a Python one-liner and return the output."""
+    return capture([python, "-c", code])
+
+
+def get_ldd_deps(binary):
+    """Return non-glibc shared library paths needed by a binary."""
+    skip = {
+        "libc.so",
+        "libm.so",
+        "libdl.so",
+        "librt.so",
+        "libpthread.so",
+        "ld-linux",
+        "linux-vdso",
+    }
+    deps = []
+    try:
+        output = capture(["ldd", binary])
+    except subprocess.CalledProcessError:
+        return deps
+    for line in output.splitlines():
+        if "=> /" not in line:
+            continue
+        lib_path = line.split("=> ")[1].split(" (")[0].strip()
+        lib_name = os.path.basename(lib_path)
+        if any(lib_name.startswith(s) for s in skip):
+            continue
+        deps.append(lib_path)
+    return deps
+
+
+def bundle_binary_with_deps(binary_path, appdir):
+    """Copy a binary and its non-glibc shared lib deps into the AppDir."""
+    bin_name = os.path.basename(binary_path)
+    shutil.copy2(binary_path, appdir / "usr" / "bin" / bin_name)
+    lib_dir = appdir / "usr" / "lib"
+    for dep in get_ldd_deps(binary_path):
+        dep_name = os.path.basename(dep)
+        if not (lib_dir / dep_name).exists():
+            shutil.copy2(dep, lib_dir / dep_name)
+
+
+def fix_absolute_symlinks(directory, resolve=False):
+    """Fix or remove absolute symlinks in a directory (non-recursive).
+
+    If resolve is True, replace absolute symlinks pointing to existing files
+    with copies. Remove dangling absolute symlinks either way.
+    """
+    for entry in directory.iterdir():
+        if not entry.is_symlink():
+            continue
+        target = os.readlink(entry)
+        if not target.startswith("/"):
+            continue
+        if resolve and os.path.isfile(target):
+            entry.unlink()
+            shutil.copy2(target, entry)
+        else:
+            entry.unlink()
+
+
+def fix_libpython_symlinks(lib_dir, pyver):
+    """Make libpython symlinks relative and ensure the linker .so exists."""
+    for f in lib_dir.glob(f"libpython{pyver}*.so"):
+        if not f.is_symlink():
+            continue
+        target = os.readlink(f)
+        if target.startswith("/"):
+            f.unlink()
+            f.symlink_to(os.path.basename(target))
+    versioned = lib_dir / f"libpython{pyver}.so.1.0"
+    linker = lib_dir / f"libpython{pyver}.so"
+    if versioned.exists() and not linker.exists():
+        linker.symlink_to(versioned.name)
+
+
+def write_apprun(appdir):
+    """Write the AppRun entry point."""
+    apprun = appdir / "AppRun"
+    apprun.write_text(
+        """\
+#!/usr/bin/env bash
+HERE="$(dirname "$(readlink -f "$0")")"
+export PATH="${HERE}/usr/bin:${PATH}"
+export PYTHONHOME="${HERE}/usr"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+
+# Prefer system patchelf/ccache if installed and version >= bundled.
+_ver() { "$1" --version 2>&1 | head -1 | grep -oE "[0-9]+\\.[0-9]+(\\.[0-9]+)?" | head -1; }
+_prefer_tool() {
+    local bundled="$1" envvar="$2"
+    [ -x "$bundled" ] || return
+    local tool_name sys_path
+    tool_name="$(basename -- "$bundled")"
+    sys_path="$(PATH="/usr/local/bin:/usr/bin:/bin" command -v "$tool_name" 2>/dev/null)" || {
+        export "$envvar=$bundled"; return
+    }
+    local sv bv
+    sv="$(_ver "$sys_path")"
+    bv="$(_ver "$bundled")"
+    if [ -n "$sv" ] && [ -n "$bv" ] && \\
+       [ "$(printf '%s\\n%s\\n' "$bv" "$sv" | sort -V | tail -1)" = "$sv" ]; then
+        export "$envvar=$sys_path"
+    else
+        export "$envvar=$bundled"
+    fi
+}
+_prefer_tool "${HERE}/usr/bin/patchelf" NUITKA_PATCHELF_BINARY
+_prefer_tool "${HERE}/usr/bin/ccache"   NUITKA_CCACHE_BINARY
+
+exec "${HERE}/usr/bin/python3" -m nuitka "$@"
+"""
+    )
+    apprun.chmod(0o755)
+
+
+def write_desktop(appdir):
+    """Write the .desktop file."""
+    (appdir / "nuitka.desktop").write_text(
+        """\
+[Desktop Entry]
+Type=Application
+Name=Nuitka
+Exec=nuitka
+Icon=nuitka
+Categories=Development;
+Terminal=true
+Comment=Python Compiler
+X-AppImage-Integrate=false
+"""
+    )
+
+
+def write_icon(appdir, nuitka_src):
+    """Copy the Nuitka logo as the AppImage icon."""
+    shutil.copy2(nuitka_src / "doc" / "images" / "Nuitka-Logo-Symbol.png",
+                 appdir / "nuitka.png")
+
+
+def write_sitecustomize(stdlib_dir):
+    """Write sitecustomize.py to add site-packages to sys.path.
+
+    Debian Python uses dist-packages but pip in a venv installs to
+    site-packages. This ensures both are on sys.path regardless of flavor.
+    """
+    (stdlib_dir / "sitecustomize.py").write_text(
+        """\
+import os
+import site
+import sys
+
+_appimage_site = os.path.join(sys.prefix, "lib",
+    "python" + ".".join(str(x) for x in sys.version_info[:2]),
+    "site-packages")
+if os.path.isdir(_appimage_site) and _appimage_site not in sys.path:
+    site.addsitedir(_appimage_site)
+"""
+    )
+
+
+def get_appimagetool(arch):
+    """Download appimagetool if not already present, return its path."""
+    tool = os.environ.get("APPIMAGETOOL")
+    if tool and os.path.isfile(tool):
+        return tool
+    tool = f"/tmp/appimagetool-{arch}"
+    if os.path.isfile(tool) and os.access(tool, os.X_OK):
+        return tool
+    print("==> Downloading appimagetool...")
+    run(
+        [
+            "curl",
+            "-fsSL",
+            f"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-{arch}.AppImage",
+            "-o",
+            tool,
+        ]
+    )
+    os.chmod(tool, 0o755)
+    return tool
+
+
+def find_system_lib(name):
+    """Search common library paths for a shared library."""
+    machine = platform.machine()
+    for prefix in [f"/lib/{machine}-linux-gnu", "/lib64", "/usr/lib"]:
+        path = os.path.join(prefix, name)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build a Nuitka AppImage")
+    parser.add_argument("--python", default=os.environ.get("PYTHON", "python3"))
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    python = args.python
+    script_dir = Path(__file__).resolve().parent
+    nuitka_src = script_dir.parent
+    arch = platform.machine()
+
+    pyver = python_query(
+        python, "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')"
+    )
+    pyabi = python_query(
+        python, "import sys; print(sys.abiflags if hasattr(sys, 'abiflags') else '')"
+    )
+    nuitka_version = re.search(
+        r"Nuitka V([0-9rc.]+)",
+        (nuitka_src / "nuitka" / "Version.py").read_text(),
+    )
+    nuitka_version = nuitka_version.group(1) if nuitka_version else "unknown"
+
+    tmpdir = Path(tempfile.mkdtemp())
+    appdir = tmpdir / "Nuitka.AppDir"
+    output = (
+        Path(args.output)
+        if args.output
+        else nuitka_src / f"Nuitka-{nuitka_version}-{arch}.AppImage"
+    )
+
+    print("=== Building Nuitka AppImage ===")
+    print(f"  Python:  {python} ({pyver})")
+    print(f"  Nuitka:  {nuitka_version}")
+    print(f"  Arch:    {arch}")
+    print(f"  Output:  {output}")
+    print()
+
+    # --- Check prerequisites ---
+    for tool in ["mksquashfs", "patchelf", "ccache"]:
+        if not shutil.which(tool):
+            sys.exit(f"Error: '{tool}' is required but not found.")
+
+    # --- Create AppDir with Python venv ---
+    print("==> Creating AppDir with Python runtime...")
+    for d in ["usr/bin", "usr/lib", "usr/include"]:
+        (appdir / d).mkdir(parents=True)
+
+    run([python, "-m", "venv", str(appdir / "usr"), "--without-pip"])
+    run(
+        [str(appdir / "usr" / "bin" / "python3"), "-m", "ensurepip", "--default-pip"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    print("==> Installing Nuitka and dependencies...")
+    pip = str(appdir / "usr" / "bin" / "pip3")
+    run([pip, "install", "--quiet", str(nuitka_src)])
+    run(
+        [
+            pip,
+            "install",
+            "--quiet",
+            "appdirs",
+            "tqdm",
+            "zstandard>=0.15",
+            "pyyaml",
+            "Jinja2>=2.10.2",
+            "ordered-set",
+        ]
+    )
+
+    # Replace venv Python symlink with real binary
+    print("==> Bundling Python runtime...")
+    venv_python = appdir / "usr" / "bin" / "python3"
+    real_python = (
+        Path(os.readlink(venv_python)).resolve()
+        if venv_python.is_symlink()
+        else venv_python
+    )
+    real_bin = appdir / "usr" / "bin" / "python3.real"
+    shutil.copy2(real_python, real_bin)
+    for name in ["python3", "python"]:
+        link = appdir / "usr" / "bin" / name
+        link.unlink(missing_ok=True)
+        link.symlink_to("python3.real")
+
+    # Remove pyvenv.cfg so the bundled Python acts as a real installation.
+    (appdir / "usr" / "pyvenv.cfg").unlink(missing_ok=True)
+
+    # --- Bundle Python stdlib ---
+    stdlib_src = Path(
+        python_query(python, "import sysconfig; print(sysconfig.get_path('stdlib'))")
+    )
+    stdlib_dst = appdir / "usr" / "lib" / f"python{pyver}"
+    # Copy everything from system stdlib over the venv's stdlib
+    for item in stdlib_src.iterdir():
+        dst = stdlib_dst / item.name
+        if item.is_dir() and not item.is_symlink():
+            shutil.copytree(item, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dst, follow_symlinks=False)
+
+    # Resolve dangling absolute symlinks (e.g. sitecustomize.py -> /etc/...)
+    fix_absolute_symlinks(stdlib_dst, resolve=True)
+
+    # Write sitecustomize.py after stdlib copy to avoid being overwritten.
+    write_sitecustomize(stdlib_dst)
+
+    # --- Bundle libpython shared library ---
+    libdir = Path(
+        python_query(
+            python, "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"
+        )
+    )
+    lib_dst = appdir / "usr" / "lib"
+    for f in libdir.glob(f"libpython{pyver}*"):
+        dst = lib_dst / f.name
+        if f.is_symlink():
+            link_target = os.readlink(f)
+            dst.symlink_to(link_target)
+        else:
+            shutil.copy2(f, dst)
+    fix_libpython_symlinks(lib_dst, pyver)
+
+    # --- Bundle Python dev headers ---
+    print("==> Bundling Python dev headers...")
+    sys_include = Path(
+        python_query(python, "import sysconfig; print(sysconfig.get_path('include'))")
+    )
+    if sys_include.is_dir():
+        inc_dst = appdir / "usr" / "include" / f"python{pyver}{pyabi}"
+        shutil.copytree(sys_include, inc_dst, dirs_exist_ok=True)
+    else:
+        print(
+            f"Warning: Python dev headers not found at {sys_include}", file=sys.stderr
+        )
+        print(
+            f"         Install python{pyver}-dev for full functionality.",
+            file=sys.stderr,
+        )
+
+    # --- Bundle Python config dir (Makefile, static lib) ---
+    cfgdir = Path(
+        python_query(
+            python, "import sysconfig; print(sysconfig.get_config_var('LIBPL'))"
+        )
+    )
+    cfgname = cfgdir.name
+    cfg_dst = appdir / "usr" / "lib" / f"python{pyver}" / cfgname
+    cfg_dst.mkdir(parents=True, exist_ok=True)
+    for item in cfgdir.iterdir():
+        dst = cfg_dst / item.name
+        dst.unlink(missing_ok=True)
+        shutil.copy2(item, dst, follow_symlinks=False)
+    # Fix config dir .so symlink
+    cfg_so = cfg_dst / f"libpython{pyver}.so"
+    cfg_so.unlink(missing_ok=True)
+    cfg_so.symlink_to(f"../../libpython{pyver}.so.1.0")
+
+    # --- Bundle external tools and their shared lib dependencies ---
+    print("==> Bundling patchelf, ccache, and shared library dependencies...")
+    patchelf = shutil.which("patchelf")
+    if patchelf:
+        bundle_binary_with_deps(patchelf, appdir)
+    ccache = shutil.which("ccache")
+    if ccache:
+        bundle_binary_with_deps(ccache, appdir)
+
+    # Also bundle libz and libexpat for Python.
+    for lib_name in ["libz.so.1", "libexpat.so.1"]:
+        if (lib_dst / lib_name).exists():
+            continue
+        src = find_system_lib(lib_name)
+        if src:
+            shutil.copy2(src, lib_dst / lib_name)
+
+    # --- Trim bloat ---
+    print("==> Trimming unnecessary files...")
+    for pattern in [
+        "**/__pycache__",
+        f"python{pyver}/test",
+        f"python{pyver}/unittest/test",
+        f"python{pyver}/idlelib",
+        f"python{pyver}/tkinter",
+        f"python{pyver}/turtledemo",
+        f"python{pyver}/site-packages/pip*",
+    ]:
+        for p in (appdir / "usr" / "lib").glob(pattern):
+            if p.is_dir():
+                shutil.rmtree(p)
+            else:
+                p.unlink()
+
+    # --- Create AppRun, desktop file, icon ---
+    write_apprun(appdir)
+    write_desktop(appdir)
+    write_icon(appdir, nuitka_src)
+
+    # --- Get appimagetool and build ---
+    appimagetool = get_appimagetool(arch)
+
+    print("==> Building AppImage...", flush=True)
+    appdir_size = capture(["du", "-sh", str(appdir)]).split()[0]
+    print(f"    AppDir size: {appdir_size}", flush=True)
+
+    env = os.environ.copy()
+    env["ARCH"] = arch
+    run(
+        [appimagetool, "--no-appstream", "--comp", "zstd", str(appdir), str(output)],
+        env=env,
+    )
+
+    print()
+    print("=== Done ===")
+    size = output.stat().st_size / (1024 * 1024)
+    print(f"{output}  ({size:.1f} MB)")
+    print()
+    print(f"Test with: {output} --version")
+
+    # Cleanup
+    shutil.rmtree(tmpdir)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# MIT License
+#
+# Copyright (c) 2026 Simon Robin Lehn
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/misc/make-appimage.py
+++ b/misc/make-appimage.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+#     Copyright 2026, Simon Robin Lehn, MIT license, see end of file
+#
+# Build a self-contained Nuitka AppImage for Linux.
+#
+# Requirements on the build host:
+#   - python3, python3-dev, python3-venv
+#   - patchelf, ccache
+#   - mksquashfs (squashfs-tools)
+#   - gcc
+#   - Internet access (downloads appimagetool runtime)
+#
+# The resulting AppImage bundles Python, dev headers, patchelf, ccache,
+# and all Nuitka dependencies. Only a C compiler ($CC) is needed on the
+# target system.
+#
+# Usage:
+#   python3 misc/make-appimage.py [--python /path/to/python3]
+
+import argparse
+import base64
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(*args, **kwargs):
+    """Run a command, raising on failure."""
+    kwargs.setdefault("check", True)
+    return subprocess.run(*args, **kwargs)
+
+
+def capture(*args, **kwargs):
+    """Run a command and return stripped stdout."""
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(*args, **kwargs).stdout.strip()
+
+
+def python_query(python, code):
+    """Run a Python one-liner and return the output."""
+    return capture([python, "-c", code])
+
+
+def get_ldd_deps(binary):
+    """Return non-glibc shared library paths needed by a binary."""
+    skip = {"libc.so", "libm.so", "libdl.so", "librt.so", "libpthread.so",
+            "ld-linux", "linux-vdso"}
+    deps = []
+    try:
+        output = capture(["ldd", binary])
+    except subprocess.CalledProcessError:
+        return deps
+    for line in output.splitlines():
+        if "=> /" not in line:
+            continue
+        lib_path = line.split("=> ")[1].split(" (")[0].strip()
+        lib_name = os.path.basename(lib_path)
+        if any(lib_name.startswith(s) for s in skip):
+            continue
+        deps.append(lib_path)
+    return deps
+
+
+def bundle_binary_with_deps(binary_path, appdir):
+    """Copy a binary and its non-glibc shared lib deps into the AppDir."""
+    bin_name = os.path.basename(binary_path)
+    shutil.copy2(binary_path, appdir / "usr" / "bin" / bin_name)
+    lib_dir = appdir / "usr" / "lib"
+    for dep in get_ldd_deps(binary_path):
+        dep_name = os.path.basename(dep)
+        if not (lib_dir / dep_name).exists():
+            shutil.copy2(dep, lib_dir / dep_name)
+
+
+def fix_absolute_symlinks(directory, resolve=False):
+    """Fix or remove absolute symlinks in a directory (non-recursive).
+
+    If resolve is True, replace absolute symlinks pointing to existing files
+    with copies. Remove dangling absolute symlinks either way.
+    """
+    for entry in directory.iterdir():
+        if not entry.is_symlink():
+            continue
+        target = os.readlink(entry)
+        if not target.startswith("/"):
+            continue
+        if resolve and os.path.isfile(target):
+            entry.unlink()
+            shutil.copy2(target, entry)
+        else:
+            entry.unlink()
+
+
+def fix_libpython_symlinks(lib_dir, pyver):
+    """Make libpython symlinks relative and ensure the linker .so exists."""
+    for f in lib_dir.glob(f"libpython{pyver}*.so"):
+        if not f.is_symlink():
+            continue
+        target = os.readlink(f)
+        if target.startswith("/"):
+            f.unlink()
+            f.symlink_to(os.path.basename(target))
+    versioned = lib_dir / f"libpython{pyver}.so.1.0"
+    linker = lib_dir / f"libpython{pyver}.so"
+    if versioned.exists() and not linker.exists():
+        linker.symlink_to(versioned.name)
+
+
+def write_apprun(appdir):
+    """Write the AppRun entry point."""
+    apprun = appdir / "AppRun"
+    apprun.write_text("""\
+#!/usr/bin/env bash
+HERE="$(dirname "$(readlink -f "$0")")"
+export PATH="${HERE}/usr/bin:${PATH}"
+export PYTHONHOME="${HERE}/usr"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+
+# Prefer system patchelf/ccache if installed and version >= bundled.
+_ver() { "$1" --version 2>&1 | head -1 | grep -oE "[0-9]+\\.[0-9]+(\\.[0-9]+)?" | head -1; }
+_prefer_tool() {
+    local bundled="$1" envvar="$2"
+    [ -x "$bundled" ] || return
+    local tool_name sys_path
+    tool_name="$(basename -- "$bundled")"
+    sys_path="$(PATH="/usr/local/bin:/usr/bin:/bin" command -v "$tool_name" 2>/dev/null)" || {
+        export "$envvar=$bundled"; return
+    }
+    local sv bv
+    sv="$(_ver "$sys_path")"
+    bv="$(_ver "$bundled")"
+    if [ -n "$sv" ] && [ -n "$bv" ] && \\
+       [ "$(printf '%s\\n%s\\n' "$bv" "$sv" | sort -V | tail -1)" = "$sv" ]; then
+        export "$envvar=$sys_path"
+    else
+        export "$envvar=$bundled"
+    fi
+}
+_prefer_tool "${HERE}/usr/bin/patchelf" NUITKA_PATCHELF_BINARY
+_prefer_tool "${HERE}/usr/bin/ccache"   NUITKA_CCACHE_BINARY
+
+exec "${HERE}/usr/bin/python3" -m nuitka "$@"
+""")
+    apprun.chmod(0o755)
+
+
+def write_desktop(appdir):
+    """Write the .desktop file."""
+    (appdir / "nuitka.desktop").write_text("""\
+[Desktop Entry]
+Type=Application
+Name=Nuitka
+Exec=nuitka
+Icon=nuitka
+Categories=Development;
+Terminal=true
+Comment=Python Compiler
+X-AppImage-Integrate=false
+""")
+
+
+def write_icon(appdir):
+    """Write a minimal 1x1 PNG icon."""
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
+        "2mNkYPj/HwADBwIAMCbHYQAAAABJRU5ErkJggg=="
+    )
+    (appdir / "nuitka.png").write_bytes(png)
+
+
+def write_sitecustomize(stdlib_dir):
+    """Write sitecustomize.py to add site-packages to sys.path.
+
+    Debian Python uses dist-packages but pip in a venv installs to
+    site-packages. This ensures both are on sys.path regardless of flavor.
+    """
+    (stdlib_dir / "sitecustomize.py").write_text("""\
+import os
+import site
+import sys
+
+_appimage_site = os.path.join(sys.prefix, "lib",
+    "python" + ".".join(str(x) for x in sys.version_info[:2]),
+    "site-packages")
+if os.path.isdir(_appimage_site) and _appimage_site not in sys.path:
+    site.addsitedir(_appimage_site)
+""")
+
+
+def get_appimagetool(arch):
+    """Download appimagetool if not already present, return its path."""
+    tool = os.environ.get("APPIMAGETOOL")
+    if tool and os.path.isfile(tool):
+        return tool
+    tool = f"/tmp/appimagetool-{arch}"
+    if os.path.isfile(tool) and os.access(tool, os.X_OK):
+        return tool
+    print("==> Downloading appimagetool...")
+    run(["curl", "-fsSL",
+         f"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-{arch}.AppImage",
+         "-o", tool])
+    os.chmod(tool, 0o755)
+    return tool
+
+
+def find_system_lib(name):
+    """Search common library paths for a shared library."""
+    machine = platform.machine()
+    for prefix in [f"/lib/{machine}-linux-gnu", "/lib64", "/usr/lib"]:
+        path = os.path.join(prefix, name)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build a Nuitka AppImage")
+    parser.add_argument("--python", default=os.environ.get("PYTHON", "python3"))
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    python = args.python
+    script_dir = Path(__file__).resolve().parent
+    nuitka_src = script_dir.parent
+    arch = platform.machine()
+
+    pyver = python_query(python, "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')")
+    pyabi = python_query(python, "import sys; print(sys.abiflags if hasattr(sys, 'abiflags') else '')")
+    nuitka_version = re.search(
+        r"Nuitka V([0-9rc.]+)",
+        (nuitka_src / "nuitka" / "Version.py").read_text(),
+    )
+    nuitka_version = nuitka_version.group(1) if nuitka_version else "unknown"
+
+    tmpdir = Path(tempfile.mkdtemp())
+    appdir = tmpdir / "Nuitka.AppDir"
+    output = Path(args.output) if args.output else nuitka_src / f"Nuitka-{nuitka_version}-{arch}.AppImage"
+
+    print("=== Building Nuitka AppImage ===")
+    print(f"  Python:  {python} ({pyver})")
+    print(f"  Nuitka:  {nuitka_version}")
+    print(f"  Arch:    {arch}")
+    print(f"  Output:  {output}")
+    print()
+
+    # --- Check prerequisites ---
+    for tool in ["mksquashfs", "patchelf", "ccache"]:
+        if not shutil.which(tool):
+            sys.exit(f"Error: '{tool}' is required but not found.")
+
+    # --- Create AppDir with Python venv ---
+    print("==> Creating AppDir with Python runtime...")
+    for d in ["usr/bin", "usr/lib", "usr/include"]:
+        (appdir / d).mkdir(parents=True)
+
+    run([python, "-m", "venv", str(appdir / "usr"), "--without-pip"])
+    run([str(appdir / "usr" / "bin" / "python3"), "-m", "ensurepip", "--default-pip"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    print("==> Installing Nuitka and dependencies...")
+    pip = str(appdir / "usr" / "bin" / "pip3")
+    run([pip, "install", "--quiet", str(nuitka_src)])
+    run([pip, "install", "--quiet",
+         "appdirs", "tqdm", "zstandard>=0.15", "pyyaml", "Jinja2>=2.10.2", "ordered-set"])
+
+    # Replace venv Python symlink with real binary
+    print("==> Bundling Python runtime...")
+    venv_python = appdir / "usr" / "bin" / "python3"
+    real_python = Path(os.readlink(venv_python)).resolve() if venv_python.is_symlink() else venv_python
+    real_bin = appdir / "usr" / "bin" / "python3.real"
+    shutil.copy2(real_python, real_bin)
+    for name in ["python3", "python"]:
+        link = appdir / "usr" / "bin" / name
+        link.unlink(missing_ok=True)
+        link.symlink_to("python3.real")
+
+    # Remove pyvenv.cfg so the bundled Python acts as a real installation.
+    (appdir / "usr" / "pyvenv.cfg").unlink(missing_ok=True)
+
+    # --- Bundle Python stdlib ---
+    stdlib_src = Path(python_query(python, "import sysconfig; print(sysconfig.get_path('stdlib'))"))
+    stdlib_dst = appdir / "usr" / "lib" / f"python{pyver}"
+    # Copy everything from system stdlib over the venv's stdlib
+    for item in stdlib_src.iterdir():
+        dst = stdlib_dst / item.name
+        if item.is_dir() and not item.is_symlink():
+            shutil.copytree(item, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dst, follow_symlinks=False)
+
+    # Resolve dangling absolute symlinks (e.g. sitecustomize.py -> /etc/...)
+    fix_absolute_symlinks(stdlib_dst, resolve=True)
+
+    # Write sitecustomize.py after stdlib copy to avoid being overwritten.
+    write_sitecustomize(stdlib_dst)
+
+    # --- Bundle libpython shared library ---
+    libdir = Path(python_query(python, "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"))
+    lib_dst = appdir / "usr" / "lib"
+    for f in libdir.glob(f"libpython{pyver}*"):
+        dst = lib_dst / f.name
+        if f.is_symlink():
+            link_target = os.readlink(f)
+            dst.symlink_to(link_target)
+        else:
+            shutil.copy2(f, dst)
+    fix_libpython_symlinks(lib_dst, pyver)
+
+    # --- Bundle Python dev headers ---
+    print("==> Bundling Python dev headers...")
+    sys_include = Path(python_query(python, "import sysconfig; print(sysconfig.get_path('include'))"))
+    if sys_include.is_dir():
+        inc_dst = appdir / "usr" / "include" / f"python{pyver}{pyabi}"
+        shutil.copytree(sys_include, inc_dst, dirs_exist_ok=True)
+    else:
+        print(f"Warning: Python dev headers not found at {sys_include}", file=sys.stderr)
+        print(f"         Install python{pyver}-dev for full functionality.", file=sys.stderr)
+
+    # --- Bundle Python config dir (Makefile, static lib) ---
+    cfgdir = Path(python_query(python, "import sysconfig; print(sysconfig.get_config_var('LIBPL'))"))
+    cfgname = cfgdir.name
+    cfg_dst = appdir / "usr" / "lib" / f"python{pyver}" / cfgname
+    cfg_dst.mkdir(parents=True, exist_ok=True)
+    for item in cfgdir.iterdir():
+        dst = cfg_dst / item.name
+        dst.unlink(missing_ok=True)
+        shutil.copy2(item, dst, follow_symlinks=False)
+    # Fix config dir .so symlink
+    cfg_so = cfg_dst / f"libpython{pyver}.so"
+    cfg_so.unlink(missing_ok=True)
+    cfg_so.symlink_to(f"../../libpython{pyver}.so.1.0")
+
+    # --- Bundle external tools and their shared lib dependencies ---
+    print("==> Bundling patchelf, ccache, and shared library dependencies...")
+    patchelf = shutil.which("patchelf")
+    if patchelf:
+        bundle_binary_with_deps(patchelf, appdir)
+    ccache = shutil.which("ccache")
+    if ccache:
+        bundle_binary_with_deps(ccache, appdir)
+
+    # Also bundle libz and libexpat for Python.
+    for lib_name in ["libz.so.1", "libexpat.so.1"]:
+        if (lib_dst / lib_name).exists():
+            continue
+        src = find_system_lib(lib_name)
+        if src:
+            shutil.copy2(src, lib_dst / lib_name)
+
+    # --- Trim bloat ---
+    print("==> Trimming unnecessary files...")
+    for pattern in ["**/__pycache__", f"python{pyver}/test",
+                     f"python{pyver}/unittest/test", f"python{pyver}/idlelib",
+                     f"python{pyver}/tkinter", f"python{pyver}/turtledemo",
+                     f"python{pyver}/site-packages/pip*"]:
+        for p in (appdir / "usr" / "lib").glob(pattern):
+            if p.is_dir():
+                shutil.rmtree(p)
+            else:
+                p.unlink()
+
+    # --- Create AppRun, desktop file, icon ---
+    write_apprun(appdir)
+    write_desktop(appdir)
+    write_icon(appdir)
+
+    # --- Get appimagetool and build ---
+    appimagetool = get_appimagetool(arch)
+
+    print("==> Building AppImage...", flush=True)
+    appdir_size = capture(["du", "-sh", str(appdir)]).split()[0]
+    print(f"    AppDir size: {appdir_size}", flush=True)
+
+    env = os.environ.copy()
+    env["ARCH"] = arch
+    run([appimagetool, "--no-appstream", "--comp", "zstd", str(appdir), str(output)], env=env)
+
+    print()
+    print("=== Done ===")
+    size = output.stat().st_size / (1024 * 1024)
+    print(f"{output}  ({size:.1f} MB)")
+    print()
+    print(f"Test with: {output} --version")
+
+    # Cleanup
+    shutil.rmtree(tmpdir)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# MIT License
+#
+# Copyright (c) 2026 Simon Robin Lehn
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/misc/make-appimage.py
+++ b/misc/make-appimage.py
@@ -18,7 +18,6 @@
 #   python3 misc/make-appimage.py [--python /path/to/python3]
 
 import argparse
-import base64
 import os
 import platform
 import re
@@ -50,8 +49,15 @@ def python_query(python, code):
 
 def get_ldd_deps(binary):
     """Return non-glibc shared library paths needed by a binary."""
-    skip = {"libc.so", "libm.so", "libdl.so", "librt.so", "libpthread.so",
-            "ld-linux", "linux-vdso"}
+    skip = {
+        "libc.so",
+        "libm.so",
+        "libdl.so",
+        "librt.so",
+        "libpthread.so",
+        "ld-linux",
+        "linux-vdso",
+    }
     deps = []
     try:
         output = capture(["ldd", binary])
@@ -116,7 +122,8 @@ def fix_libpython_symlinks(lib_dir, pyver):
 def write_apprun(appdir):
     """Write the AppRun entry point."""
     apprun = appdir / "AppRun"
-    apprun.write_text("""\
+    apprun.write_text(
+        """\
 #!/usr/bin/env bash
 HERE="$(dirname "$(readlink -f "$0")")"
 export PATH="${HERE}/usr/bin:${PATH}"
@@ -147,13 +154,15 @@ _prefer_tool "${HERE}/usr/bin/patchelf" NUITKA_PATCHELF_BINARY
 _prefer_tool "${HERE}/usr/bin/ccache"   NUITKA_CCACHE_BINARY
 
 exec "${HERE}/usr/bin/python3" -m nuitka "$@"
-""")
+"""
+    )
     apprun.chmod(0o755)
 
 
 def write_desktop(appdir):
     """Write the .desktop file."""
-    (appdir / "nuitka.desktop").write_text("""\
+    (appdir / "nuitka.desktop").write_text(
+        """\
 [Desktop Entry]
 Type=Application
 Name=Nuitka
@@ -163,16 +172,14 @@ Categories=Development;
 Terminal=true
 Comment=Python Compiler
 X-AppImage-Integrate=false
-""")
-
-
-def write_icon(appdir):
-    """Write a minimal 1x1 PNG icon."""
-    png = base64.b64decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
-        "2mNkYPj/HwADBwIAMCbHYQAAAABJRU5ErkJggg=="
+"""
     )
-    (appdir / "nuitka.png").write_bytes(png)
+
+
+def write_icon(appdir, nuitka_src):
+    """Copy the Nuitka logo as the AppImage icon."""
+    shutil.copy2(nuitka_src / "doc" / "images" / "Nuitka-Logo-Symbol.png",
+                 appdir / "nuitka.png")
 
 
 def write_sitecustomize(stdlib_dir):
@@ -181,7 +188,8 @@ def write_sitecustomize(stdlib_dir):
     Debian Python uses dist-packages but pip in a venv installs to
     site-packages. This ensures both are on sys.path regardless of flavor.
     """
-    (stdlib_dir / "sitecustomize.py").write_text("""\
+    (stdlib_dir / "sitecustomize.py").write_text(
+        """\
 import os
 import site
 import sys
@@ -191,7 +199,8 @@ _appimage_site = os.path.join(sys.prefix, "lib",
     "site-packages")
 if os.path.isdir(_appimage_site) and _appimage_site not in sys.path:
     site.addsitedir(_appimage_site)
-""")
+"""
+    )
 
 
 def get_appimagetool(arch):
@@ -203,9 +212,15 @@ def get_appimagetool(arch):
     if os.path.isfile(tool) and os.access(tool, os.X_OK):
         return tool
     print("==> Downloading appimagetool...")
-    run(["curl", "-fsSL",
-         f"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-{arch}.AppImage",
-         "-o", tool])
+    run(
+        [
+            "curl",
+            "-fsSL",
+            f"https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-{arch}.AppImage",
+            "-o",
+            tool,
+        ]
+    )
     os.chmod(tool, 0o755)
     return tool
 
@@ -231,8 +246,12 @@ def main():
     nuitka_src = script_dir.parent
     arch = platform.machine()
 
-    pyver = python_query(python, "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')")
-    pyabi = python_query(python, "import sys; print(sys.abiflags if hasattr(sys, 'abiflags') else '')")
+    pyver = python_query(
+        python, "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')"
+    )
+    pyabi = python_query(
+        python, "import sys; print(sys.abiflags if hasattr(sys, 'abiflags') else '')"
+    )
     nuitka_version = re.search(
         r"Nuitka V([0-9rc.]+)",
         (nuitka_src / "nuitka" / "Version.py").read_text(),
@@ -241,7 +260,11 @@ def main():
 
     tmpdir = Path(tempfile.mkdtemp())
     appdir = tmpdir / "Nuitka.AppDir"
-    output = Path(args.output) if args.output else nuitka_src / f"Nuitka-{nuitka_version}-{arch}.AppImage"
+    output = (
+        Path(args.output)
+        if args.output
+        else nuitka_src / f"Nuitka-{nuitka_version}-{arch}.AppImage"
+    )
 
     print("=== Building Nuitka AppImage ===")
     print(f"  Python:  {python} ({pyver})")
@@ -261,19 +284,37 @@ def main():
         (appdir / d).mkdir(parents=True)
 
     run([python, "-m", "venv", str(appdir / "usr"), "--without-pip"])
-    run([str(appdir / "usr" / "bin" / "python3"), "-m", "ensurepip", "--default-pip"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    run(
+        [str(appdir / "usr" / "bin" / "python3"), "-m", "ensurepip", "--default-pip"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
     print("==> Installing Nuitka and dependencies...")
     pip = str(appdir / "usr" / "bin" / "pip3")
     run([pip, "install", "--quiet", str(nuitka_src)])
-    run([pip, "install", "--quiet",
-         "appdirs", "tqdm", "zstandard>=0.15", "pyyaml", "Jinja2>=2.10.2", "ordered-set"])
+    run(
+        [
+            pip,
+            "install",
+            "--quiet",
+            "appdirs",
+            "tqdm",
+            "zstandard>=0.15",
+            "pyyaml",
+            "Jinja2>=2.10.2",
+            "ordered-set",
+        ]
+    )
 
     # Replace venv Python symlink with real binary
     print("==> Bundling Python runtime...")
     venv_python = appdir / "usr" / "bin" / "python3"
-    real_python = Path(os.readlink(venv_python)).resolve() if venv_python.is_symlink() else venv_python
+    real_python = (
+        Path(os.readlink(venv_python)).resolve()
+        if venv_python.is_symlink()
+        else venv_python
+    )
     real_bin = appdir / "usr" / "bin" / "python3.real"
     shutil.copy2(real_python, real_bin)
     for name in ["python3", "python"]:
@@ -285,7 +326,9 @@ def main():
     (appdir / "usr" / "pyvenv.cfg").unlink(missing_ok=True)
 
     # --- Bundle Python stdlib ---
-    stdlib_src = Path(python_query(python, "import sysconfig; print(sysconfig.get_path('stdlib'))"))
+    stdlib_src = Path(
+        python_query(python, "import sysconfig; print(sysconfig.get_path('stdlib'))")
+    )
     stdlib_dst = appdir / "usr" / "lib" / f"python{pyver}"
     # Copy everything from system stdlib over the venv's stdlib
     for item in stdlib_src.iterdir():
@@ -302,7 +345,11 @@ def main():
     write_sitecustomize(stdlib_dst)
 
     # --- Bundle libpython shared library ---
-    libdir = Path(python_query(python, "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"))
+    libdir = Path(
+        python_query(
+            python, "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))"
+        )
+    )
     lib_dst = appdir / "usr" / "lib"
     for f in libdir.glob(f"libpython{pyver}*"):
         dst = lib_dst / f.name
@@ -315,16 +362,27 @@ def main():
 
     # --- Bundle Python dev headers ---
     print("==> Bundling Python dev headers...")
-    sys_include = Path(python_query(python, "import sysconfig; print(sysconfig.get_path('include'))"))
+    sys_include = Path(
+        python_query(python, "import sysconfig; print(sysconfig.get_path('include'))")
+    )
     if sys_include.is_dir():
         inc_dst = appdir / "usr" / "include" / f"python{pyver}{pyabi}"
         shutil.copytree(sys_include, inc_dst, dirs_exist_ok=True)
     else:
-        print(f"Warning: Python dev headers not found at {sys_include}", file=sys.stderr)
-        print(f"         Install python{pyver}-dev for full functionality.", file=sys.stderr)
+        print(
+            f"Warning: Python dev headers not found at {sys_include}", file=sys.stderr
+        )
+        print(
+            f"         Install python{pyver}-dev for full functionality.",
+            file=sys.stderr,
+        )
 
     # --- Bundle Python config dir (Makefile, static lib) ---
-    cfgdir = Path(python_query(python, "import sysconfig; print(sysconfig.get_config_var('LIBPL'))"))
+    cfgdir = Path(
+        python_query(
+            python, "import sysconfig; print(sysconfig.get_config_var('LIBPL'))"
+        )
+    )
     cfgname = cfgdir.name
     cfg_dst = appdir / "usr" / "lib" / f"python{pyver}" / cfgname
     cfg_dst.mkdir(parents=True, exist_ok=True)
@@ -356,10 +414,15 @@ def main():
 
     # --- Trim bloat ---
     print("==> Trimming unnecessary files...")
-    for pattern in ["**/__pycache__", f"python{pyver}/test",
-                     f"python{pyver}/unittest/test", f"python{pyver}/idlelib",
-                     f"python{pyver}/tkinter", f"python{pyver}/turtledemo",
-                     f"python{pyver}/site-packages/pip*"]:
+    for pattern in [
+        "**/__pycache__",
+        f"python{pyver}/test",
+        f"python{pyver}/unittest/test",
+        f"python{pyver}/idlelib",
+        f"python{pyver}/tkinter",
+        f"python{pyver}/turtledemo",
+        f"python{pyver}/site-packages/pip*",
+    ]:
         for p in (appdir / "usr" / "lib").glob(pattern):
             if p.is_dir():
                 shutil.rmtree(p)
@@ -369,7 +432,7 @@ def main():
     # --- Create AppRun, desktop file, icon ---
     write_apprun(appdir)
     write_desktop(appdir)
-    write_icon(appdir)
+    write_icon(appdir, nuitka_src)
 
     # --- Get appimagetool and build ---
     appimagetool = get_appimagetool(arch)
@@ -380,7 +443,10 @@ def main():
 
     env = os.environ.copy()
     env["ARCH"] = arch
-    run([appimagetool, "--no-appstream", "--comp", "zstd", str(appdir), str(output)], env=env)
+    run(
+        [appimagetool, "--no-appstream", "--comp", "zstd", str(appdir), str(output)],
+        env=env,
+    )
 
     print()
     print("=== Done ===")

--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -287,6 +287,37 @@ def getLaunchingSystemPrefixPath():
 _the_sys_prefix = None
 
 
+def _getAppImageSystemPrefix(bundled_version_tuple):
+    """When running inside an AppImage, return '/usr' if system python3-dev
+    headers are the same version or newer than the bundled ones."""
+
+    if os.name == "nt" or "APPIMAGE" not in os.environ:
+        return None
+
+    import glob
+
+    # Scan for system Python dev headers.
+    system_versions = []
+    for header_dir in glob.glob("/usr/include/python3.*/Python.h"):
+        try:
+            ver_str = header_dir.split("/python")[1].split("/")[0]
+            parts = ver_str.split(".")
+            ver_tuple = (int(parts[0]), int(parts[1]))
+            system_versions.append(ver_tuple)
+        except (ValueError, IndexError):
+            continue
+
+    if not system_versions:
+        return None
+
+    newest_system = max(system_versions)
+
+    if newest_system >= bundled_version_tuple:
+        return "/usr"
+
+    return None
+
+
 def getSystemPrefixPath():
     """Return real sys.prefix as an absolute path breaking out of virtualenv.
 
@@ -307,6 +338,11 @@ def getSystemPrefixPath():
             sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)
         )
         sys_prefix = os.path.abspath(sys_prefix)
+
+        # When inside an AppImage, prefer system python3-dev if newer.
+        appimage_system_prefix = _getAppImageSystemPrefix(sys.version_info[0:2])
+        if appimage_system_prefix is not None:
+            sys_prefix = appimage_system_prefix
 
         # Some virtualenv contain the "orig-prefix.txt" as a textual link to the
         # target, this is often on Windows with virtualenv. There are two places to

--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -287,25 +287,33 @@ def getLaunchingSystemPrefixPath():
 _the_sys_prefix = None
 
 
+_appimage_system_prefix_cached = False
+_appimage_system_prefix_result = None
+
+
 def _getAppImageSystemPrefix(bundled_version_tuple):
     """When running inside an AppImage, return '/usr' if system python3-dev
     headers are the same version or newer than the bundled ones."""
+
+    global _appimage_system_prefix_cached, _appimage_system_prefix_result  # pylint: disable=global-statement
+
+    if _appimage_system_prefix_cached:
+        return _appimage_system_prefix_result
+
+    _appimage_system_prefix_cached = True
 
     if os.name == "nt" or "APPIMAGE" not in os.environ:
         return None
 
     import glob
+    import re
 
     # Scan for system Python dev headers.
     system_versions = []
     for header_dir in glob.glob("/usr/include/python3.*/Python.h"):
-        try:
-            ver_str = header_dir.split("/python")[1].split("/")[0]
-            parts = ver_str.split(".")
-            ver_tuple = (int(parts[0]), int(parts[1]))
-            system_versions.append(ver_tuple)
-        except (ValueError, IndexError):
-            continue
+        match = re.search(r"/python(\d+)\.(\d+)", header_dir)
+        if match:
+            system_versions.append((int(match.group(1)), int(match.group(2))))
 
     if not system_versions:
         return None
@@ -313,6 +321,7 @@ def _getAppImageSystemPrefix(bundled_version_tuple):
     newest_system = max(system_versions)
 
     if newest_system >= bundled_version_tuple:
+        _appimage_system_prefix_result = "/usr"
         return "/usr"
 
     return None

--- a/nuitka/PythonVersions.py
+++ b/nuitka/PythonVersions.py
@@ -488,6 +488,46 @@ def getLaunchingSystemPrefixPath():
 _the_sys_prefix = None
 
 
+_appimage_system_prefix_cached = False
+_appimage_system_prefix_result = None
+
+
+def _getAppImageSystemPrefix(bundled_version_tuple):
+    """When running inside an AppImage, return '/usr' if system python3-dev
+    headers are the same version or newer than the bundled ones."""
+
+    global _appimage_system_prefix_cached, _appimage_system_prefix_result  # pylint: disable=global-statement
+
+    if _appimage_system_prefix_cached:
+        return _appimage_system_prefix_result
+
+    _appimage_system_prefix_cached = True
+
+    if os.name == "nt" or "APPIMAGE" not in os.environ:
+        return None
+
+    import glob
+    import re
+
+    # Scan for system Python dev headers.
+    system_versions = []
+    for header_dir in glob.glob("/usr/include/python3.*/Python.h"):
+        match = re.search(r"/python(\d+)\.(\d+)", header_dir)
+        if match:
+            system_versions.append((int(match.group(1)), int(match.group(2))))
+
+    if not system_versions:
+        return None
+
+    newest_system = max(system_versions)
+
+    if newest_system >= bundled_version_tuple:
+        _appimage_system_prefix_result = "/usr"
+        return "/usr"
+
+    return None
+
+
 def getSystemPrefixPath():
     """Return real sys.prefix as an absolute path breaking out of virtualenv.
 
@@ -508,6 +548,11 @@ def getSystemPrefixPath():
             sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)
         )
         sys_prefix = os.path.abspath(sys_prefix)
+
+        # When inside an AppImage, prefer system python3-dev if newer.
+        appimage_system_prefix = _getAppImageSystemPrefix(sys.version_info[0:2])
+        if appimage_system_prefix is not None:
+            sys_prefix = appimage_system_prefix
 
         # Some virtualenv contain the "orig-prefix.txt" as a textual link to the
         # target, this is often on Windows with virtualenv. There are two places to

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -461,19 +461,34 @@ Error, needs 'patchelf' on your system, to modify 'RPATH' settings that \
 need to be updated."""
 
 
+def _getPatchelfBinary():
+    """Return the patchelf binary to use, honoring NUITKA_PATCHELF_BINARY."""
+    return os.getenv("NUITKA_PATCHELF_BINARY", "patchelf")
+
+
 def checkPatchElfPresenceAndUsability(logger):
     """Checks if patchelf is present and usable."""
 
     output = executeToolChecked(
         logger=logger,
-        command=("patchelf", "--version"),
+        command=(_getPatchelfBinary(), "--version"),
         absence_message="""\
 Error, standalone mode on %s requires 'patchelf' to be \
 installed. Use 'apt/dnf/yum install patchelf' first."""
         % getOS(),
     )
 
-    if output.split() == b"0.18.0":
+    # Skip version check for the AppImage-bundled patchelf, where Debian's
+    # 0.18.0 includes distro-backported fixes for the known issues.
+    # Only trust the bundled binary (path inside the AppImage), not a system
+    # patchelf that might genuinely be the buggy upstream 0.18.0.
+    appdir = os.environ.get("APPDIR")
+    patchelf_is_bundled = (
+        "APPIMAGE" in os.environ
+        and appdir is not None
+        and os.getenv("NUITKA_PATCHELF_BINARY", "").startswith(appdir)
+    )
+    if output.split() == b"0.18.0" and not patchelf_is_bundled:
         return logger.sysexit(
             "Error, patchelf version 0.18.0 is a known buggy release and cannot be used. Please upgrade or downgrade it."
         )
@@ -482,7 +497,7 @@ installed. Use 'apt/dnf/yum install patchelf' first."""
 def _setSharedLibraryRPATHElf(filename, rpath):
     executeToolChecked(
         logger=postprocessing_logger,
-        command=("patchelf", "--force-rpath", "--set-rpath", rpath, filename),
+        command=(_getPatchelfBinary(), "--force-rpath", "--set-rpath", rpath, filename),
         stderr_filter=_filterPatchelfErrorOutput,
         absence_message=_patchelf_usage,
     )
@@ -928,7 +943,7 @@ def cleanupHeaderForAndroid(filename):
 
     executeToolChecked(
         logger=postprocessing_logger,
-        command=("patchelf", "--shrink-rpath", filename),
+        command=(_getPatchelfBinary(), "--shrink-rpath", filename),
         stderr_filter=_filterPatchelfErrorOutput,
         absence_message=_patchelf_usage,
     )


### PR DESCRIPTION
## Self-contained AppImage, CI for tag-releases

  Adds support for building a self-contained Nuitka AppImage for Linux. The AppImage bundles Python,
  stdlib, dev headers, patchelf, ccache, and all Nuitka dependencies. Only a C compiler is needed on the
   target system.

  New files:
  - misc/make-appimage.py — build script
  - .github/workflows/appimage.yml — CI workflow, triggered on version tags and manual dispatch
  - misc/Dockerfile.appimage — Debian stable build container (optional, for local builds)

packaged binary is around ~25 MB - [Nuitka-4.1rc4-linux-x86_64.AppImage.zip](https://github.com/user-attachments/files/26009396/Nuitka-4.1rc4-linux-x86_64.AppImage.zip)

example workflow run: https://github.com/srlehn/Nuitka/actions/runs/23120126109


## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [x] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [ ] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective. (packaged binary)

### Prompts

  Package Nuitka as a self-contained Linux AppImage for the upstream repo. Bundle everything needed
  except a C compiler — Python runtime, stdlib, dev headers, patchelf, ccache, shared lib deps, Nuitka's
   Python deps. Use the repo's logo as the icon.

  Build script in Python. AppRun prefers system patchelf/ccache over bundled if newer. Keep Nuitka core
  changes minimal for PR mergeability — add env var for patchelf binary selection, skip the 0.18.0
  rejection for the bundled one, prefer system python3-dev headers when available.

  Dockerfile for reproducible builds in Debian stable. CI workflow triggered on version tags and manual
  dispatch, building inside Debian stable (not Ubuntu). Attach artifact to GitHub Release on tag pushes.

## Summary by Sourcery

Package Nuitka as a self-contained Linux x86_64 AppImage and automate its release builds.

New Features:
- Add a self-contained Linux AppImage packaging script bundling Nuitka, Python, development headers, dependencies, and build tools.

Enhancements:
- Allow AppImage builds to use newer system Python development headers and prefer newer system patchelf or ccache binaries when available.

Build:
- Add a Debian stable container definition for reproducible local AppImage builds.

CI:
- Add a workflow that builds and verifies the Linux x86_64 AppImage on version tags or manual dispatch, uploads it as an artifact, and attaches it to GitHub Releases.

Tests:
- Verify the generated AppImage by executing its version command in CI.