### PR TITLE
Fix wrongful inclusion of cython when using pyav

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -328,6 +328,12 @@
           - 'AutoIt'
       when: 'win32'
 
+- module-name: 'av' # checksum: 1bc92d85
+  anti-bloat:
+    - description: 'remove cython usage'
+      no-auto-follow:
+        'cython': 'ignore'
+
 - module-name: 'av.audio.frame' # checksum: f3ef0d81
   implicit-imports:
     - depends:


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR fixes the wrongful inclusion of cython while using pyav in a standalone build.

Edit: I've used the top module `av` as cython is used everywhere. On version 16.1.0 as in the report the anti bloat message was reported for `av.utils` - in the newerst version 17.0.0 on the other hand for `av.opaque`.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3823 .

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Bug Fixes:
- Prevent unintended inclusion of the Cython package when using the av/pyav module in standalone builds.