### PR TITLE
Plugins: Fix standalone forkserver __main__ bootstrap for multiprocessing

### DIFF
--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -507,6 +507,13 @@ static void setCommandLineParameters(int argc, wchar_t **argv) {
         }
 
         if ((i + 1 < argc) && (strcmpFilename(argv[i], FILENAME_EMPTY_STR "-c") == 0)) {
+            // The multiprocessing resource tracker can launch like this.
+            if (scanFilename(argv[i + 1],
+                             FILENAME_EMPTY_STR "from multiprocessing.resource_tracker import main; main(%i)",
+                             &multiprocessing_resource_tracker_arg) == 1) {
+                break;
+            }
+
             // The joblib loky resource tracker is launched like this.
             if (scanFilename(argv[i + 1],
                              FILENAME_EMPTY_STR

--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -100,6 +100,9 @@ try:
 except ImportError:
     from multiprocessing.reduction import ForkingPickler
 
+import os
+import sys
+
 class C:
    def f():
        pass
@@ -125,14 +128,11 @@ else:
         def _fixup_main_from_path_for_nuitka(main_path):
             if main_path is not None:
                 try:
-                    import os
                     main_path_exists = os.path.exists(main_path)
                 except Exception:
                     main_path_exists = False
 
                 if not main_path_exists:
-                    import sys
-
                     try:
                         parents_main = sys.modules["__parents_main__"]
                     except KeyError:
@@ -183,7 +183,6 @@ def __nuitka_freeze_support():
     # This is a variant of freeze_support that will work for multiprocessing and
     # joblib equally well.
     kwds = {}
-    args = []
 
     if not hasattr(builtins, "__nuitka_original_args"):
         return
@@ -206,7 +205,7 @@ def __nuitka_freeze_support():
     # Otherwise main module names will not work.
     sys.modules["__main__"] = sys.modules["__parents_main__"]
 
-    multiprocessing.spawn.spawn_main(*args, **kwds)
+    multiprocessing.spawn.spawn_main(**kwds)
 __nuitka_freeze_support()
 """
         else:

--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -113,6 +113,41 @@ def _reduce_compiled_method(m):
 ForkingPickler.register(type(C().f), _reduce_compiled_method)
 if str is bytes:
     ForkingPickler.register(type(C.f), _reduce_compiled_method)
+
+try:
+    import multiprocessing.spawn
+except ImportError:
+    pass
+else:
+    if not hasattr(multiprocessing.spawn, "__nuitka_original_fixup_main_from_path"):
+        multiprocessing.spawn.__nuitka_original_fixup_main_from_path = multiprocessing.spawn._fixup_main_from_path
+
+        def _fixup_main_from_path_for_nuitka(main_path):
+            if main_path is not None:
+                try:
+                    import os
+                    main_path_exists = os.path.exists(main_path)
+                except Exception:
+                    main_path_exists = False
+
+                if not main_path_exists:
+                    import sys
+
+                    try:
+                        parents_main = sys.modules["__parents_main__"]
+                    except KeyError:
+                        try:
+                            import __parents_main__ as parents_main
+                        except ImportError:
+                            return
+
+                    sys.modules["__main__"] = parents_main
+                    sys.modules["__mp_main__"] = parents_main
+                    return
+
+            return multiprocessing.spawn.__nuitka_original_fixup_main_from_path(main_path)
+
+        multiprocessing.spawn._fixup_main_from_path = _fixup_main_from_path_for_nuitka
 """,
                 """\
 Monkey patching "multiprocessing" for compiled methods.""",
@@ -145,18 +180,16 @@ def __nuitka_freeze_support():
     import sys
     import builtins
 
-    # Not needed, and can crash from minor "__file__" differences, depending on invocation
-    import multiprocessing.spawn
-    multiprocessing.spawn._fixup_main_from_path = lambda mod_name : None
-
     # This is a variant of freeze_support that will work for multiprocessing and
     # joblib equally well.
     kwds = {}
     args = []
 
-    if hasattr(builtins, "__nuitka_original_args"):
-        sys.argv = builtins.__nuitka_original_args
-        del builtins.__nuitka_original_args
+    if not hasattr(builtins, "__nuitka_original_args"):
+        return
+
+    sys.argv = builtins.__nuitka_original_args
+    del builtins.__nuitka_original_args
 
     for arg in sys.argv[2:]:
         try:
@@ -180,9 +213,11 @@ __nuitka_freeze_support()
             source_code += """
 def __nuitka_freeze_support():
     import __builtin__, sys
-    if hasattr(__builtin__, "__nuitka_original_args"):
-        sys.argv = __builtin__.__nuitka_original_args
-        del __builtin__.__nuitka_original_args
+    if not hasattr(__builtin__, "__nuitka_original_args"):
+        return
+
+    sys.argv = __builtin__.__nuitka_original_args
+    del __builtin__.__nuitka_original_args
 
     sys.modules["__main__"] = sys.modules[__name__]
     __import__("multiprocessing.forking").forking.freeze_support()

--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -128,7 +128,13 @@ else:
         def _fixup_main_from_path_for_nuitka(main_path):
             if main_path is not None:
                 try:
-                    main_path_exists = os.path.exists(main_path)
+                    # Compiled children must never execute the source path via
+                    # runpy.run_path(), even if it still exists next to an
+                    # accelerated binary.
+                    if "__compiled__" in globals():
+                        main_path_exists = False
+                    else:
+                        main_path_exists = os.path.exists(main_path)
                 except Exception:
                     main_path_exists = False
 
@@ -179,6 +185,7 @@ Monkey patching "multiprocessing" for compiled methods.""",
 def __nuitka_freeze_support():
     import sys
     import builtins
+    import multiprocessing.spawn
 
     # This is a variant of freeze_support that will work for multiprocessing and
     # joblib equally well.

--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -117,41 +117,19 @@ ForkingPickler.register(type(C().f), _reduce_compiled_method)
 if str is bytes:
     ForkingPickler.register(type(C.f), _reduce_compiled_method)
 
-try:
+if str is not bytes:
     import multiprocessing.spawn
-except ImportError:
-    pass
-else:
+
     if not hasattr(multiprocessing.spawn, "__nuitka_original_fixup_main_from_path"):
         multiprocessing.spawn.__nuitka_original_fixup_main_from_path = multiprocessing.spawn._fixup_main_from_path
 
         def _fixup_main_from_path_for_nuitka(main_path):
-            if main_path is not None:
-                try:
-                    # Compiled children must never execute the source path via
-                    # runpy.run_path(), even if it still exists next to an
-                    # accelerated binary.
-                    if "__compiled__" in globals():
-                        main_path_exists = False
-                    else:
-                        main_path_exists = os.path.exists(main_path)
-                except Exception:
-                    main_path_exists = False
+            assert main_path is not None
 
-                if not main_path_exists:
-                    try:
-                        parents_main = sys.modules["__parents_main__"]
-                    except KeyError:
-                        try:
-                            import __parents_main__ as parents_main
-                        except ImportError:
-                            return
+            import __parents_main__ as parents_main
 
-                    sys.modules["__main__"] = parents_main
-                    sys.modules["__mp_main__"] = parents_main
-                    return
-
-            return multiprocessing.spawn.__nuitka_original_fixup_main_from_path(main_path)
+            sys.modules["__main__"] = parents_main
+            sys.modules["__mp_main__"] = parents_main
 
         multiprocessing.spawn._fixup_main_from_path = _fixup_main_from_path_for_nuitka
 """,

--- a/tests/standalone/MultiprocessingForkserverUsing.py
+++ b/tests/standalone/MultiprocessingForkserverUsing.py
@@ -2,6 +2,8 @@
 
 # nuitka-project: --mode=standalone
 
+# nuitka-skip-unless-expression: hasattr(__import__("multiprocessing"), "get_all_start_methods") and "forkserver" in __import__("multiprocessing").get_all_start_methods()
+
 
 from __future__ import print_function
 

--- a/tests/standalone/MultiprocessingForkserverUsing.py
+++ b/tests/standalone/MultiprocessingForkserverUsing.py
@@ -1,0 +1,27 @@
+"""Standalone regression test for multiprocessing forkserver worker start."""
+
+# nuitka-project: --mode=standalone
+
+
+from __future__ import print_function
+
+import multiprocessing as mp
+
+
+def poolTask(value):
+    return value + 1
+
+
+if __name__ == "__main__":
+    context = mp.get_context("forkserver")
+    pool = context.Pool(1)
+
+    try:
+        async_result = pool.apply_async(poolTask, (41,))
+        result = async_result.get(timeout=10)
+    finally:
+        pool.close()
+        pool.join()
+
+    assert result == 42, result
+    print("OK")

--- a/tests/standalone/MultiprocessingForkserverUsing32.py
+++ b/tests/standalone/MultiprocessingForkserverUsing32.py
@@ -2,9 +2,6 @@
 
 # nuitka-project: --mode=standalone
 
-# nuitka-skip-unless-expression: hasattr(__import__("multiprocessing"), "get_all_start_methods") and "forkserver" in __import__("multiprocessing").get_all_start_methods()
-
-
 from __future__ import print_function
 
 import multiprocessing as mp

--- a/tests/standalone/MultiprocessingForkserverUsing32.py
+++ b/tests/standalone/MultiprocessingForkserverUsing32.py
@@ -16,11 +16,11 @@ if __name__ == "__main__":
     pool = context.Pool(1)
 
     try:
-        async_result = pool.apply_async(poolTask, (41,))
+        async_result = pool.apply_async(poolTask, (9,))
         result = async_result.get(timeout=10)
     finally:
         pool.close()
         pool.join()
 
-    assert result == 42, result
+    assert result == 10, result
     print("OK")

--- a/tests/standalone/MultiprocessingForkserverUsing32.py
+++ b/tests/standalone/MultiprocessingForkserverUsing32.py
@@ -2,6 +2,8 @@
 
 # nuitka-project: --mode=standalone
 
+# nuitka-skip-unless-expression: os.name != "nt"
+
 from __future__ import print_function
 
 import multiprocessing as mp


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR fixes standalone `multiprocessing` + `forkserver` worker bootstrap so top-level task functions from `__main__` can be unpickled reliably.

- Updates `MultiprocessingPlugin` post-load patching for `multiprocessing.spawn._fixup_main_from_path`:
  - keeps CPython behavior when `main_path` exists,
  - falls back to mapping `__main__`/`__mp_main__` to `__parents_main__` when `main_path` is missing in standalone mode.
- Makes generated `__parents_main__` freeze-support safe for import-only paths by returning early when fork args are absent.
- Adds regression test `tests/standalone/MultiprocessingForkserverUsing.py` that uses a top-level pool task under `forkserver`.

Validation performed:

- `NUITKA_EXTRA_OPTIONS=--static-libpython=no python tests/standalone/run_all.py only MultiprocessingForkserverUsing`
- `./bin/autoformat-nuitka-source nuitka/plugins/standard/MultiprocessingPlugin.py tests/standalone/MultiprocessingForkserverUsing.py`
- `./bin/check-nuitka-with-pylint nuitka/plugins/standard/MultiprocessingPlugin.py tests/standalone/MultiprocessingForkserverUsing.py`

## 🧐 Why was it initiated? Any relevant Issues?

Initiated to fix a standalone `forkserver` worker forkbomb caused by `FileNotFoundError` during multiprocessing bootstrap.

In the failing path, `multiprocessing.spawn._fixup_main_from_path(main_path)` reaches `runpy.run_path(main_path, ...)`, but in standalone mode the source script path is not present in the dist folder. Workers exit, the pool respawns replacements, and the cycle repeats.

This was reproduced with a standalone benchmark using `ctx = mp.get_context("forkserver")` and pool tasks. No public issue link is included for this change.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
    > My note on this: I know there is an problem with `forkserver`, and it has been there for a long time. I did not create an issue, but I followed this idea when creating this fix, as shown in the chatlog below.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective.

[opencode sessions and docs during the fixing process](https://gist.github.com/ElgoogUdiab/04d2ebd34b6f3061c35aaa9499308680)

## Summary by Sourcery

Fix standalone multiprocessing forkserver worker bootstrap to correctly initialize __main__ when the original main script path is unavailable.

Bug Fixes:
- Ensure multiprocessing.spawn._fixup_main_from_path falls back to using the compiled __parents_main__ module when the main script path does not exist in standalone mode.
- Prevent __nuitka_freeze_support from running argument parsing logic when original process arguments are not available, avoiding crashes in import-only contexts.

Tests:
- Add a standalone regression test that uses a forkserver context and a top-level pool task to validate worker startup and result passing.

## Summary by Sourcery

Fix standalone multiprocessing forkserver worker initialization so compiled children correctly bootstrap their __main__ module when the original script path is unavailable.

Bug Fixes:
- Ensure multiprocessing.spawn._fixup_main_from_path in standalone binaries falls back to using the compiled __parents_main__ module when the main script path does not exist or should not be executed.
- Prevent __nuitka_freeze_support from running multiprocessing argument parsing when original process arguments are not present, avoiding crashes in import-only startup paths.
- Handle multiprocessing resource tracker command line detection in the main program argument scanner to avoid misinterpreting its invocation.

Tests:
- Add a standalone regression test that uses a forkserver context and a top-level pool task to verify worker processes start correctly and return expected results.