### PR TITLE
Avoid including typing_extensions when using numpy

### DIFF
--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3243,7 +3243,7 @@
       replacements_plain:
         'type(attr) is types.MethodType': 'isinstance(attr, types.MethodType)'
 
-- module-name: 'numpy' # checksum: cfff3d48
+- module-name: 'numpy' # checksum: 2b67913d
   dlls:
     - from_filenames:
         relative_path: '.libs'
@@ -3279,6 +3279,9 @@
       no-auto-follow:
         'charset_normalizer': 'ignore'
     - description: 'disable bug hiding'
+      no-auto-follow:
+        'typing_extensions': 'ignore'
+    - description: 'avoid typing_extensions dependency'
       replacements_plain:
         'raise ImportError(msg) from e': 'raise e'
   implicit-imports:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -3243,7 +3243,7 @@
       replacements_plain:
         'type(attr) is types.MethodType': 'isinstance(attr, types.MethodType)'
 
-- module-name: 'numpy' # checksum: 2b67913d
+- module-name: 'numpy' # checksum: e8a53225
   dlls:
     - from_filenames:
         relative_path: '.libs'
@@ -3278,10 +3278,10 @@
     - description: 'avoid charset_normalizer dependency'
       no-auto-follow:
         'charset_normalizer': 'ignore'
-    - description: 'disable bug hiding'
+    - description: 'avoid typing_extensions dependency'
       no-auto-follow:
         'typing_extensions': 'ignore'
-    - description: 'avoid typing_extensions dependency'
+    - description: 'disable bug hiding'
       replacements_plain:
         'raise ImportError(msg) from e': 'raise e'
   implicit-imports:


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR fixes the wrongful inclusion of typing-extensions while using numpy in a standalone build.
I've used the top module `numpy` as typing-extensions is used everywhere.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3826 .

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Prevent standalone NumPy builds from unnecessarily including the typing_extensions package as a dependency.

Bug Fixes:
- Exclude typing_extensions from automatic following when analyzing NumPy to avoid bundling it into standalone builds.

Build:
- Adjust NumPy standard plugin package configuration to ignore typing_extensions and update its checksum metadata.