### PR TITLE
Fix exact list add MemoryError handling

### DIFF
--- a/nuitka/nodes/shapes/BuiltinTypeShapes.py
+++ b/nuitka/nodes/shapes/BuiltinTypeShapes.py
@@ -27,6 +27,7 @@ from .ControlFlowDescriptions import (
     ControlFlowDescriptionFullEscape,
     ControlFlowDescriptionLshiftUnsupported,
     ControlFlowDescriptionMatmultUnsupported,
+    ControlFlowDescriptionMemoryErrorNoEscape,
     ControlFlowDescriptionModUnsupported,
     ControlFlowDescriptionMulUnsupported,
     ControlFlowDescriptionNoEscape,
@@ -1922,6 +1923,10 @@ operation_result_bytearray_noescape = tshape_bytearray, ControlFlowDescriptionNo
 
 operation_result_dict_noescape = tshape_dict, ControlFlowDescriptionNoEscape
 operation_result_dict_valueerror = tshape_dict, ControlFlowDescriptionValueErrorNoEscape
+operation_result_list_memoryerror = (
+    tshape_list,
+    ControlFlowDescriptionMemoryErrorNoEscape,
+)
 
 
 operation_result_bool_element_based = (
@@ -3564,7 +3569,7 @@ add_shapes_list.update(
         tshape_bytearray: operation_result_unsupported_add,
         tshape_unicode: operation_result_unsupported_add,
         tshape_tuple: operation_result_unsupported_add,
-        tshape_list: operation_result_list_noescape,
+        tshape_list: operation_result_list_memoryerror,
         tshape_set: operation_result_unsupported_add,
         tshape_frozenset: operation_result_unsupported_add,
         tshape_dict: operation_result_unsupported_add,
@@ -3594,7 +3599,7 @@ iadd_shapes_list.update(
         tshape_bytearray: operation_result_list_noescape,
         tshape_unicode: operation_result_list_noescape,
         tshape_tuple: operation_result_list_noescape,
-        tshape_list: operation_result_list_noescape,
+        tshape_list: operation_result_list_memoryerror,
         tshape_set: operation_result_list_noescape,
         tshape_frozenset: operation_result_list_noescape,
         tshape_dict: operation_result_list_noescape,

--- a/nuitka/nodes/shapes/ControlFlowDescriptions.py
+++ b/nuitka/nodes/shapes/ControlFlowDescriptions.py
@@ -69,6 +69,12 @@ class ControlFlowDescriptionValueErrorNoEscape(ControlFlowDescriptionNoEscape):
         return ValueError
 
 
+class ControlFlowDescriptionMemoryErrorNoEscape(ControlFlowDescriptionNoEscape):
+    @staticmethod
+    def getExceptionExit():
+        return MemoryError
+
+
 class ControlFlowDescriptionComparisonUnorderable(ControlFlowDescriptionNoEscape):
     @staticmethod
     def getExceptionExit():

--- a/tests/basics/GarbageCollectionTest.py
+++ b/tests/basics/GarbageCollectionTest.py
@@ -2,6 +2,8 @@
 
 """Exercise cleanup after exact list add MemoryError."""
 
+# nuitka-skip-unless-expression: sys.platform.startswith("linux") and os.path.exists("/proc/self/status") and hasattr(__import__("resource"), "RLIMIT_AS")
+
 import gc
 import resource
 
@@ -21,30 +23,44 @@ def churn_dict_items(rounds):
         gc.collect(1)
 
 
-gc.set_threshold(1, 1, 1)
+def exercise_list_add_memory_error(name, inplace):
+    gc.set_threshold(1, 1, 1)
 
-a = [None] * 2_000_000
-b = [None] * 2_000_000
+    a = [None] * 2_000_000
+    b = [None] * 2_000_000
 
-churn_dict_items(16)
+    churn_dict_items(16)
 
-current_vm = current_vm_bytes()
-resource.setrlimit(
-    resource.RLIMIT_AS,
-    (current_vm + 1024 * 1024, current_vm + 1024 * 1024),
-)
+    current_vm = current_vm_bytes()
+    old_soft_limit, old_hard_limit = resource.getrlimit(resource.RLIMIT_AS)
+    target_soft_limit = current_vm + 1024 * 1024
 
-try:
-    _ = a + b
-except MemoryError:
-    print("memory-error")
+    if old_hard_limit not in (-1, resource.RLIM_INFINITY):
+        target_soft_limit = min(target_soft_limit, old_hard_limit)
 
-    del a
-    del b
+    resource.setrlimit(resource.RLIMIT_AS, (target_soft_limit, old_hard_limit))
 
-    gc.collect()
-    churn_dict_items(128)
+    try:
+        try:
+            if inplace:
+                a += b
+            else:
+                _ = a + b
+        except MemoryError:
+            print(name, "memory-error")
 
-    print("post-gc-ok")
-else:
-    print("concat-succeeded")
+            del a
+            del b
+
+            gc.collect()
+            churn_dict_items(128)
+
+            print(name, "post-gc-ok")
+        else:
+            print(name, "concat-succeeded")
+    finally:
+        resource.setrlimit(resource.RLIMIT_AS, (old_soft_limit, old_hard_limit))
+
+
+exercise_list_add_memory_error("add", inplace=False)
+exercise_list_add_memory_error("iadd", inplace=True)

--- a/tests/basics/GarbageCollectionTest.py
+++ b/tests/basics/GarbageCollectionTest.py
@@ -1,0 +1,50 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+"""Exercise cleanup after exact list add MemoryError."""
+
+import gc
+import resource
+
+
+def current_vm_bytes():
+    with open("/proc/self/status", "r", encoding="utf-8") as status_file:
+        for line in status_file:
+            if line.startswith("VmSize:"):
+                return int(line.split()[1]) * 1024
+
+    raise RuntimeError("VmSize not found")
+
+
+def churn_dict_items(rounds):
+    for _ in range(rounds):
+        tuple({"left": 1, "right": 2}.items())
+        gc.collect(1)
+
+
+gc.set_threshold(1, 1, 1)
+
+a = [None] * 2_000_000
+b = [None] * 2_000_000
+
+churn_dict_items(16)
+
+current_vm = current_vm_bytes()
+resource.setrlimit(
+    resource.RLIMIT_AS,
+    (current_vm + 1024 * 1024, current_vm + 1024 * 1024),
+)
+
+try:
+    _ = a + b
+except MemoryError:
+    print("memory-error")
+
+    del a
+    del b
+
+    gc.collect()
+    churn_dict_items(128)
+
+    print("post-gc-ok")
+else:
+    print("concat-succeeded")


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR fixes exact list `+` / `+=` error handling when the fast path raises
`MemoryError`.

For exact lists, Nuitka previously described the specialized add path as
`noescape`, so generated C code omitted the normal `NULL` / error-exit check.
When `LIST_CONCAT()` failed, the pending `MemoryError` leaked into later cleanup
and could surface as a wrong traceback or a crash during GC-heavy cleanup.

The PR adds focused regression coverage in `tests/basics/GarbageCollectionTest.py`.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes <https://github.com/Nuitka/Nuitka/issues/3678>.

The public issue was reported as a Python 3.12 GC SIGSEGV on `2025-11-27`, and
an additional coverage-driven crash trace was reported on `2026-01-07`.
Local narrowing showed the visible GC crash was a downstream symptom: exact list
concat could raise `MemoryError`, but Nuitka's shape metadata still told code
generation that the path could not raise.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - Local verification covered:
  - `python3.12 Nuitka/tests/basics/run_all.py only GarbageCollectionTest`
  - `python3.12 Nuitka/tests/basics/run_all.py only ReferencingTest`
  - `python3.10 Nuitka/tests/basics/run_all.py only GarbageCollectionTest`
  - case-local repro and coverage closure scripts under `cases/issue-3678-py312-gc-sigsegv/scripts/`
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.


## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Handle MemoryError correctly for exact list concatenation and add regression coverage for GC behavior after list add failures.

Bug Fixes:
- Mark exact list add operations as potentially raising MemoryError instead of fully no-escape to avoid leaking errors into later cleanup.

Tests:
- Add a garbage-collection regression test that forces MemoryError on large list concatenation and verifies stable cleanup and post-GC behavior.