### PR TITLE
Match upcoming GC changes in 3.14.5

### DIFF
--- a/nuitka/build/AdaptPythonHeaderFiles.py
+++ b/nuitka/build/AdaptPythonHeaderFiles.py
@@ -155,13 +155,17 @@ def _applyExpectedAdaptedPythonHeaderReplacements(adapted, filename):
             adapted = _replaceExpectedInAdaptedPythonHeaderFile(
                 content=adapted,
                 filename=filename,
-                old="#  define _PyObject_GC_TRACK(op) \\\n        _PyObject_GC_TRACK(__FILE__, __LINE__, _PyObject_CAST(op))",
+                old="""\
+#  define _PyObject_GC_TRACK(op) \\
+        _PyObject_GC_TRACK(__FILE__, __LINE__, _PyObject_CAST(op))""",
                 new="#  define _PyObject_GC_TRACK(op) \\\n        Nuitka_GC_Track(_PyObject_CAST(op))",
             )
             adapted = _replaceExpectedInAdaptedPythonHeaderFile(
                 content=adapted,
                 filename=filename,
-                old="#  define _PyObject_GC_UNTRACK(op) \\\n        _PyObject_GC_UNTRACK(__FILE__, __LINE__, _PyObject_CAST(op))",
+                old="""\
+#  define _PyObject_GC_UNTRACK(op) \\
+        _PyObject_GC_UNTRACK(__FILE__, __LINE__, _PyObject_CAST(op))""",
                 new="#  define _PyObject_GC_UNTRACK(op) \\\n        Nuitka_GC_UnTrack(_PyObject_CAST(op))",
             )
 

--- a/nuitka/build/AdaptPythonHeaderFiles.py
+++ b/nuitka/build/AdaptPythonHeaderFiles.py
@@ -139,6 +139,32 @@ def _applyExpectedAdaptedPythonHeaderReplacements(adapted, filename):
             replacement="#  define _Py_DEC_REFTOTAL(interp) \\\n    _Py_DecRefTotal(_PyThreadState_GET())",
         )
 
+        if shallMakeModule() and isPythonWithGil():
+            adapted = _replaceExpectedInAdaptedPythonHeaderFile(
+                content=adapted,
+                filename=filename,
+                old="#  define _PyObject_GC_TRACK(op) \\\n        _PyObject_GC_TRACK(_PyObject_CAST(op))",
+                new="#  define _PyObject_GC_TRACK(op) \\\n        Nuitka_GC_Track(_PyObject_CAST(op))",
+            )
+            adapted = _replaceExpectedInAdaptedPythonHeaderFile(
+                content=adapted,
+                filename=filename,
+                old="#  define _PyObject_GC_UNTRACK(op) \\\n        _PyObject_GC_UNTRACK(_PyObject_CAST(op))",
+                new="#  define _PyObject_GC_UNTRACK(op) \\\n        Nuitka_GC_UnTrack(_PyObject_CAST(op))",
+            )
+            adapted = _replaceExpectedInAdaptedPythonHeaderFile(
+                content=adapted,
+                filename=filename,
+                old="#  define _PyObject_GC_TRACK(op) \\\n        _PyObject_GC_TRACK(__FILE__, __LINE__, _PyObject_CAST(op))",
+                new="#  define _PyObject_GC_TRACK(op) \\\n        Nuitka_GC_Track(_PyObject_CAST(op))",
+            )
+            adapted = _replaceExpectedInAdaptedPythonHeaderFile(
+                content=adapted,
+                filename=filename,
+                old="#  define _PyObject_GC_UNTRACK(op) \\\n        _PyObject_GC_UNTRACK(__FILE__, __LINE__, _PyObject_CAST(op))",
+                new="#  define _PyObject_GC_UNTRACK(op) \\\n        Nuitka_GC_UnTrack(_PyObject_CAST(op))",
+            )
+
     if filename == "pycore_stackref.h" and 0x3E0 <= python_version < 0x3F0:
         adapted = _substituteExpectedInAdaptedPythonHeaderFile(
             content=adapted,
@@ -304,7 +330,7 @@ def _getPythonInternalHeadersAndHash(internal_include_dir):
     header_files = []
 
     hash_obj.updateFromValues(
-        "adapted-python-headers-v8",
+        "adapted-python-headers-v9",
         "module" if shallMakeModule() else "non-module",
     )
 

--- a/nuitka/build/include/nuitka/constants_blob.h
+++ b/nuitka/build/include/nuitka/constants_blob.h
@@ -14,7 +14,7 @@
  *
  */
 
-extern void loadConstantsBlob(PyThreadState *tstate, PyObject **, char const *name);
+extern int loadConstantsBlob(PyThreadState *tstate, PyObject **, char const *name);
 
 // We define a macro that declares the external symbols and provides accessor functions.
 // For INCBIN/C23, the generating C file already defines these functions, so we just declare them.

--- a/nuitka/build/include/nuitka/freelists.h
+++ b/nuitka/build/include/nuitka/freelists.h
@@ -67,30 +67,17 @@ static const bool use_freelists = true;
 
 #if PYTHON_VERSION >= 0x3e0
 
-// CPython 3.14.4 added "array_raw" to "_qsbr_shared", shifting the
-// interpreter "object_state.freelists" by one pointer width.
+// CPython 3.14 changed the layout before post-QSBR interpreter fields in
+// 3.14.4 and again in 3.14.5.
 static inline struct _Py_freelists *Nuitka_Py_freelists_GET(PyThreadState *tstate) {
 #ifdef Py_GIL_DISABLED
     return &((_PyThreadStateImpl *)tstate)->freelists;
 #else
-    struct _Py_freelists *freelists = &tstate->interp->object_state.freelists;
-
 #if _NUITKA_MODULE_MODE && PYTHON_VERSION < 0x3f0
-    static int freelists_pointer_delta = 2;
-
-    if (freelists_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        freelists_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
+    return (struct _Py_freelists *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(
+        &tstate->interp->object_state.freelists);
 #else
-        freelists_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return (struct _Py_freelists *)((char *)freelists + freelists_pointer_delta * sizeof(void *));
-#else
-    return freelists;
+    return &tstate->interp->object_state.freelists;
 #endif
 #endif
 }

--- a/nuitka/build/include/nuitka/importing.h
+++ b/nuitka/build/include/nuitka/importing.h
@@ -51,7 +51,7 @@ NUITKA_MAY_BE_UNUSED static PyObject *Nuitka_GetSysModules(void) {
 #elif PYTHON_VERSION < 0x3c0
     return _PyInterpreterState_GET()->modules;
 #else
-    return _PyInterpreterState_GET()->imports.modules;
+    return Nuitka_PyInterpreterState_GetImportsState(_PyInterpreterState_GET())->modules;
 #endif
 }
 

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -257,6 +257,71 @@ NUITKA_MAY_BE_UNUSED static inline managed_static_type_state *Nuitka_PyStaticTyp
 
 #endif
 
+#if PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0
+// CPython 3.14.5 grew "_gc_runtime_state" in GIL builds, shifting all later
+// interpreter fields by three pointer widths.
+static inline int Nuitka_PyInterpreterState_PostGcPointerDelta(void) {
+#if _NUITKA_MODULE_MODE && !defined(Py_GIL_DISABLED)
+    static int post_gc_pointer_delta = 99;
+
+    if (post_gc_pointer_delta == 99) {
+        int runtime_pointer_shift = 0;
+        int compile_time_pointer_shift = 0;
+        int runtime_version = Nuitka_GetRuntimeVersion();
+
+        if (runtime_version >= 0x3e5) {
+            runtime_pointer_shift += 3;
+        }
+
+#if PYTHON_VERSION >= 0x3e5
+        compile_time_pointer_shift += 3;
+#endif
+        post_gc_pointer_delta = runtime_pointer_shift - compile_time_pointer_shift;
+    }
+
+    return post_gc_pointer_delta;
+#else
+    return 0;
+#endif
+}
+
+static inline void *Nuitka_PyInterpreterState_AdjustPostGcPointer(void *field_ptr) {
+    return (char *)field_ptr + Nuitka_PyInterpreterState_PostGcPointerDelta() * sizeof(void *);
+}
+
+// CPython 3.14 changed the interpreter layout twice before fields after
+// "_qsbr_shared": 3.14.4 added "_qsbr_shared.array_raw" (+1 pointer) and
+// 3.14.5 grew "_gc_runtime_state" in GIL builds (+3 pointers).
+static inline int Nuitka_PyInterpreterState_PostQsbrPointerDelta(void) {
+#if _NUITKA_MODULE_MODE && !defined(Py_GIL_DISABLED)
+    static int post_qsbr_pointer_delta = 99;
+
+    if (post_qsbr_pointer_delta == 99) {
+        int post_gc_pointer_delta = Nuitka_PyInterpreterState_PostGcPointerDelta();
+        int runtime_version = Nuitka_GetRuntimeVersion();
+        int qsbr_pointer_delta = 0;
+
+        if (runtime_version >= 0x3e4) {
+            qsbr_pointer_delta += 1;
+        }
+
+#if PYTHON_VERSION >= 0x3e4
+        qsbr_pointer_delta -= 1;
+#endif
+        post_qsbr_pointer_delta = post_gc_pointer_delta + qsbr_pointer_delta;
+    }
+
+    return post_qsbr_pointer_delta;
+#else
+    return 0;
+#endif
+}
+
+static inline void *Nuitka_PyInterpreterState_AdjustPostQsbrPointer(void *field_ptr) {
+    return (char *)field_ptr + Nuitka_PyInterpreterState_PostQsbrPointerDelta() * sizeof(void *);
+}
+#endif
+
 #ifdef _NUITKA_ADAPTED_PYTHON_HEADERS
 /* Cross-compiler offset access and runtime abstraction layer */
 #include "nuitka/python_internals_access.h"
@@ -270,31 +335,13 @@ NUITKA_MAY_BE_UNUSED static inline managed_static_type_state *Nuitka_PyStaticTyp
 #if PYTHON_VERSION >= 0x3c0
 static inline size_t Nuitka_static_builtin_index_get(PyTypeObject *self) { return (size_t)self->tp_subclasses - 1; }
 
+static inline struct _import_state *Nuitka_PyInterpreterState_GetImportsState(PyInterpreterState *interp) {
 #if PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0
-static inline int Nuitka_PyInterpreterState_PostQsbrPointerDelta(void) {
-#if _NUITKA_MODULE_MODE && !defined(Py_GIL_DISABLED)
-    static int post_qsbr_pointer_delta = 2;
-
-    if (post_qsbr_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        post_qsbr_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
+    return (struct _import_state *)Nuitka_PyInterpreterState_AdjustPostGcPointer(&interp->imports);
 #else
-        post_qsbr_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return post_qsbr_pointer_delta;
-#else
-    return 0;
+    return &interp->imports;
 #endif
 }
-
-static inline void *Nuitka_PyInterpreterState_AdjustPostQsbrPointer(void *field_ptr) {
-    return (char *)field_ptr + Nuitka_PyInterpreterState_PostQsbrPointerDelta() * sizeof(void *);
-}
-#endif
 
 static inline struct types_state *Nuitka_PyInterpreterState_GetTypesState(PyInterpreterState *interp) {
 #if PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0
@@ -516,6 +563,20 @@ static inline void Nuitka_Py_ScheduleGC(PyThreadState *tstate) {
         _Py_set_eval_breaker_bit(tstate, _PY_GC_SCHEDULED_BIT);
     }
 }
+
+static inline bool Nuitka_GC_UsesGeneration0List(void) {
+#if _NUITKA_MODULE_MODE && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
+    static int uses_generation0_list = -1;
+
+    if (uses_generation0_list == -1) {
+        uses_generation0_list = Nuitka_GetRuntimeVersion() >= 0x3e5;
+    }
+
+    return uses_generation0_list != 0;
+#else
+    return PYTHON_VERSION >= 0x3e5;
+#endif
+}
 #endif
 
 /* Due to ABI issues, it seems that on Windows the symbols used by
@@ -527,9 +588,142 @@ static inline void Nuitka_Py_ScheduleGC(PyThreadState *tstate) {
  * become runtime incompatible.
  *
  */
-#if (PYTHON_VERSION >= 0x3e0 && !defined(Py_GIL_DISABLED)) && (PYTHON_VERSION < 0x3e5)
+#if _NUITKA_MODULE_MODE && PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
+typedef struct {
+    PyObject *trash_delete_later;
+    int trash_delete_nesting;
+    int enabled;
+    int debug;
+    struct gc_generation young;
+    struct gc_generation old[2];
+    struct gc_generation permanent_generation;
+    struct gc_generation_stats generation_stats[NUM_GENERATIONS];
+    int collecting;
+    PyObject *garbage;
+    PyObject *callbacks;
+    Py_ssize_t heap_size;
+    Py_ssize_t work_to_do;
+    int visited_space;
+    int phase;
+} Nuitka_GCStateIncremental;
 
-#if PYTHON_VERSION >= 0x3e0
+typedef struct {
+    PyObject *trash_delete_later;
+    int trash_delete_nesting;
+    int enabled;
+    int debug;
+    struct gc_generation generations[NUM_GENERATIONS];
+    struct gc_generation permanent_generation;
+    struct gc_generation_stats generation_stats[NUM_GENERATIONS];
+    int collecting;
+    PyObject *garbage;
+    PyObject *callbacks;
+    Py_ssize_t heap_size;
+    Py_ssize_t dummy1;
+    int dummy2;
+    int dummy3;
+    Py_ssize_t long_lived_total;
+    Py_ssize_t long_lived_pending;
+    PyGC_Head *generation0;
+} Nuitka_GCStateGenerational;
+
+static inline Nuitka_GCStateIncremental *Nuitka_GC_GetIncrementalState(struct _gc_runtime_state *gcstate) {
+    return (Nuitka_GCStateIncremental *)gcstate;
+}
+
+static inline Nuitka_GCStateGenerational *Nuitka_GC_GetGenerationalState(struct _gc_runtime_state *gcstate) {
+    return (Nuitka_GCStateGenerational *)gcstate;
+}
+
+static inline bool Nuitka_GC_TrackOwnsAccounting(void) {
+    static int owns_accounting = -1;
+
+    if (owns_accounting == -1) {
+        int runtime_version = Nuitka_GetRuntimeVersion();
+        owns_accounting = runtime_version >= 0x3e1 && runtime_version < 0x3e5;
+    }
+
+    return owns_accounting != 0;
+}
+
+#undef Nuitka_GC_Track
+static inline void Nuitka_GC_Track(void *raw_op) {
+    PyObject *op = (PyObject *)raw_op;
+    PyGC_Head *gc = _Py_AS_GC(op);
+    struct _gc_runtime_state *gcstate = &_PyInterpreterState_GET()->gc;
+
+    if (Nuitka_GC_UsesGeneration0List()) {
+        Nuitka_GCStateGenerational *gcstate_generational = Nuitka_GC_GetGenerationalState(gcstate);
+        PyGC_Head *generation0 = gcstate_generational->generation0;
+        PyGC_Head *last = (PyGC_Head *)(generation0->_gc_prev);
+
+        _PyGCHead_SET_NEXT(last, gc);
+        _PyGCHead_SET_PREV(gc, last);
+        _PyGCHead_SET_NEXT(gc, generation0);
+        generation0->_gc_prev = (uintptr_t)gc;
+
+        gcstate_generational->heap_size++;
+    } else {
+        Nuitka_GCStateIncremental *gcstate_incremental = Nuitka_GC_GetIncrementalState(gcstate);
+        PyGC_Head *generation0 = &gcstate_incremental->young.head;
+        PyGC_Head *last = (PyGC_Head *)(generation0->_gc_prev);
+
+        _PyGCHead_SET_NEXT(last, gc);
+        _PyGCHead_SET_PREV(gc, last);
+
+        {
+            uintptr_t not_visited = 1 ^ gcstate_incremental->visited_space;
+            gc->_gc_next = ((uintptr_t)generation0) | not_visited;
+        }
+
+        generation0->_gc_prev = (uintptr_t)gc;
+
+        if (Nuitka_GC_TrackOwnsAccounting()) {
+            gcstate_incremental->young.count++;
+            gcstate_incremental->heap_size++;
+
+            if (gcstate_incremental->young.count > gcstate_incremental->young.threshold) {
+                if (gcstate_incremental->enabled && gcstate_incremental->young.threshold &&
+                    !_Py_atomic_load_int_relaxed(&gcstate_incremental->collecting) &&
+                    !_PyErr_Occurred(_PyThreadState_GET())) {
+                    Nuitka_Py_ScheduleGC(_PyThreadState_GET());
+                }
+            }
+        }
+    }
+}
+
+// TODO: Does this code have to be in the header really? spell-checker: ignore gcstate
+#undef Nuitka_GC_UnTrack
+static inline void Nuitka_GC_UnTrack(void *raw_op) {
+    PyObject *op = (PyObject *)raw_op;
+    PyGC_Head *gc = _Py_AS_GC(op);
+    PyGC_Head *prev = _PyGCHead_PREV(gc);
+    PyGC_Head *next = _PyGCHead_NEXT(gc);
+
+    _PyGCHead_SET_NEXT(prev, next);
+    _PyGCHead_SET_PREV(next, prev);
+    gc->_gc_next = 0;
+    gc->_gc_prev &= _PyGC_PREV_MASK_FINALIZED;
+
+    if (Nuitka_GC_UsesGeneration0List()) {
+        struct _gc_runtime_state *gcstate = &_PyInterpreterState_GET()->gc;
+        gcstate->heap_size--;
+    } else if (Nuitka_GC_TrackOwnsAccounting()) {
+        Nuitka_GCStateIncremental *gcstate_incremental = Nuitka_GC_GetIncrementalState(&_PyInterpreterState_GET()->gc);
+
+        if (gcstate_incremental->young.count > 0) {
+            gcstate_incremental->young.count--;
+        }
+
+        gcstate_incremental->heap_size--;
+    }
+}
+
+#undef _PyObject_GC_TRACK
+#undef _PyObject_GC_UNTRACK
+#elif (PYTHON_VERSION >= 0x3e0 && !defined(Py_GIL_DISABLED)) && (PYTHON_VERSION < 0x3e5)
+
 static inline bool Nuitka_GC_TrackOwnsAccounting(void) {
 #if _NUITKA_MODULE_MODE
     static int owns_accounting = -1;
@@ -543,15 +737,10 @@ static inline bool Nuitka_GC_TrackOwnsAccounting(void) {
     return PYTHON_VERSION >= 0x3e1;
 #endif
 }
-#endif
 
 #undef Nuitka_GC_Track
 static inline void Nuitka_GC_Track(void *raw_op) {
     PyObject *op = (PyObject *)raw_op;
-#ifdef Py_GIL_DISABLED
-    assert(!_PyObject_GC_IS_TRACKED(op));
-    _PyObject_SET_GC_BITS(op, _PyGC_BITS_TRACKED);
-#else
     PyGC_Head *gc = _Py_AS_GC(op);
 
     struct _gc_runtime_state *gcstate = &_PyInterpreterState_GET()->gc;
@@ -559,11 +748,12 @@ static inline void Nuitka_GC_Track(void *raw_op) {
     PyGC_Head *last = (PyGC_Head *)(generation0->_gc_prev);
     _PyGCHead_SET_NEXT(last, gc);
     _PyGCHead_SET_PREV(gc, last);
-    uintptr_t not_visited = 1 ^ gcstate->visited_space;
-    gc->_gc_next = ((uintptr_t)generation0) | not_visited;
+    {
+        uintptr_t not_visited = 1 ^ gcstate->visited_space;
+        gc->_gc_next = ((uintptr_t)generation0) | not_visited;
+    }
     generation0->_gc_prev = (uintptr_t)gc;
 
-#if PYTHON_VERSION >= 0x3e0
     if (Nuitka_GC_TrackOwnsAccounting()) {
         gcstate->young.count++;
         gcstate->heap_size++;
@@ -575,18 +765,12 @@ static inline void Nuitka_GC_Track(void *raw_op) {
             }
         }
     }
-#endif
-#endif
 }
 
 // TODO: Does this code have to be in the header really? spell-checker: ignore gcstate
 #undef Nuitka_GC_UnTrack
 static inline void Nuitka_GC_UnTrack(void *raw_op) {
     PyObject *op = (PyObject *)raw_op;
-#ifdef Py_GIL_DISABLED
-    assert(_PyObject_GC_IS_TRACKED(op));
-    _PyObject_CLEAR_GC_BITS(op, _PyGC_BITS_TRACKED);
-#else
     PyGC_Head *gc = _Py_AS_GC(op);
     PyGC_Head *prev = _PyGCHead_PREV(gc);
     PyGC_Head *next = _PyGCHead_NEXT(gc);
@@ -594,7 +778,6 @@ static inline void Nuitka_GC_UnTrack(void *raw_op) {
     _PyGCHead_SET_PREV(next, prev);
     gc->_gc_next = 0;
     gc->_gc_prev &= _PyGC_PREV_MASK_FINALIZED;
-#endif
 }
 
 #undef _PyObject_GC_TRACK

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -124,6 +124,14 @@ NUITKA_MAY_BE_UNUSED static inline int Nuitka_GetRuntimeVersion(void) {
 #define Nuitka_GetRuntimeVersion() PYTHON_VERSION
 #endif
 
+#if _NUITKA_MODULE_MODE && PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
+// 'pycore_tuple.h' expands '_PyObject_GC_TRACK()' in inline helpers, so the
+// Nuitka runtime-aware replacements must be declared before that header is
+// included.
+NUITKA_MAY_BE_UNUSED static inline void Nuitka_GC_Track(void *raw_op);
+NUITKA_MAY_BE_UNUSED static inline void Nuitka_GC_UnTrack(void *raw_op);
+#endif
+
 #if defined(_WIN32)
 // Windows is too difficult for API redefines.
 #define MIN_PYCORE_PYTHON_VERSION 0x380
@@ -348,6 +356,14 @@ static inline struct types_state *Nuitka_PyInterpreterState_GetTypesState(PyInte
     return (struct types_state *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->types);
 #else
     return &interp->types;
+#endif
+}
+
+static inline struct _Py_dict_state *Nuitka_PyInterpreterState_GetDictState(PyInterpreterState *interp) {
+#if PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0
+    return (struct _Py_dict_state *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->dict_state);
+#else
+    return &interp->dict_state;
 #endif
 }
 
@@ -634,6 +650,28 @@ static inline Nuitka_GCStateIncremental *Nuitka_GC_GetIncrementalState(struct _g
 static inline Nuitka_GCStateGenerational *Nuitka_GC_GetGenerationalState(struct _gc_runtime_state *gcstate) {
     return (Nuitka_GCStateGenerational *)gcstate;
 }
+
+static inline PyGC_Head *Nuitka_GCHead_NEXT(PyGC_Head *gc) {
+    if (Nuitka_GC_UsesGeneration0List()) {
+        return (PyGC_Head *)gc->_gc_next;
+    } else {
+        uintptr_t next = gc->_gc_next & _PyGC_PREV_MASK;
+        return (PyGC_Head *)next;
+    }
+}
+
+static inline void Nuitka_GCHead_SET_NEXT(PyGC_Head *gc, PyGC_Head *next) {
+    if (Nuitka_GC_UsesGeneration0List()) {
+        gc->_gc_next = (uintptr_t)next;
+    } else {
+        uintptr_t unext = (uintptr_t)next;
+        assert((unext & ~_PyGC_PREV_MASK) == 0);
+        gc->_gc_next = (gc->_gc_next & ~_PyGC_PREV_MASK) | unext;
+    }
+}
+
+#define _PyGCHead_NEXT Nuitka_GCHead_NEXT
+#define _PyGCHead_SET_NEXT Nuitka_GCHead_SET_NEXT
 
 static inline bool Nuitka_GC_TrackOwnsAccounting(void) {
     static int owns_accounting = -1;

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -509,6 +509,15 @@ typedef long Py_hash_t;
 #define NUITKA_CROSS_MODULE
 #define NUITKA_LOCAL_MODULE static
 
+#if PYTHON_VERSION >= 0x3e0
+// TODO: Does this code have to be in the header really? spell-checker: ignore gcstate
+static inline void Nuitka_Py_ScheduleGC(PyThreadState *tstate) {
+    if (!_Py_eval_breaker_bit_is_set(tstate, _PY_GC_SCHEDULED_BIT)) {
+        _Py_set_eval_breaker_bit(tstate, _PY_GC_SCHEDULED_BIT);
+    }
+}
+#endif
+
 /* Due to ABI issues, it seems that on Windows the symbols used by
  * "_PyObject_GC_TRACK" were not exported before 3.8 and we need to use a
  * function that does it instead.
@@ -518,13 +527,7 @@ typedef long Py_hash_t;
  * become runtime incompatible.
  *
  */
-#if PYTHON_VERSION >= 0x3e0 && !defined(Py_GIL_DISABLED)
-// TODO: Does this code have to be in the header really? spell-checker: ignore gcstate
-static inline void Nuitka_Py_ScheduleGC(PyThreadState *tstate) {
-    if (!_Py_eval_breaker_bit_is_set(tstate, _PY_GC_SCHEDULED_BIT)) {
-        _Py_set_eval_breaker_bit(tstate, _PY_GC_SCHEDULED_BIT);
-    }
-}
+#if (PYTHON_VERSION >= 0x3e0 && !defined(Py_GIL_DISABLED)) && (PYTHON_VERSION < 0x3e5)
 
 #if PYTHON_VERSION >= 0x3e0
 static inline bool Nuitka_GC_TrackOwnsAccounting(void) {

--- a/nuitka/build/include/nuitka/python_internals_access.h
+++ b/nuitka/build/include/nuitka/python_internals_access.h
@@ -10,37 +10,11 @@
 
 #if _NUITKA_MODULE_MODE && PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
 static inline struct _Py_interp_cached_objects *Nuitka_PyInterpreterState_GetCachedObjects(PyInterpreterState *interp) {
-    static int cached_objects_pointer_delta = 2;
-
-    if (cached_objects_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        cached_objects_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
-#else
-        cached_objects_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return (struct _Py_interp_cached_objects *)((char *)&interp->cached_objects +
-                                                cached_objects_pointer_delta * sizeof(void *));
+    return (struct _Py_interp_cached_objects *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->cached_objects);
 }
 
 static inline struct _Py_interp_static_objects *Nuitka_PyInterpreterState_GetStaticObjects(PyInterpreterState *interp) {
-    static int static_objects_pointer_delta = 2;
-
-    if (static_objects_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        static_objects_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
-#else
-        static_objects_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return (struct _Py_interp_static_objects *)((char *)&interp->static_objects +
-                                                static_objects_pointer_delta * sizeof(void *));
+    return (struct _Py_interp_static_objects *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->static_objects);
 }
 #endif
 

--- a/nuitka/build/static_src/HelpersAllocator.c
+++ b/nuitka/build/static_src/HelpersAllocator.c
@@ -679,7 +679,7 @@ void Nuitka_PyObject_GC_Link(PyObject *op) {
         Nuitka_gc_collect_generations(tstate);
         gcstate->collecting = 0;
     }
-#elif (PYTHON_VERSION < 0x3e0) || (PYTHON_VERSION >= 0x3e5)
+#elif PYTHON_VERSION < 0x3e0
     // TODO: This is not the no-GIL implementation
     PyGC_Head *gc = _Py_AS_GC(op);
 
@@ -700,15 +700,86 @@ void Nuitka_PyObject_GC_Link(PyObject *op) {
         !_PyErr_Occurred(tstate)) {
         Nuitka_Py_ScheduleGC(tstate);
     }
-#else
-    // TODO: This is considering the no-GIL implementation
+#elif _NUITKA_MODULE_MODE && PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
+    // TODO: This is not the no-GIL implementation
     PyGC_Head *gc = _Py_AS_GC(op);
 
     // gc must be correctly aligned
     _PyObject_ASSERT(op, ((uintptr_t)gc & (sizeof(uintptr_t) - 1)) == 0);
 
+    // TODO: Have this passed.
+    PyThreadState *tstate = _PyThreadState_GET();
+    GCState *gcstate = &tstate->interp->gc;
+
     gc->_gc_next = 0;
     gc->_gc_prev = 0;
+
+    if (Nuitka_GC_UsesGeneration0List()) {
+        Nuitka_GCStateGenerational *gcstate_generational = Nuitka_GC_GetGenerationalState(gcstate);
+
+        gcstate_generational->generations[0].count++;
+
+        if (gcstate_generational->generations[0].count > gcstate_generational->generations[0].threshold &&
+            gcstate_generational->enabled && gcstate_generational->generations[0].threshold &&
+            !_Py_atomic_load_int_relaxed(&gcstate_generational->collecting) && !_PyErr_Occurred(tstate)) {
+            Nuitka_Py_ScheduleGC(tstate);
+        }
+    } else if (!Nuitka_GC_TrackOwnsAccounting()) {
+        Nuitka_GCStateIncremental *gcstate_incremental = Nuitka_GC_GetIncrementalState(gcstate);
+
+        gcstate_incremental->young.count++;
+        gcstate_incremental->heap_size++;
+
+        if (gcstate_incremental->young.count > gcstate_incremental->young.threshold && gcstate_incremental->enabled &&
+            gcstate_incremental->young.threshold && !_Py_atomic_load_int_relaxed(&gcstate_incremental->collecting) &&
+            !_PyErr_Occurred(tstate)) {
+            Nuitka_Py_ScheduleGC(tstate);
+        }
+    }
+#elif PYTHON_VERSION < 0x3e5
+    // TODO: This is not the no-GIL implementation
+    PyGC_Head *gc = _Py_AS_GC(op);
+
+    // gc must be correctly aligned
+    _PyObject_ASSERT(op, ((uintptr_t)gc & (sizeof(uintptr_t) - 1)) == 0);
+
+    // TODO: Have this passed.
+    PyThreadState *tstate = _PyThreadState_GET();
+    GCState *gcstate = &tstate->interp->gc;
+
+    gc->_gc_next = 0;
+    gc->_gc_prev = 0;
+
+    if (!Nuitka_GC_TrackOwnsAccounting()) {
+        gcstate->young.count++;
+        gcstate->heap_size++;
+
+        if (gcstate->young.count > gcstate->young.threshold && gcstate->enabled && gcstate->young.threshold &&
+            !_Py_atomic_load_int_relaxed(&gcstate->collecting) && !_PyErr_Occurred(tstate)) {
+            Nuitka_Py_ScheduleGC(tstate);
+        }
+    }
+#else
+    // TODO: This is not the no-GIL implementation
+    PyGC_Head *gc = _Py_AS_GC(op);
+
+    // gc must be correctly aligned
+    _PyObject_ASSERT(op, ((uintptr_t)gc & (sizeof(uintptr_t) - 1)) == 0);
+
+    // TODO: Have this passed.
+    PyThreadState *tstate = _PyThreadState_GET();
+    GCState *gcstate = &tstate->interp->gc;
+
+    gc->_gc_next = 0;
+    gc->_gc_prev = 0;
+
+    gcstate->generations[0].count++;
+
+    if (gcstate->generations[0].count > gcstate->generations[0].threshold && gcstate->enabled &&
+        gcstate->generations[0].threshold && !_Py_atomic_load_int_relaxed(&gcstate->collecting) &&
+        !_PyErr_Occurred(tstate)) {
+        Nuitka_Py_ScheduleGC(tstate);
+    }
 #endif
 }
 

--- a/nuitka/build/static_src/HelpersAllocator.c
+++ b/nuitka/build/static_src/HelpersAllocator.c
@@ -679,7 +679,7 @@ void Nuitka_PyObject_GC_Link(PyObject *op) {
         Nuitka_gc_collect_generations(tstate);
         gcstate->collecting = 0;
     }
-#elif PYTHON_VERSION < 0x3e0
+#elif (PYTHON_VERSION < 0x3e0) || (PYTHON_VERSION >= 0x3e5)
     // TODO: This is not the no-GIL implementation
     PyGC_Head *gc = _Py_AS_GC(op);
 

--- a/nuitka/build/static_src/HelpersConstantsBlob.c
+++ b/nuitka/build/static_src/HelpersConstantsBlob.c
@@ -1328,16 +1328,18 @@ static unsigned char const *_unpackBlobConstants(PyThreadState *tstate, PyObject
     return data;
 }
 
-static void unpackBlobConstants(PyThreadState *tstate, PyObject **output, unsigned char const *data) {
+static int unpackBlobConstants(PyThreadState *tstate, PyObject **output, unsigned char const *data) {
     int count = (int)unpackValueUint16(&data);
 
 #ifdef _NUITKA_EXPERIMENTAL_DEBUG_CONSTANTS
     printf("unpackBlobConstants count %d\n", count);
 #endif
     _unpackBlobConstants(tstate, output, data, count);
+
+    return count;
 }
 
-void loadConstantsBlob(PyThreadState *tstate, PyObject **output, char const *name) {
+int loadConstantsBlob(PyThreadState *tstate, PyObject **output, char const *name) {
     static bool init_done = false;
 
     if (init_done == false) {
@@ -1392,7 +1394,7 @@ void loadConstantsBlob(PyThreadState *tstate, PyObject **output, char const *nam
         w += size;
     }
 
-    unpackBlobConstants(tstate, output, w);
+    return unpackBlobConstants(tstate, output, w);
 }
 
 //     Part of "Nuitka", an optimizing Python compiler that is compatible and

--- a/nuitka/code_generation/templates/CodeTemplatesModules.py
+++ b/nuitka/code_generation/templates/CodeTemplatesModules.py
@@ -109,7 +109,7 @@ NUITKA_MAY_BE_UNUSED static uint32_t _Nuitka_PyDictKeys_GetVersionForCurrentStat
     if (dk->dk_version != 0) {
         return dk->dk_version;
     }
-    uint32_t result = interp->dict_state.next_keys_version++;
+    uint32_t result = Nuitka_PyInterpreterState_GetDictState(interp)->next_keys_version++;
     dk->dk_version = result;
     return result;
 }

--- a/nuitka/code_generation/templates/CodeTemplatesModules.py
+++ b/nuitka/code_generation/templates/CodeTemplatesModules.py
@@ -65,10 +65,20 @@ static bool constants_created = false;
 /* Function to create module private constants. */
 static void createModuleConstants(PyThreadState *tstate) {
     if (constants_created == false) {
-        loadConstantsBlob(tstate, (PyObject **)&mod_consts, UN_TRANSLATE(%(module_const_blob_name)s));
+        NUITKA_MAY_BE_UNUSED int constants_loaded_count =
+            loadConstantsBlob(tstate, (PyObject **)&mod_consts, UN_TRANSLATE(%(module_const_blob_name)s));
         constants_created = true;
 
 #ifndef __NUITKA_NO_ASSERT__
+        if (constants_loaded_count != %(constants_count)d) {
+            fprintf(stderr,
+                    "Corrupt constants blob for %%s: expected %(constants_count)d values, got %%d\n",
+                    UN_TRANSLATE(%(module_const_blob_name)s),
+                    constants_loaded_count);
+            fflush(stderr);
+            abort();
+        }
+
 %(module_constants_check_hash)s
 #endif
     }

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2023,6 +2023,11 @@
     - patterns:
         - '_cython/_credentials/roots.pem'
 
+- module-name: 'grpc_requests' # checksum: c60b4c80
+  data-files:
+    - include-metadata:
+        - 'protobuf'
+
 - module-name: 'gruut' # checksum: fddc60ae
   data-files:
     - patterns:

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -5082,7 +5082,7 @@
     - dirs:
         - 'proj_dir'
 
-- module-name: 'pypylon' # checksum: b6d023e2
+- module-name: 'pypylon' # checksum: 3494369e
   data-files:
     - patterns:
         - '**/*.sig'
@@ -5103,6 +5103,9 @@
           - 'Pylon'
           - 'gxapi'
           - 'uxapi'
+          - 'libpylon'
+          - 'libgxapi'
+          - 'libuxapi'
       when: 'not macos'
     - from_filenames:
         relative_path: 'pylonDataProcessingPlugins'

--- a/nuitka/tools/general/generate_header/templates_c/python_internals_access.h.j2
+++ b/nuitka/tools/general/generate_header/templates_c/python_internals_access.h.j2
@@ -10,35 +10,11 @@
 
 #if _NUITKA_MODULE_MODE && PYTHON_VERSION >= 0x3e0 && PYTHON_VERSION < 0x3f0 && !defined(Py_GIL_DISABLED)
 static inline struct _Py_interp_cached_objects *Nuitka_PyInterpreterState_GetCachedObjects(PyInterpreterState *interp) {
-    static int cached_objects_pointer_delta = 2;
-
-    if (cached_objects_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        cached_objects_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
-#else
-        cached_objects_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return (struct _Py_interp_cached_objects *)((char *)&interp->cached_objects + cached_objects_pointer_delta * sizeof(void *));
+    return (struct _Py_interp_cached_objects *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->cached_objects);
 }
 
 static inline struct _Py_interp_static_objects *Nuitka_PyInterpreterState_GetStaticObjects(PyInterpreterState *interp) {
-    static int static_objects_pointer_delta = 2;
-
-    if (static_objects_pointer_delta == 2) {
-        int runtime_has_qsbr_array_raw = Nuitka_GetRuntimeVersion() >= 0x3e4;
-
-#if PYTHON_VERSION >= 0x3e4
-        static_objects_pointer_delta = runtime_has_qsbr_array_raw ? 0 : -1;
-#else
-        static_objects_pointer_delta = runtime_has_qsbr_array_raw ? 1 : 0;
-#endif
-    }
-
-    return (struct _Py_interp_static_objects *)((char *)&interp->static_objects + static_objects_pointer_delta * sizeof(void *));
+    return (struct _Py_interp_static_objects *)Nuitka_PyInterpreterState_AdjustPostQsbrPointer(&interp->static_objects);
 }
 #endif
 


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

In preparation for the 3.14.5 release, switch back to the code for the old generational GC.

I'm not yet clear on whether the incremental GC will be in 3.15. For now, I've left it so that Nuitka will also use the generational GC for 3.15. If that changes, it's pretty easy to update here.

## 🧐 Why was it initiated? Any relevant Issues?

CPython is [reverting the incremental GC for 3.14](https://discuss.python.org/t/reverting-the-incremental-gc-in-python-3-14-and-3-15/107014).

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Align GC integration with CPython’s reversion to generational GC for Python 3.14.5 and 3.15.

Bug Fixes:
- Ensure GC scheduling and triggering logic matches CPython behavior for Python 3.14.5 and newer.

Enhancements:
- Refine version guards around GC scheduling and triggering to support both pre-3.14 and post-3.14.5 runtimes.