### PR TITLE
Support `args-as-a-type-variable-tuple` in PEP 646

### DIFF
--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -16,9 +16,13 @@ from nuitka.nodes.AsyncgenNodes import (
 )
 from nuitka.nodes.BuiltinIteratorNodes import (
     ExpressionBuiltinIter1,
+    ExpressionBuiltinIterForUnpack,
     StatementSpecialUnpackCheck,
 )
-from nuitka.nodes.BuiltinNextNodes import ExpressionSpecialUnpack
+from nuitka.nodes.BuiltinNextNodes import (
+    ExpressionBuiltinNext1,
+    ExpressionSpecialUnpack,
+)
 from nuitka.nodes.BuiltinRefNodes import (
     ExpressionBuiltinExceptionRef,
     makeExpressionBuiltinTypeRef,
@@ -39,6 +43,7 @@ from nuitka.nodes.ExecEvalNodes import ExpressionBuiltinExec
 from nuitka.nodes.FunctionNodes import (
     ExpressionFunctionBody,
     ExpressionFunctionRef,
+    makeExpressionFunctionCall,
     makeExpressionFunctionCreation,
 )
 from nuitka.nodes.GeneratorNodes import (
@@ -69,6 +74,11 @@ from nuitka.PythonVersions import python_version
 from nuitka.specs.ParameterSpecs import ParameterSpec
 
 from .FutureSpecState import getFutureSpec
+from .InternalModule import (
+    internal_source_ref,
+    makeInternalHelperFunctionBody,
+    once_decorator,
+)
 from .ReformulationExecStatements import wrapEvalGlobalsAndLocals
 from .ReformulationTryFinallyStatements import (
     makeTryFinallyReleaseStatement,
@@ -728,6 +738,66 @@ def makeDeferredAnnotateFunctionObject(provider, keys, values, source_ref):
     )
 
 
+@once_decorator
+def getParameterAnnotationUnpackingHelper():
+    helper_name = "_unpack_parameter_annotation"
+
+    result = makeInternalHelperFunctionBody(
+        name=helper_name,
+        parameters=ParameterSpec(
+            ps_name=helper_name,
+            ps_normal_args=("unpack",),
+            ps_list_star_arg=None,
+            ps_dict_star_arg=None,
+            ps_default_count=0,
+            ps_kw_only_args=(),
+            ps_pos_only_args=(),
+        ),
+    )
+
+    unpacked_variable = result.allocateTempVariable(
+        temp_scope=None, name="unpacked", temp_type="object"
+    )
+
+    unpack_variable = result.getVariableForAssignment(variable_name="unpack")
+
+    tried = makeStatementsSequenceFromStatements(
+        makeStatementAssignmentVariable(
+            variable=unpacked_variable,
+            source=ExpressionBuiltinNext1(
+                value=ExpressionBuiltinIterForUnpack(
+                    value=ExpressionVariableRef(
+                        variable=unpack_variable,
+                        source_ref=internal_source_ref,
+                    ),
+                    source_ref=internal_source_ref,
+                ),
+                source_ref=internal_source_ref,
+            ),
+            source_ref=internal_source_ref,
+        ),
+        StatementReturn(
+            expression=ExpressionTempVariableRef(
+                variable=unpacked_variable, source_ref=internal_source_ref
+            ),
+            source_ref=internal_source_ref,
+        ),
+    )
+
+    result.setChildBody(
+        makeStatementsSequenceFromStatement(
+            makeTryFinallyReleaseStatement(
+                provider=result,
+                tried=tried,
+                variables=(unpacked_variable,),
+                source_ref=internal_source_ref,
+            )
+        )
+    )
+
+    return result
+
+
 def buildParameterAnnotations(provider, node, source_ref):
     # Too many branches, because there is too many cases, pylint: disable=too-many-branches
 
@@ -752,10 +822,39 @@ def buildParameterAnnotations(provider, node, source_ref):
             assert arg.annotation is None
         elif getKind(arg) == "arg":
             if arg.annotation is not None:
-                addAnnotation(
-                    key=arg.arg,
-                    value=buildAnnotationNode(provider, arg.annotation, source_ref),
-                )
+                if python_version >= 0x3B0 and getKind(arg.annotation) == "Starred":
+                    value = buildAnnotationNode(
+                        provider, arg.annotation.value, source_ref
+                    )
+
+                    result = makeExpressionFunctionCall(
+                        function=makeExpressionFunctionCreation(
+                            function_ref=ExpressionFunctionRef(
+                                function_body=getParameterAnnotationUnpackingHelper(),
+                                source_ref=source_ref,
+                            ),
+                            defaults=(),
+                            kw_defaults=None,
+                            annotations=None,
+                            source_ref=source_ref,
+                        ),
+                        values=(value,),
+                        source_ref=source_ref,
+                    )
+
+                    result.setCompatibleSourceReference(
+                        value.getCompatibleSourceReference()
+                    )
+
+                    addAnnotation(
+                        key=arg.arg,
+                        value=result,
+                    )
+                else:
+                    addAnnotation(
+                        key=arg.arg,
+                        value=buildAnnotationNode(provider, arg.annotation, source_ref),
+                    )
         elif getKind(arg) == "Tuple":
             for sub_arg in arg.elts:
                 extractArgAnnotation(sub_arg)

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -827,23 +827,9 @@ def buildParameterAnnotations(provider, node, source_ref):
                         provider, arg.annotation.value, source_ref
                     )
 
-                    result = makeExpressionFunctionCall(
-                        function=makeExpressionFunctionCreation(
-                            function_ref=ExpressionFunctionRef(
-                                function_body=getParameterAnnotationUnpackingHelper(),
-                                source_ref=source_ref,
-                            ),
-                            defaults=(),
-                            kw_defaults=None,
-                            annotations=None,
-                            source_ref=source_ref,
-                        ),
-                        values=(value,),
+                    result = ExpressionBuiltinNext1(
+                        value=ExpressionBuiltinIterForUnpack(value, source_ref),
                         source_ref=source_ref,
-                    )
-
-                    result.setCompatibleSourceReference(
-                        value.getCompatibleSourceReference()
                     )
 
                     addAnnotation(

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -43,7 +43,6 @@ from nuitka.nodes.ExecEvalNodes import ExpressionBuiltinExec
 from nuitka.nodes.FunctionNodes import (
     ExpressionFunctionBody,
     ExpressionFunctionRef,
-    makeExpressionFunctionCall,
     makeExpressionFunctionCreation,
 )
 from nuitka.nodes.GeneratorNodes import (
@@ -74,11 +73,6 @@ from nuitka.PythonVersions import python_version
 from nuitka.specs.ParameterSpecs import ParameterSpec
 
 from .FutureSpecState import getFutureSpec
-from .InternalModule import (
-    internal_source_ref,
-    makeInternalHelperFunctionBody,
-    once_decorator,
-)
 from .ReformulationExecStatements import wrapEvalGlobalsAndLocals
 from .ReformulationTryFinallyStatements import (
     makeTryFinallyReleaseStatement,

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -766,15 +766,13 @@ def buildParameterAnnotations(provider, node, source_ref):
                         source_ref=source_ref,
                     )
 
-                    addAnnotation(
-                        key=arg.arg,
-                        value=result,
-                    )
                 else:
-                    addAnnotation(
-                        key=arg.arg,
-                        value=buildAnnotationNode(provider, arg.annotation, source_ref),
-                    )
+                    result = buildAnnotationNode(provider, arg.annotation, source_ref)
+
+                addAnnotation(
+                    key=arg.arg,
+                    value=result,
+                )
         elif getKind(arg) == "Tuple":
             for sub_arg in arg.elts:
                 extractArgAnnotation(sub_arg)

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -732,69 +732,6 @@ def makeDeferredAnnotateFunctionObject(provider, keys, values, source_ref):
     )
 
 
-# TODO: Not sure if this body is still needed.
-# A standalone unpacking operation should be directly equivalent.
-#
-# @once_decorator
-# def getParameterAnnotationUnpackingHelper():
-#     helper_name = "_unpack_parameter_annotation"
-#
-#     result = makeInternalHelperFunctionBody(
-#         name=helper_name,
-#         parameters=ParameterSpec(
-#             ps_name=helper_name,
-#             ps_normal_args=("unpack",),
-#             ps_list_star_arg=None,
-#             ps_dict_star_arg=None,
-#             ps_default_count=0,
-#             ps_kw_only_args=(),
-#             ps_pos_only_args=(),
-#         ),
-#     )
-#
-#     unpacked_variable = result.allocateTempVariable(
-#         temp_scope=None, name="unpacked", temp_type="object"
-#     )
-#
-#     unpack_variable = result.getVariableForAssignment(variable_name="unpack")
-#
-#     tried = makeStatementsSequenceFromStatements(
-#         makeStatementAssignmentVariable(
-#             variable=unpacked_variable,
-#             source=ExpressionBuiltinNext1(
-#                 value=ExpressionBuiltinIterForUnpack(
-#                     value=ExpressionVariableRef(
-#                         variable=unpack_variable,
-#                         source_ref=internal_source_ref,
-#                     ),
-#                     source_ref=internal_source_ref,
-#                 ),
-#                 source_ref=internal_source_ref,
-#             ),
-#             source_ref=internal_source_ref,
-#         ),
-#         StatementReturn(
-#             expression=ExpressionTempVariableRef(
-#                 variable=unpacked_variable, source_ref=internal_source_ref
-#             ),
-#             source_ref=internal_source_ref,
-#         ),
-#     )
-#
-#     result.setChildBody(
-#         makeStatementsSequenceFromStatement(
-#             makeTryFinallyReleaseStatement(
-#                 provider=result,
-#                 tried=tried,
-#                 variables=(unpacked_variable,),
-#                 source_ref=internal_source_ref,
-#             )
-#         )
-#     )
-#
-#     return result
-
-
 def buildParameterAnnotations(provider, node, source_ref):
     # Too many branches, because there is too many cases, pylint: disable=too-many-branches
 

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -738,64 +738,67 @@ def makeDeferredAnnotateFunctionObject(provider, keys, values, source_ref):
     )
 
 
-@once_decorator
-def getParameterAnnotationUnpackingHelper():
-    helper_name = "_unpack_parameter_annotation"
-
-    result = makeInternalHelperFunctionBody(
-        name=helper_name,
-        parameters=ParameterSpec(
-            ps_name=helper_name,
-            ps_normal_args=("unpack",),
-            ps_list_star_arg=None,
-            ps_dict_star_arg=None,
-            ps_default_count=0,
-            ps_kw_only_args=(),
-            ps_pos_only_args=(),
-        ),
-    )
-
-    unpacked_variable = result.allocateTempVariable(
-        temp_scope=None, name="unpacked", temp_type="object"
-    )
-
-    unpack_variable = result.getVariableForAssignment(variable_name="unpack")
-
-    tried = makeStatementsSequenceFromStatements(
-        makeStatementAssignmentVariable(
-            variable=unpacked_variable,
-            source=ExpressionBuiltinNext1(
-                value=ExpressionBuiltinIterForUnpack(
-                    value=ExpressionVariableRef(
-                        variable=unpack_variable,
-                        source_ref=internal_source_ref,
-                    ),
-                    source_ref=internal_source_ref,
-                ),
-                source_ref=internal_source_ref,
-            ),
-            source_ref=internal_source_ref,
-        ),
-        StatementReturn(
-            expression=ExpressionTempVariableRef(
-                variable=unpacked_variable, source_ref=internal_source_ref
-            ),
-            source_ref=internal_source_ref,
-        ),
-    )
-
-    result.setChildBody(
-        makeStatementsSequenceFromStatement(
-            makeTryFinallyReleaseStatement(
-                provider=result,
-                tried=tried,
-                variables=(unpacked_variable,),
-                source_ref=internal_source_ref,
-            )
-        )
-    )
-
-    return result
+# TODO: Not sure if this body is still needed.
+# A standalone unpacking operation should be directly equivalent.
+#
+# @once_decorator
+# def getParameterAnnotationUnpackingHelper():
+#     helper_name = "_unpack_parameter_annotation"
+#
+#     result = makeInternalHelperFunctionBody(
+#         name=helper_name,
+#         parameters=ParameterSpec(
+#             ps_name=helper_name,
+#             ps_normal_args=("unpack",),
+#             ps_list_star_arg=None,
+#             ps_dict_star_arg=None,
+#             ps_default_count=0,
+#             ps_kw_only_args=(),
+#             ps_pos_only_args=(),
+#         ),
+#     )
+#
+#     unpacked_variable = result.allocateTempVariable(
+#         temp_scope=None, name="unpacked", temp_type="object"
+#     )
+#
+#     unpack_variable = result.getVariableForAssignment(variable_name="unpack")
+#
+#     tried = makeStatementsSequenceFromStatements(
+#         makeStatementAssignmentVariable(
+#             variable=unpacked_variable,
+#             source=ExpressionBuiltinNext1(
+#                 value=ExpressionBuiltinIterForUnpack(
+#                     value=ExpressionVariableRef(
+#                         variable=unpack_variable,
+#                         source_ref=internal_source_ref,
+#                     ),
+#                     source_ref=internal_source_ref,
+#                 ),
+#                 source_ref=internal_source_ref,
+#             ),
+#             source_ref=internal_source_ref,
+#         ),
+#         StatementReturn(
+#             expression=ExpressionTempVariableRef(
+#                 variable=unpacked_variable, source_ref=internal_source_ref
+#             ),
+#             source_ref=internal_source_ref,
+#         ),
+#     )
+#
+#     result.setChildBody(
+#         makeStatementsSequenceFromStatement(
+#             makeTryFinallyReleaseStatement(
+#                 provider=result,
+#                 tried=tried,
+#                 variables=(unpacked_variable,),
+#                 source_ref=internal_source_ref,
+#             )
+#         )
+#     )
+#
+#     return result
 
 
 def buildParameterAnnotations(provider, node, source_ref):

--- a/tests/basics/Generics311.py
+++ b/tests/basics/Generics311.py
@@ -1,0 +1,43 @@
+from typing import Tuple, TypeVar, TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+
+def func1(*args: *Ts) -> None:
+    print(Ts)
+    print(*Ts)
+
+
+func1()
+print(func1.__annotations__)
+
+
+def func2(*args: *Tuple[int, ...]) -> None:
+    print(Ts)
+    print(*Ts)
+
+
+func2()
+print(func2.__annotations__)
+
+
+def func3(*args: Tuple[*Ts]) -> Tuple[*Ts]:
+    print(Ts)
+    print(*Ts)
+
+
+func3()
+print(func3.__annotations__)
+
+
+try:
+
+    def func4(*args: *T) -> T:
+        print(T)
+        print(*T)
+
+    func4()
+    print(func4.__annotations__)
+except TypeError as e:
+    print(e)

--- a/tests/basics/Generics311.py
+++ b/tests/basics/Generics311.py
@@ -11,8 +11,10 @@ Ts = TypeVarTuple("Ts")
 
 print("Module level T=", T)
 print("Module level Ts=", Ts)
+print()
 
-print("Unpacking a TypeVar tuple with star list arguments gives:")
+
+print("[Part: 1] Unpacking a TypeVar tuple with star list arguments gives:")
 
 
 def func1(*args: *Ts) -> None:
@@ -21,31 +23,50 @@ def func1(*args: *Ts) -> None:
 
 
 func1()
-print(func1.__annotations__)
-
-print("Manually defining a Tuple[int,...] gives:")
+print(func1.__annotations__, "\n")
 
 
-def func2(*args: *Tuple[int, ...]) -> None:
+print("[Part: 2] Manually defining a Tuple[int,...] gives:")
+
+
+def func21(*args: *Tuple[int, ...]) -> None:
     pass
 
 
-func2()
-print("Annotations", func2.__annotations__)
+func21()
+print("Annotations", func21.__annotations__, "\n")
 
 
-print("Unpacking a TypeVar tuple with star list arguments gives:")
+def func22(*args: *tuple[int, ...]) -> None:
+    pass
 
 
-def func3(*args: Tuple[*Ts]) -> Tuple[*Ts]:
+func22()
+print("Annotations", func22.__annotations__, "\n")
+
+
+print("[Part: 3] Unpacking a TypeVar tuple with star list arguments gives:")
+
+
+def func31(*args: Tuple[*Ts]) -> Tuple[*Ts]:
     print("Function level Ts=", Ts)
     print("Function level *Ts=", *Ts)
 
 
-func3()
-print("Annotations", func3.__annotations__)
+func31()
+print("Annotations", func31.__annotations__, "\n")
 
-print("Unpacking a TypeVar with star list arguments should raise an error:")
+
+def func32(*args: tuple[*Ts]) -> tuple[*Ts]:
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
+
+
+func32()
+print("Annotations", func32.__annotations__, "\n")
+
+
+print("[Part: 4] Unpacking a TypeVar with star list arguments should raise an error:")
 try:
 
     def func4(*args: *T) -> T:
@@ -53,6 +74,6 @@ try:
         print(*T)
 
     func4()
-    print("Annotations", func4.__annotations__)
+    print("Annotations", func4.__annotations__, "\n")
 except TypeError as e:
-    print("Expected error:", e)
+    print("Expected error:", e, "\n")

--- a/tests/basics/Generics311.py
+++ b/tests/basics/Generics311.py
@@ -1,36 +1,51 @@
+"""Generic annotations tests, cover most important forms of them."""
+
+# Tests are dirty on purpose.
+#
+# pylint: disable=not-an-iterable,unused-argument
+
 from typing import Tuple, TypeVar, TypeVarTuple
 
 T = TypeVar("T")
 Ts = TypeVarTuple("Ts")
 
+print("Module level T=", T)
+print("Module level Ts=", Ts)
+
+print("Unpacking a TypeVar tuple with star list arguments gives:")
+
 
 def func1(*args: *Ts) -> None:
-    print(Ts)
-    print(*Ts)
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
 
 
 func1()
 print(func1.__annotations__)
 
+print("Manually defining a Tuple[int,...] gives:")
+
 
 def func2(*args: *Tuple[int, ...]) -> None:
-    print(Ts)
-    print(*Ts)
+    pass
 
 
 func2()
-print(func2.__annotations__)
+print("Annotations", func2.__annotations__)
+
+
+print("Unpacking a TypeVar tuple with star list arguments gives:")
 
 
 def func3(*args: Tuple[*Ts]) -> Tuple[*Ts]:
-    print(Ts)
-    print(*Ts)
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
 
 
 func3()
-print(func3.__annotations__)
+print("Annotations", func3.__annotations__)
 
-
+print("Unpacking a TypeVar with star list arguments should raise an error:")
 try:
 
     def func4(*args: *T) -> T:
@@ -38,6 +53,6 @@ try:
         print(*T)
 
     func4()
-    print(func4.__annotations__)
+    print("Annotations", func4.__annotations__)
 except TypeError as e:
-    print(e)
+    print("Expected error:", e)


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

Since `Python 3.11` added support for [PEP 646](https://peps.python.org/pep-0646/#args-as-a-type-variable-tuple), the `*args as a Type Variable Tuple` feature appears to be unimplemented. As a result, `Starred` AST nodes in argument parsing are handled incorrectly, which leads to errors in parameter annotations at function definition time.

This was discovered in https://github.com/home-assistant/core (`homeassistant/util/async_.py`)

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3457

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Add support for unpacking starred parameter annotations introduced by PEP 646 in Python 3.11 and cover the behavior with new generics tests.

New Features:
- Support function parameter annotations using PEP 646-style starred TypeVarTuple syntax in Python 3.11.

Bug Fixes:
- Correct handling of Starred AST nodes in function parameter annotations to avoid errors at function definition time under Python 3.11.

Enhancements:
- Introduce an internal helper function to safely unpack starred parameter annotation values during compilation.

Tests:
- Add Python 3.11 generics tests validating starred TypeVarTuple and tuple-based parameter annotations, including error cases for invalid usage.