### PR TITLE
Python3.6+: Fix missing '__classcell__' and adjusting 'Nuitka_Cell_Check'

### DIFF
--- a/nuitka/build/include/nuitka/compiled_cell.h
+++ b/nuitka/build/include/nuitka/compiled_cell.h
@@ -9,7 +9,9 @@
 
 extern PyTypeObject Nuitka_Cell_Type;
 
-static inline bool Nuitka_Cell_Check(PyObject *object) { return Py_TYPE(object) == &Nuitka_Cell_Type; }
+static inline bool Nuitka_Cell_Check(PyObject *object) {
+    return Py_TYPE(object) == &Nuitka_Cell_Type || PyCell_Check(object);
+}
 
 struct Nuitka_CellObject {
     /* Python object folklore: */

--- a/nuitka/build/static_src/HelpersTypes.c
+++ b/nuitka/build/static_src/HelpersTypes.c
@@ -373,9 +373,9 @@ static PyTypeObject *_getTypeGenericAliasType(void) {
 
     if (type_generic_alias_type == NULL) {
 
-        PyObject *types_module = IMPORT_HARD_TYPES();
+        PyObject *typing_module = IMPORT_HARD_TYPING();
 
-        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(types_module, "GenericAlias");
+        type_generic_alias_type = (PyTypeObject *)PyObject_GetAttrString(typing_module, "_GenericAlias");
         CHECK_OBJECT(type_generic_alias_type);
     }
 

--- a/nuitka/build/static_src/MainProgram.c
+++ b/nuitka/build/static_src/MainProgram.c
@@ -507,6 +507,13 @@ static void setCommandLineParameters(int argc, wchar_t **argv) {
         }
 
         if ((i + 1 < argc) && (strcmpFilename(argv[i], FILENAME_EMPTY_STR "-c") == 0)) {
+            // The multiprocessing resource tracker can launch like this.
+            if (scanFilename(argv[i + 1],
+                             FILENAME_EMPTY_STR "from multiprocessing.resource_tracker import main; main(%i)",
+                             &multiprocessing_resource_tracker_arg) == 1) {
+                break;
+            }
+
             // The joblib loky resource tracker is launched like this.
             if (scanFilename(argv[i + 1],
                              FILENAME_EMPTY_STR

--- a/nuitka/code_generation/CodeGeneration.py
+++ b/nuitka/code_generation/CodeGeneration.py
@@ -243,6 +243,7 @@ from .ListCodes import (
 )
 from .LocalsDictCodes import (
     generateLocalsDictDelCode,
+    generateLocalsDictSetClassCellCode,
     generateLocalsDictSetCode,
     generateLocalsDictVariableCheckCode,
     generateLocalsDictVariableRefCode,
@@ -1084,6 +1085,7 @@ setStatementDispatchDict(
         "STATEMENT_DICT_OPERATION_SET": generateDictOperationSetCode,
         "STATEMENT_DICT_OPERATION_SET_KEY_VALUE": generateDictOperationSetCodeKeyValue,
         "STATEMENT_LOCALS_DICT_OPERATION_SET": generateLocalsDictSetCode,
+        "STATEMENT_LOCALS_DICT_OPERATION_SET_CLASS_CELL": generateLocalsDictSetClassCellCode,
         "STATEMENT_LOCALS_DICT_OPERATION_DEL": generateLocalsDictDelCode,
         "STATEMENT_LOOP": generateLoopCode,
         "STATEMENT_LOOP_BREAK": generateLoopBreakCode,

--- a/nuitka/code_generation/LocalsDictCodes.py
+++ b/nuitka/code_generation/LocalsDictCodes.py
@@ -137,6 +137,73 @@ def generateLocalsDictSetCode(statement, emit, context):
         )
 
 
+def generateLocalsDictSetClassCellCode(statement, emit, context):
+    from .c_types.CTypePyObjectPointers import CTypeCellObject
+    from .VariableCodes import getLocalVariableDeclaration
+
+    class_variable = statement.getClassVariable()
+
+    variable_declaration = getLocalVariableDeclaration(
+        context=context, variable=class_variable, variable_trace=None
+    )
+
+    # Only emit __classcell__ storage if the variable is actually a cell.
+    # If no method closes over __class__, no cell exists and no __classcell__
+    # is needed.
+    if variable_declaration.getCType() is not CTypeCellObject:
+        return
+
+    context.setCurrentSourceCodeReference(statement.getSourceReference())
+
+    # Make type.__new__() accepts it.
+    emit("Py_SET_TYPE(%s, &PyCell_Type);" % variable_declaration)
+
+    locals_scope = statement.getLocalsDictScope()
+
+    locals_declaration = context.addLocalsDictName(locals_scope.getCodeName())
+
+    is_dict = locals_scope.hasShapeDictionaryExact()
+
+    if is_dict:
+        res_name = context.getBoolResName()
+
+        emit(
+            "%s = DICT_SET_ITEM(%s, %s, (PyObject *)%s);"
+            % (
+                res_name,
+                locals_declaration,
+                context.getConstantCode("__classcell__"),
+                variable_declaration,
+            )
+        )
+
+        getErrorExitBoolCode(
+            condition="%s == false" % res_name,
+            needs_check=False,
+            emit=emit,
+            context=context,
+        )
+    else:
+        res_name = context.getIntResName()
+
+        emit(
+            "%s = PyObject_SetItem(%s, %s, (PyObject *)%s);"
+            % (
+                res_name,
+                locals_declaration,
+                context.getConstantCode("__classcell__"),
+                variable_declaration,
+            )
+        )
+
+        getErrorExitBoolCode(
+            condition="%s != 0" % res_name,
+            needs_check=True,
+            emit=emit,
+            context=context,
+        )
+
+
 def generateLocalsDictDelCode(statement, emit, context):
     locals_scope = statement.getLocalsDictScope()
 

--- a/nuitka/nodes/DictionaryNodes.py
+++ b/nuitka/nodes/DictionaryNodes.py
@@ -491,6 +491,9 @@ class ExpressionDictOperationPop3(ExpressionDictOperationPop3Base):
 
         # TODO: Check for "None" default and demote to ExpressionDictOperationSetdefault3 in
         # that case.
+        if self.known_hashable_key is None:
+            trace_collection.onExceptionRaiseExit(BaseException)
+
         return self, None, None
 
     # TODO: These turn this into dictionary item removals, as value is unused.
@@ -578,6 +581,9 @@ class ExpressionDictOperationSetdefault2(ExpressionDictOperationSetdefault2Base)
 
         # TODO: Check for "None" default and demote to ExpressionDictOperationSetdefault3 in
         # that case.
+        if self.known_hashable_key is None:
+            trace_collection.onExceptionRaiseExit(BaseException)
+
         return self, None, None
 
     def mayRaiseException(self, exception_type):
@@ -634,6 +640,9 @@ class ExpressionDictOperationSetdefault3(ExpressionDictOperationSetdefault3Base)
 
         # TODO: Check for "None" default and demote to ExpressionDictOperationSetdefault3 in
         # that case.
+        if self.known_hashable_key is None:
+            trace_collection.onExceptionRaiseExit(BaseException)
+
         return self, None, None
 
     def mayRaiseException(self, exception_type):

--- a/nuitka/nodes/LocalsDictNodes.py
+++ b/nuitka/nodes/LocalsDictNodes.py
@@ -653,6 +653,52 @@ class ExpressionLocalsDictRef(ExpressionBuiltinLocalsRef):
         return True
 
 
+class StatementLocalsDictOperationSetClassCell(StatementBase):
+    kind = "STATEMENT_LOCALS_DICT_OPERATION_SET_CLASS_CELL"
+
+    __slots__ = ("locals_scope", "class_variable")
+
+    def __init__(self, locals_scope, class_variable, source_ref):
+        StatementBase.__init__(self, source_ref=source_ref)
+
+        self.locals_scope = locals_scope
+        self.class_variable = class_variable
+
+    def finalize(self):
+        del self.parent
+        del self.locals_scope
+
+    def computeStatement(self, trace_collection):
+        return self, None, None
+
+    def getDetails(self):
+        return {
+            "locals_scope": self.locals_scope,
+            "class_variable": self.class_variable,
+        }
+
+    def getDetailsForDisplay(self):
+        return {
+            "locals_scope": self.locals_scope.getCodeName(),
+            "class_variable": self.class_variable.getName(),
+        }
+
+    def getLocalsDictScope(self):
+        return self.locals_scope
+
+    def getClassVariable(self):
+        return self.class_variable
+
+    @staticmethod
+    def mayRaiseException(exception_type):
+        # Might be a mapping, not a dict, so SetItem could fail.
+        return True
+
+    @staticmethod
+    def getStatementNiceName():
+        return "locals dictionary __classcell__ set statement"
+
+
 class StatementReleaseLocals(StatementBase):
     kind = "STATEMENT_RELEASE_LOCALS"
 

--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -100,6 +100,9 @@ try:
 except ImportError:
     from multiprocessing.reduction import ForkingPickler
 
+import os
+import sys
+
 class C:
    def f():
        pass
@@ -113,6 +116,22 @@ def _reduce_compiled_method(m):
 ForkingPickler.register(type(C().f), _reduce_compiled_method)
 if str is bytes:
     ForkingPickler.register(type(C.f), _reduce_compiled_method)
+
+if str is not bytes:
+    import multiprocessing.spawn
+
+    if not hasattr(multiprocessing.spawn, "__nuitka_original_fixup_main_from_path"):
+        multiprocessing.spawn.__nuitka_original_fixup_main_from_path = multiprocessing.spawn._fixup_main_from_path
+
+        def _fixup_main_from_path_for_nuitka(main_path):
+            assert main_path is not None
+
+            import __parents_main__ as parents_main
+
+            sys.modules["__main__"] = parents_main
+            sys.modules["__mp_main__"] = parents_main
+
+        multiprocessing.spawn._fixup_main_from_path = _fixup_main_from_path_for_nuitka
 """,
                 """\
 Monkey patching "multiprocessing" for compiled methods.""",
@@ -144,19 +163,17 @@ Monkey patching "multiprocessing" for compiled methods.""",
 def __nuitka_freeze_support():
     import sys
     import builtins
-
-    # Not needed, and can crash from minor "__file__" differences, depending on invocation
     import multiprocessing.spawn
-    multiprocessing.spawn._fixup_main_from_path = lambda mod_name : None
 
     # This is a variant of freeze_support that will work for multiprocessing and
     # joblib equally well.
     kwds = {}
-    args = []
 
-    if hasattr(builtins, "__nuitka_original_args"):
-        sys.argv = builtins.__nuitka_original_args
-        del builtins.__nuitka_original_args
+    if not hasattr(builtins, "__nuitka_original_args"):
+        return
+
+    sys.argv = builtins.__nuitka_original_args
+    del builtins.__nuitka_original_args
 
     for arg in sys.argv[2:]:
         try:
@@ -173,16 +190,18 @@ def __nuitka_freeze_support():
     # Otherwise main module names will not work.
     sys.modules["__main__"] = sys.modules["__parents_main__"]
 
-    multiprocessing.spawn.spawn_main(*args, **kwds)
+    multiprocessing.spawn.spawn_main(**kwds)
 __nuitka_freeze_support()
 """
         else:
             source_code += """
 def __nuitka_freeze_support():
     import __builtin__, sys
-    if hasattr(__builtin__, "__nuitka_original_args"):
-        sys.argv = __builtin__.__nuitka_original_args
-        del __builtin__.__nuitka_original_args
+    if not hasattr(__builtin__, "__nuitka_original_args"):
+        return
+
+    sys.argv = __builtin__.__nuitka_original_args
+    del __builtin__.__nuitka_original_args
 
     sys.modules["__main__"] = sys.modules[__name__]
     __import__("multiprocessing.forking").forking.freeze_support()

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -217,9 +217,15 @@ def buildClassNode3(provider, node, source_ref):
     class_locals_scope.registerProvidedVariable(class_variable)
 
     if python_version >= 0x3C0:
-        type_params_expressions = buildNodeTuple(
-            provider=outline_body, nodes=node.type_params, source_ref=source_ref
-        )
+        type_params_expressions = []
+        for _, type_param_var in type_variables:
+            type_params_expressions.append(
+                ExpressionTempVariableRef(
+                    variable=type_param_var,
+                    source_ref=source_ref,
+                )
+            )
+        type_params_expressions = tuple(type_params_expressions)
     else:
         type_params_expressions = ()
 

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -58,6 +58,7 @@ from nuitka.nodes.ListOperationNodes import ExpressionListOperationExtend
 from nuitka.nodes.LocalsDictNodes import (
     ExpressionLocalsDictRef,
     StatementLocalsDictOperationSet,
+    StatementLocalsDictOperationSetClassCell,
     StatementReleaseLocals,
     StatementSetLocals,
 )
@@ -335,6 +336,15 @@ def buildClassNode3(provider, node, source_ref):
                 source=makeConstantRefNode(
                     constant={}, source_ref=source_ref, user_provided=True
                 ),
+                source_ref=source_ref,
+            )
+        )
+
+    if python_version >= 0x360:
+        statements.append(
+            StatementLocalsDictOperationSetClassCell(
+                locals_scope=locals_scope,
+                class_variable=class_variable,
                 source_ref=source_ref,
             )
         )

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -16,9 +16,13 @@ from nuitka.nodes.AsyncgenNodes import (
 )
 from nuitka.nodes.BuiltinIteratorNodes import (
     ExpressionBuiltinIter1,
+    ExpressionBuiltinIterForUnpack,
     StatementSpecialUnpackCheck,
 )
-from nuitka.nodes.BuiltinNextNodes import ExpressionSpecialUnpack
+from nuitka.nodes.BuiltinNextNodes import (
+    ExpressionBuiltinNext1,
+    ExpressionSpecialUnpack,
+)
 from nuitka.nodes.BuiltinRefNodes import (
     ExpressionBuiltinExceptionRef,
     makeExpressionBuiltinTypeRef,
@@ -752,9 +756,22 @@ def buildParameterAnnotations(provider, node, source_ref):
             assert arg.annotation is None
         elif getKind(arg) == "arg":
             if arg.annotation is not None:
+                if python_version >= 0x3B0 and getKind(arg.annotation) == "Starred":
+                    value = buildAnnotationNode(
+                        provider, arg.annotation.value, source_ref
+                    )
+
+                    result = ExpressionBuiltinNext1(
+                        value=ExpressionBuiltinIterForUnpack(value, source_ref),
+                        source_ref=source_ref,
+                    )
+
+                else:
+                    result = buildAnnotationNode(provider, arg.annotation, source_ref)
+
                 addAnnotation(
                     key=arg.arg,
-                    value=buildAnnotationNode(provider, arg.annotation, source_ref),
+                    value=result,
                 )
         elif getKind(arg) == "Tuple":
             for sub_arg in arg.elts:

--- a/tests/basics/BuiltinSuperTest.py
+++ b/tests/basics/BuiltinSuperTest.py
@@ -139,6 +139,31 @@ if sys.version_info >= (3, 6):
 makeSuperCall(type, None)
 makeSuperCall(type, 1)
 
+
+def makeClassDecorator(cls):
+    def __init__(self):
+        cls.__self_init__(self)
+
+    cls.__init__ = __init__
+    return cls
+
+
+class Parent:
+    def __init__(self):
+        print("Initialized")
+
+    def __init_subclass__(cls, *, decorator):
+        decorator(cls)()
+
+
+class Child(
+    Parent,
+    decorator=makeClassDecorator,
+):
+    def __self_init__(self):
+        super().__init__()
+
+
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #

--- a/tests/basics/BuiltinSuperTest.py
+++ b/tests/basics/BuiltinSuperTest.py
@@ -140,30 +140,6 @@ makeSuperCall(type, None)
 makeSuperCall(type, 1)
 
 
-def makeClassDecorator(cls):
-    def __init__(self):
-        cls.__self_init__(self)
-
-    cls.__init__ = __init__
-    return cls
-
-
-class Parent:
-    def __init__(self):
-        print("Initialized")
-
-    def __init_subclass__(cls, *, decorator):
-        decorator(cls)()
-
-
-class Child(
-    Parent,
-    decorator=makeClassDecorator,
-):
-    def __self_init__(self):
-        super().__init__()
-
-
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #

--- a/tests/basics/BuiltinSuperTest36.py
+++ b/tests/basics/BuiltinSuperTest36.py
@@ -1,3 +1,20 @@
+try:
+
+    class Meta(type):
+        def __new__(mcs, name, bases, namespace):
+            cls = type.__new__(mcs, name, bases, namespace)
+            cls.test()
+
+    class WithClassRef(metaclass=Meta):
+        def test():
+            return __class__
+
+except BaseException:
+    raise
+else:
+    print("Success")
+
+
 def makeClassDecorator(cls):
     def __init__(self):
         cls.__self_init__(self)

--- a/tests/basics/BuiltinSuperTest36.py
+++ b/tests/basics/BuiltinSuperTest36.py
@@ -1,0 +1,22 @@
+def makeClassDecorator(cls):
+    def __init__(self):
+        cls.__self_init__(self)
+
+    cls.__init__ = __init__
+    return cls
+
+
+class Parent:
+    def __init__(self):
+        print("Initialized")
+
+    def __init_subclass__(cls, *, decorator):
+        decorator(cls)()
+
+
+class Child(
+    Parent,
+    decorator=makeClassDecorator,
+):
+    def __self_init__(self):
+        super().__init__()

--- a/tests/basics/ClassesTest312.py
+++ b/tests/basics/ClassesTest312.py
@@ -62,6 +62,35 @@ try:
 except NameError:
     print("!!!")
 
+
+class Base[T, V]: ...
+
+
+class Sub[Silly](Base[Silly, str]): ...
+
+
+print("Base parameters", Base.__parameters__)
+print("Base bases", Base.__bases__, Base.__orig_bases__)
+print("Subclass parameters", Sub.__parameters__)
+print("Subclass bases", Sub.__bases__, Sub.__orig_bases__)
+print("Subclass with param", Sub[int], type(Sub[int]))
+
+
+class FullyBound(Base[str, str]): ...
+
+
+print(
+    "FullyBound fields",
+    FullyBound.__parameters__,
+    FullyBound.__bases__,
+    FullyBound.__orig_bases__,
+)
+
+try:
+    FullyBound[int]
+except Exception as error:
+    print("Caught exception trying to pass parameters to FullyBound", type(error))
+
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #

--- a/tests/basics/Generics311.py
+++ b/tests/basics/Generics311.py
@@ -1,0 +1,79 @@
+"""Generic annotations tests, cover most important forms of them."""
+
+# Tests are dirty on purpose.
+#
+# pylint: disable=not-an-iterable,unused-argument
+
+from typing import Tuple, TypeVar, TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+print("Module level T=", T)
+print("Module level Ts=", Ts)
+print()
+
+
+print("[Part: 1] Unpacking a TypeVar tuple with star list arguments gives:")
+
+
+def func1(*args: *Ts) -> None:
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
+
+
+func1()
+print(func1.__annotations__, "\n")
+
+
+print("[Part: 2] Manually defining a Tuple[int,...] gives:")
+
+
+def func21(*args: *Tuple[int, ...]) -> None:
+    pass
+
+
+func21()
+print("Annotations", func21.__annotations__, "\n")
+
+
+def func22(*args: *tuple[int, ...]) -> None:
+    pass
+
+
+func22()
+print("Annotations", func22.__annotations__, "\n")
+
+
+print("[Part: 3] Unpacking a TypeVar tuple with star list arguments gives:")
+
+
+def func31(*args: Tuple[*Ts]) -> Tuple[*Ts]:
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
+
+
+func31()
+print("Annotations", func31.__annotations__, "\n")
+
+
+def func32(*args: tuple[*Ts]) -> tuple[*Ts]:
+    print("Function level Ts=", Ts)
+    print("Function level *Ts=", *Ts)
+
+
+func32()
+print("Annotations", func32.__annotations__, "\n")
+
+
+print("[Part: 4] Unpacking a TypeVar with star list arguments should raise an error:")
+try:
+
+    def func4(*args: *T) -> T:
+        print(T)
+        print(*T)
+
+    func4()
+    print("Annotations", func4.__annotations__, "\n")
+except TypeError as e:
+    print("Expected error:", e, "\n")

--- a/tests/basics/WalrusOperationsTest38.py
+++ b/tests/basics/WalrusOperationsTest38.py
@@ -1,0 +1,73 @@
+"""Walrus dictionary operation corner cases."""
+
+
+def case1_pop3_unknown_key(key, **kwargs):
+    """Walrus with 'kwargs.pop(key, None)' where key hashability is unknown."""
+
+    if (value := kwargs.pop(key, None)) is not None:
+        return value
+
+    return None
+
+
+def case2_pop3_union_key(flag, **kwargs):
+    """Walrus pop with runtime key being hashable string or unhashable list."""
+
+    key = [] if flag else "x"
+
+    if (value := kwargs.pop(key, None)) is not None:
+        return value
+
+    return None
+
+
+def case3_pop3_nested_walrus(key, **kwargs):
+    """Nested walrus pop calls to stress short-circuit ordering and side effects."""
+
+    if (left := kwargs.pop(key, None)) is not None and (
+        right := kwargs.pop("y", None)
+    ) is not None:
+        return left, right
+
+    return None
+
+
+def case4_setdefault3_unknown_key(key, **kwargs):
+    """Walrus with 'kwargs.setdefault(key, 123)' for unknown key hashability."""
+
+    if (value := kwargs.setdefault(key, 123)) is not None:
+        return value
+
+    return None
+
+
+def case5_pop3_in_try(key, **kwargs):
+    """Walrus pop inside explicit try/except to exercise try node exception tracking."""
+
+    try:
+        if (value := kwargs.pop(key, None)) is not None:
+            return value
+    except TypeError:
+        return "caught"
+
+    return None
+
+
+print("case1-hit", case1_pop3_unknown_key("x", x=1))
+print("case1-miss", case1_pop3_unknown_key("x"))
+
+print("case2-false", case2_pop3_union_key(False, x=1))
+
+try:
+    print("case2-true", case2_pop3_union_key(True, x=1))
+except TypeError:
+    print("case2-true", "TypeError")
+
+print("case3-both", case3_pop3_nested_walrus("x", x=1, y=2))
+print("case3-missing", case3_pop3_nested_walrus("x", x=1))
+
+print("case4", case4_setdefault3_unknown_key("x"))
+
+print("case5-hit", case5_pop3_in_try("x", x=1))
+print("case5-miss", case5_pop3_in_try("x"))
+print("case5-caught", case5_pop3_in_try([], x=1))

--- a/tests/standalone/MultiprocessingForkserverUsing32.py
+++ b/tests/standalone/MultiprocessingForkserverUsing32.py
@@ -1,0 +1,28 @@
+"""Standalone regression test for multiprocessing forkserver worker start."""
+
+# nuitka-project: --mode=standalone
+
+# nuitka-skip-unless-expression: os.name != "nt"
+
+from __future__ import print_function
+
+import multiprocessing as mp
+
+
+def poolTask(value):
+    return value + 1
+
+
+if __name__ == "__main__":
+    context = mp.get_context("forkserver")
+    pool = context.Pool(1)
+
+    try:
+        async_result = pool.apply_async(poolTask, (9,))
+        result = async_result.get(timeout=10)
+    finally:
+        pool.close()
+        pool.join()
+
+    assert result == 10, result
+    print("OK")


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

I noticed that this example involves the `__classcell__` mechanism in the bytecode starting from `Python 3.6+`.

This mechanism is currently not handled in Nuitka, and it appears as a dictionary entry that is consumed during class creation, specifically in `type.__new__()`.

According to [PEP 487](https://peps.python.org/pep-0487/), the overall process is as follows:
This is an example of the abstracted code structure from my issue compiled into bytecode.
```
              0 MAKE_CELL                0 (__class__)

 15           2 RESUME                   0
              4 LOAD_NAME                0 (__name__)
              6 STORE_NAME               1 (__module__)
              8 LOAD_CONST               0 ('Child')
             10 STORE_NAME               2 (__qualname__)

 19          12 LOAD_CLOSURE             0 (__class__)
             14 BUILD_TUPLE              1
             16 LOAD_CONST               1 (<code object __self_init__ at 0x7feec3633e10, file "<__class>", line 19>)
             18 MAKE_FUNCTION            8 (closure)
             20 STORE_NAME               3 (__self_init__)
             22 LOAD_CLOSURE             0 (__class__)
             24 COPY                     1
             26 STORE_NAME               4 (__classcell__)
             28 RETURN_VALUE
```
Based on the CPython bytecode, the critical execution order can be confirmed as follows:

- The class body of Child has co_cellvars: (`__class__`,), meaning __class__ is a cell variable.
- MAKE_CELL 0 (`__class__`) creates an empty cell at the beginning of class body execution.
- `__self_init__` captures this cell via a closure (co_freevars: (`__class__`,)).
- The class body stores the cell itself into the namespace dictionary via STORE_NAME `__classcell__`.
- `type.__new__()` retrieves `__classcell__` from the class namespace and calls PyCell_Set(cell, new_class) to populate it.
- This happens inside `type.__new__()`, before `type.__init__()` invokes `__init_subclass__`.

## 🧐 Why was it initiated? Any relevant Issues?

- #3846

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Handle Python 3.6+ __classcell__ in compiled class bodies and broaden cell-type detection for interoperability with CPython cells.

New Features:
- Populate __classcell__ in class locals for Python 3.6+ class bodies so type.__new__ can initialize class closures correctly.

Bug Fixes:
- Fix missing __classcell__ handling that broke patterns relying on __init_subclass__, decorators, and super() with class-local closures.

Enhancements:
- Update Nuitka_Cell_Check to recognize both Nuitka-compiled and native PyCell objects for more robust cell handling.

Tests:
- Add regression test covering __classcell__ interaction with class decorators, __init_subclass__, and super() to guard against regressions.