### PR TITLE
Fix the `__parameters__` attribute of generic classes

### DIFF
--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -373,9 +373,9 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
 
     if (type_generic_alias_type == NULL) {
 
-        PyObject *types_module = IMPORT_HARD_TYPING();
+        PyObject *typing_module = IMPORT_HARD_TYPING();
 
-        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "_GenericAlias");
+        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(typing_module, "_GenericAlias");
         CHECK_OBJECT(type_generic_alias_type);
     }
 

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -373,9 +373,9 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
 
     if (type_generic_alias_type == NULL) {
 
-        PyObject *types_module = IMPORT_HARD_TYPES();
+        PyObject *types_module = IMPORT_HARD_TYPING();
 
-        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "GenericAlias");
+        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "_GenericAlias");
         CHECK_OBJECT(type_generic_alias_type);
     }
 

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -217,9 +217,15 @@ def buildClassNode3(provider, node, source_ref):
     class_locals_scope.registerProvidedVariable(class_variable)
 
     if python_version >= 0x3C0:
-        type_params_expressions = buildNodeTuple(
-            provider=outline_body, nodes=node.type_params, source_ref=source_ref
-        )
+        type_params_expressions = []
+        for _, type_param_var in type_variables:
+            type_params_expressions.append(
+                ExpressionTempVariableRef(
+                    variable=type_param_var,
+                    source_ref=source_ref,
+                )
+            )
+        type_params_expressions = tuple(type_params_expressions)
     else:
         type_params_expressions = ()
 

--- a/tests/basics/ClassesTest312.py
+++ b/tests/basics/ClassesTest312.py
@@ -75,6 +75,22 @@ print("Subclass parameters", Sub.__parameters__)
 print("Subclass bases", Sub.__bases__, Sub.__orig_bases__)
 print("Subclass with param", Sub[int], type(Sub[int]))
 
+
+class FullyBound(Base[str, str]): ...
+
+
+print(
+    "FullyBound fields",
+    FullyBound.__parameters__,
+    FullyBound.__bases__,
+    FullyBound.__orig_bases__,
+)
+
+try:
+    FullyBound[int]
+except Exception as error:
+    print("Caught exception trying to pass parameters to FullyBound", type(error))
+
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #

--- a/tests/basics/ClassesTest312.py
+++ b/tests/basics/ClassesTest312.py
@@ -62,6 +62,19 @@ try:
 except NameError:
     print("!!!")
 
+
+class Base[T, V]: ...
+
+
+class Sub[Silly](Base[Silly, str]): ...
+
+
+print("Base parameters", Base.__parameters__)
+print("Base bases", Base.__bases__, Base.__orig_bases__)
+print("Subclass parameters", Sub.__parameters__)
+print("Subclass bases", Sub.__bases__, Sub.__orig_bases__)
+print("Subclass with param", Sub[int], type(Sub[int]))
+
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Fixes the value of `__parameters__` for subclasses to match CPython. In particular:

1. Only use a single instance of type variables.
2. Use `typing._GenericAlias` and `types.GenericAlias`

Both of these changes fix `_generic_init_subclass`, which in turn fixes `__parameters__` and allows `typing.__typing_prepare_subst__` to work correctly.

## 🧐 Why was it initiated? Any relevant Issues?

- #3812

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Align generic class handling with CPython so that subclass __parameters__ and generic aliasing behave correctly.

Bug Fixes:
- Correct the construction of type parameter expressions for generic classes to ensure __parameters__ on subclasses matches CPython semantics.
- Use typing._GenericAlias instead of types.GenericAlias to fix generic alias type resolution in the runtime helper.

Tests:
- Add coverage for base and subclass generic parameter metadata, including __parameters__, __bases__, __orig_bases__, and parameterized subclasses.