### PR TITLE
Plugins: Cache callback dispatch for onFunctionBodyParsing and onClassBodyParsing

### DIFF
--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -83,6 +83,8 @@ active_plugins_with_decide_compilation = []
 active_plugins_with_decide_annotations = []
 active_plugins_with_decide_doc_strings = []
 active_plugins_with_decide_assertions = []
+active_plugins_with_function_body_parsing = []
+active_plugins_with_class_body_parsing = []
 plugin_name2plugin_classes = {}
 plugin_options = OrderedDict()
 plugin_values = {}
@@ -168,6 +170,18 @@ def _addActivePlugin(plugin_class, args, force=False):
 
     if type(plugin_instance).decideAssertions is not NuitkaPluginBase.decideAssertions:
         active_plugins_with_decide_assertions.append(plugin_instance)
+
+    if (
+        type(plugin_instance).onFunctionBodyParsing
+        is not NuitkaPluginBase.onFunctionBodyParsing
+    ):
+        active_plugins_with_function_body_parsing.append(plugin_instance)
+
+    if (
+        type(plugin_instance).onClassBodyParsing
+        is not NuitkaPluginBase.onClassBodyParsing
+    ):
+        active_plugins_with_class_body_parsing.append(plugin_instance)
 
     is_gui_toolkit_plugin = getattr(plugin_class, "plugin_gui_toolkit", False)
 
@@ -1698,13 +1712,14 @@ through incomplete set import by '%s' plugin encountered."""
     @classmethod
     @counted_plugin_method
     def onFunctionBodyParsing(cls, provider, function_name, body):
+        if not active_plugins_with_function_body_parsing:
+            return
+
         module_name = provider.getParentModule().getFullName()
 
         function_qualname = provider.getChildQualname(function_name)
 
-        for plugin in getActivePlugins():
-            # TODO: Could record what functions got modified by what plugin
-            # and in what way checking the return value
+        for plugin in active_plugins_with_function_body_parsing:
             plugin.onFunctionBodyParsing(
                 module_name=module_name,
                 function_qualname=function_qualname,
@@ -1715,11 +1730,12 @@ through incomplete set import by '%s' plugin encountered."""
     @classmethod
     @counted_plugin_method
     def onClassBodyParsing(cls, provider, class_name, node):
+        if not active_plugins_with_class_body_parsing:
+            return
+
         module_name = provider.getParentModule().getFullName()
 
-        for plugin in getActivePlugins():
-            # TODO: Could record what classes got modified by what plugin
-            # and in what way checking the return value
+        for plugin in active_plugins_with_class_body_parsing:
             plugin.onClassBodyParsing(
                 module_name=module_name,
                 class_name=class_name,

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -1712,9 +1712,6 @@ through incomplete set import by '%s' plugin encountered."""
     @classmethod
     @counted_plugin_method
     def onFunctionBodyParsing(cls, provider, function_name, body):
-        if not active_plugins_with_function_body_parsing:
-            return
-
         module_name = provider.getParentModule().getFullName()
 
         function_qualname = provider.getChildQualname(function_name)
@@ -1730,9 +1727,6 @@ through incomplete set import by '%s' plugin encountered."""
     @classmethod
     @counted_plugin_method
     def onClassBodyParsing(cls, provider, class_name, node):
-        if not active_plugins_with_class_body_parsing:
-            return
-
         module_name = provider.getParentModule().getFullName()
 
         for plugin in active_plugins_with_class_body_parsing:

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -1621,9 +1621,6 @@ through incomplete set import by '%s' plugin encountered."""
 
     @classmethod
     def onFunctionBodyParsing(cls, provider, function_name, body):
-        if not active_plugins_with_function_body_parsing:
-            return
-
         module_name = provider.getParentModule().getFullName()
 
         function_qualname = provider.getChildQualname(function_name)
@@ -1638,9 +1635,6 @@ through incomplete set import by '%s' plugin encountered."""
 
     @classmethod
     def onClassBodyParsing(cls, provider, class_name, node):
-        if not active_plugins_with_class_body_parsing:
-            return
-
         module_name = provider.getParentModule().getFullName()
 
         for plugin in active_plugins_with_class_body_parsing:

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -77,6 +77,8 @@ from .PluginBase import NuitkaPluginBase, control_tags
 
 # Maps plugin name to plugin instances.
 active_plugins = OrderedDict()
+active_plugins_with_function_body_parsing = []
+active_plugins_with_class_body_parsing = []
 plugin_name2plugin_classes = {}
 plugin_options = OrderedDict()
 plugin_values = {}
@@ -138,6 +140,18 @@ def _addActivePlugin(plugin_class, args, force=False):
     assert isinstance(plugin_instance, NuitkaPluginBase), plugin_instance
 
     active_plugins[plugin_name] = plugin_instance
+
+    if (
+        type(plugin_instance).onFunctionBodyParsing
+        is not NuitkaPluginBase.onFunctionBodyParsing
+    ):
+        active_plugins_with_function_body_parsing.append(plugin_instance)
+
+    if (
+        type(plugin_instance).onClassBodyParsing
+        is not NuitkaPluginBase.onClassBodyParsing
+    ):
+        active_plugins_with_class_body_parsing.append(plugin_instance)
 
     is_gui_toolkit_plugin = getattr(plugin_class, "plugin_gui_toolkit", False)
 
@@ -1607,13 +1621,14 @@ through incomplete set import by '%s' plugin encountered."""
 
     @classmethod
     def onFunctionBodyParsing(cls, provider, function_name, body):
+        if not active_plugins_with_function_body_parsing:
+            return
+
         module_name = provider.getParentModule().getFullName()
 
         function_qualname = provider.getChildQualname(function_name)
 
-        for plugin in getActivePlugins():
-            # TODO: Could record what functions got modified by what plugin
-            # and in what way checking the return value
+        for plugin in active_plugins_with_function_body_parsing:
             plugin.onFunctionBodyParsing(
                 module_name=module_name,
                 function_qualname=function_qualname,
@@ -1623,11 +1638,12 @@ through incomplete set import by '%s' plugin encountered."""
 
     @classmethod
     def onClassBodyParsing(cls, provider, class_name, node):
+        if not active_plugins_with_class_body_parsing:
+            return
+
         module_name = provider.getParentModule().getFullName()
 
-        for plugin in getActivePlugins():
-            # TODO: Could record what classes got modified by what plugin
-            # and in what way checking the return value
+        for plugin in active_plugins_with_class_body_parsing:
             plugin.onClassBodyParsing(
                 module_name=module_name,
                 class_name=class_name,

--- a/nuitka/plugins/Plugins.py
+++ b/nuitka/plugins/Plugins.py
@@ -147,41 +147,21 @@ def _addActivePlugin(plugin_class, args, force=False):
 
     active_plugins[plugin_name] = plugin_instance
 
-    if (
-        type(plugin_instance).getImplicitImports
-        is not NuitkaPluginBase.getImplicitImports
+    plugin_type = type(plugin_instance)
+
+    for callback_name, plugin_collection in (
+        ("getImplicitImports", active_plugins_with_implicit_imports),
+        ("decideCompilation", active_plugins_with_decide_compilation),
+        ("decideAnnotations", active_plugins_with_decide_annotations),
+        ("decideDocStrings", active_plugins_with_decide_doc_strings),
+        ("decideAssertions", active_plugins_with_decide_assertions),
+        ("onFunctionBodyParsing", active_plugins_with_function_body_parsing),
+        ("onClassBodyParsing", active_plugins_with_class_body_parsing),
     ):
-        active_plugins_with_implicit_imports.append(plugin_instance)
-
-    if (
-        type(plugin_instance).decideCompilation
-        is not NuitkaPluginBase.decideCompilation
-    ):
-        active_plugins_with_decide_compilation.append(plugin_instance)
-
-    if (
-        type(plugin_instance).decideAnnotations
-        is not NuitkaPluginBase.decideAnnotations
-    ):
-        active_plugins_with_decide_annotations.append(plugin_instance)
-
-    if type(plugin_instance).decideDocStrings is not NuitkaPluginBase.decideDocStrings:
-        active_plugins_with_decide_doc_strings.append(plugin_instance)
-
-    if type(plugin_instance).decideAssertions is not NuitkaPluginBase.decideAssertions:
-        active_plugins_with_decide_assertions.append(plugin_instance)
-
-    if (
-        type(plugin_instance).onFunctionBodyParsing
-        is not NuitkaPluginBase.onFunctionBodyParsing
-    ):
-        active_plugins_with_function_body_parsing.append(plugin_instance)
-
-    if (
-        type(plugin_instance).onClassBodyParsing
-        is not NuitkaPluginBase.onClassBodyParsing
-    ):
-        active_plugins_with_class_body_parsing.append(plugin_instance)
+        if getattr(plugin_type, callback_name) is not getattr(
+            NuitkaPluginBase, callback_name
+        ):
+            plugin_collection.append(plugin_instance)
 
     is_gui_toolkit_plugin = getattr(plugin_class, "plugin_gui_toolkit", False)
 


### PR DESCRIPTION
## Summary

- Cache which plugins override `onFunctionBodyParsing` and `onClassBodyParsing` at activation time using the existing `active_plugins_with_*` pattern
- Only ~1 of ~22 active plugins (AntiBloatPlugin) overrides these callbacks, yet every function and class in every module triggers a full iteration of all active plugins
- Early-return before computing `module_name` / `function_qualname` when no plugin overrides the callback

## Changes

- Add `active_plugins_with_function_body_parsing` and `active_plugins_with_class_body_parsing` lists, populated in `_addActivePlugin()` using the same `type(plugin).method is not NuitkaPluginBase.method` pattern used for `decideCompilation`, `decideAnnotations`, etc.
- `onFunctionBodyParsing` and `onClassBodyParsing` dispatch methods use the filtered lists instead of `getActivePlugins()`

## Test plan

- [x] Verified successful compilation (`python3 -m nuitka --module`) with changes applied
- [ ] Full test suite