### PR TITLE
CodeGen: Add unlikely() hints to error exit templates

### DIFF
--- a/nuitka/code_generation/templates/CodeTemplatesExceptions.py
+++ b/nuitka/code_generation/templates/CodeTemplatesExceptions.py
@@ -28,7 +28,7 @@ if (%(condition)s) {
 }"""
 
 template_error_catch_exception = """\
-if (%(condition)s) {
+if (unlikely(%(condition)s)) {
     assert(HAS_ERROR_OCCURRED(tstate));
 
     FETCH_ERROR_OCCURRED_STATE(tstate, &%(exception_state_name)s);
@@ -40,7 +40,7 @@ if (%(condition)s) {
 }"""
 
 template_error_format_string_exception = """\
-if (%(condition)s) {
+if (unlikely(%(condition)s)) {
 %(release_temps)s
 %(set_exception)s
 


### PR DESCRIPTION
## Summary

- Add `unlikely()` branch prediction hints to the 3 error-exit templates that were missing them in `CodeTemplatesExceptions.py`
- `template_error_format_name_error_exception` already had the hint — this makes all 4 templates consistent

## Details

These 3 templates are the single funnel for all 176 `getErrorExitCode`/`getErrorExitBoolCode` call sites across 35 code generation files. Every error check in every generated C function (NULL pointer checks, exception indicator checks, bool error checks) now hints the branch predictor that the error path is cold.

The `unlikely()` macro (defined via Hedley in `prelude.h` as `__builtin_expect(..., 0)`) tells GCC/Clang to:
- Layout error-path code out-of-line (after the fast path)
- Initialize branch prediction counters favoring the non-error path

### Verified by diffing generated C

Compiled a test program before/after — every diff is strictly `if (X)` → `if (unlikely(X))` on error-exit conditions only. No other generated code changed. Helpers, constants, and loader files are identical.

```diff
< if (tmp_return_value == NULL) {
> if (unlikely(tmp_return_value == NULL)) {

< if (tmp_call_result_1 == NULL) {
> if (unlikely(tmp_call_result_1 == NULL)) {

< if (CONSIDER_THREADING(tstate) == false) {
> if (unlikely(CONSIDER_THREADING(tstate) == false)) {
```

## Test plan

- [x] Diff generated C before/after — only `unlikely()` wrappers added
- [x] Ran basics test suite (compiles programs and compares output against CPython) — all tests passing
- [ ] Benchmark compiled binaries (pystone, nbody) to measure branch misprediction improvement

## Summary by Sourcery

Add branch prediction hints to error-handling code generation templates and update plugin configuration for selected third-party modules.

Enhancements:
- Mark generated error-handling branches as unlikely in exception-related code templates to improve layout and prediction of cold error paths.
- Extend the standard plugin configuration to reduce unnecessary dependencies for the 'av', 'numpy', and 'openvino' modules by adjusting anti-bloat and DLL handling settings.