### PR TITLE
Implement `__annotate__` for classes

### DIFF
--- a/nuitka/nodes/ClassNodes.py
+++ b/nuitka/nodes/ClassNodes.py
@@ -7,6 +7,7 @@ The classes are are at the core of the language and have their complexities.
 
 """
 
+from nuitka.containers.OrderedDicts import OrderedDict
 from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.PythonVersions import python_version
 
@@ -147,7 +148,7 @@ class ExpressionClassMappingBody(MarkNeedsAnnotationsMixin, ExpressionClassBodyB
 
         self.qualname_setup = None
         self.static_attributes = OrderedSet() if python_version >= 0x3D0 else None
-        self.deferred_annotations = {} if python_version >= 0x3E0 else None
+        self.deferred_annotations = OrderedDict() if python_version >= 0x3E0 else None
 
     def addStaticAttribute(self, static_attribute):
         self.static_attributes.add(static_attribute)

--- a/nuitka/nodes/ClassNodes.py
+++ b/nuitka/nodes/ClassNodes.py
@@ -124,7 +124,12 @@ class ExpressionClassMappingBody(MarkNeedsAnnotationsMixin, ExpressionClassBodyB
 
     kind = "EXPRESSION_CLASS_MAPPING_BODY"
 
-    __slots__ = ("needs_annotations_dict", "qualname_setup", "static_attributes")
+    __slots__ = (
+        "needs_annotations_dict",
+        "qualname_setup",
+        "static_attributes",
+        "deferred_annotations",
+    )
 
     # Force creation with proper type.
     locals_kind = "python_mapping_class"
@@ -142,6 +147,7 @@ class ExpressionClassMappingBody(MarkNeedsAnnotationsMixin, ExpressionClassBodyB
 
         self.qualname_setup = None
         self.static_attributes = OrderedSet() if python_version >= 0x3D0 else None
+        self.deferred_annotations = {} if python_version >= 0x3E0 else None
 
     def addStaticAttribute(self, static_attribute):
         self.static_attributes.add(static_attribute)

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -73,6 +73,7 @@ from nuitka.nodes.VariableNameNodes import (
     StatementDelVariableName,
 )
 from nuitka.nodes.VariableRefNodes import ExpressionTempVariableRef
+from nuitka.options.Options import isExperimental
 from nuitka.PythonVersions import python_version
 from nuitka.specs.ParameterSpecs import ParameterSpec
 
@@ -628,20 +629,23 @@ def buildAnnAssignNode(provider, node, source_ref):
             else:
                 ref_class = ExpressionVariableNameRef
 
-            statements.append(
-                StatementAssignmentSubscript(
-                    subscribed=ref_class(
-                        provider=provider,
-                        variable_name="__annotations__",
+            if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
+                provider.deferred_annotations[variable_name] = annotation
+            else:
+                statements.append(
+                    StatementAssignmentSubscript(
+                        subscribed=ref_class(
+                            provider=provider,
+                            variable_name="__annotations__",
+                            source_ref=source_ref,
+                        ),
+                        subscript=makeConstantRefNode(
+                            constant=variable_name, source_ref=source_ref
+                        ),
+                        source=annotation,
                         source_ref=source_ref,
-                    ),
-                    subscript=makeConstantRefNode(
-                        constant=variable_name, source_ref=source_ref
-                    ),
-                    source=annotation,
-                    source_ref=source_ref,
+                    )
                 )
-            )
         else:
             # Functions or disabled.
             if node.simple:

--- a/nuitka/tree/ReformulationAssignmentStatements.py
+++ b/nuitka/tree/ReformulationAssignmentStatements.py
@@ -618,20 +618,24 @@ def buildAnnAssignNode(provider, node, source_ref):
         if use_annotations and (
             provider.isExpressionClassBodyBase() or provider.isCompiledPythonModule()
         ):
-            annotation = buildAnnotationNode(provider, node.annotation, source_ref)
-
-            # TODO: As CPython core considers this implementation detail, and it seems
-            # mostly useless to support having this as a closure taken name after a
-            # __del__ on annotations, we might do this except in full compat mode. It
-            # will produce only noise for all annotations in classes otherwise.
-            if python_version < 0x370:
-                ref_class = ExpressionVariableLocalNameRef
+            if (
+                python_version >= 0x3E0
+                and isExperimental("deferred-annotations")
+                and provider.isExpressionClassBodyBase()
+            ):
+                provider.deferred_annotations[variable_name] = node.annotation
             else:
-                ref_class = ExpressionVariableNameRef
+                annotation = buildAnnotationNode(provider, node.annotation, source_ref)
 
-            if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
-                provider.deferred_annotations[variable_name] = annotation
-            else:
+                # TODO: As CPython core considers this implementation detail, and it seems
+                # mostly useless to support having this as a closure taken name after a
+                # __del__ on annotations, we might do this except in full compat mode. It
+                # will produce only noise for all annotations in classes otherwise.
+                if python_version < 0x370:
+                    ref_class = ExpressionVariableLocalNameRef
+                else:
+                    ref_class = ExpressionVariableNameRef
+
                 statements.append(
                     StatementAssignmentSubscript(
                         subscribed=ref_class(

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -357,6 +357,8 @@ def buildClassNode3(provider, node, source_ref):
                     source_ref=source_ref,
                 )
             )
+
+            class_dict_creation_function.deferred_annotations = None
     elif (
         python_version >= 0x360
         and class_dict_creation_function.needsAnnotationsDictionary()

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -32,6 +32,8 @@ from nuitka.nodes.ConditionalNodes import (
 )
 from nuitka.nodes.ConstantRefNodes import (
     ExpressionConstantIntRef,
+    ExpressionConstantNoneRef,
+    ExpressionConstantStrRef,
     ExpressionConstantTupleRef,
     makeConstantRefNode,
 )
@@ -102,6 +104,7 @@ from .InternalModule import (
     once_decorator,
 )
 from .ReformulationDictionaryCreation import buildDictionaryUnpacking
+from .ReformulationFunctionStatements import makeDeferredAnnotateFunctionObject
 from .ReformulationSequenceCreation import buildTupleUnpacking
 from .ReformulationTryExceptStatements import makeTryExceptSingleHandlerNode
 from .ReformulationTryFinallyStatements import (
@@ -315,7 +318,29 @@ def buildClassNode3(provider, node, source_ref):
             )
         )
 
-    if (
+    if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
+        keys = []
+        values = []
+        for key, value in class_dict_creation_function.deferred_annotations.items():
+            keys.append(key)
+            values.append(value)
+        statements.append(
+            StatementLocalsDictOperationSet(
+                locals_scope=locals_scope,
+                variable_name="__annotate__",
+                source=makeDeferredAnnotateFunctionObject(
+                    provider=class_dict_creation_function,
+                    annotations=makeDictCreationOrConstant2(
+                        keys=keys,
+                        values=values,
+                        source_ref=source_ref,
+                    ),
+                    source_ref=source_ref,
+                ),
+                source_ref=source_ref,
+            )
+        )
+    elif (
         python_version >= 0x360
         and class_dict_creation_function.needsAnnotationsDictionary()
     ):

--- a/nuitka/tree/ReformulationClasses3.py
+++ b/nuitka/tree/ReformulationClasses3.py
@@ -32,8 +32,6 @@ from nuitka.nodes.ConditionalNodes import (
 )
 from nuitka.nodes.ConstantRefNodes import (
     ExpressionConstantIntRef,
-    ExpressionConstantNoneRef,
-    ExpressionConstantStrRef,
     ExpressionConstantTupleRef,
     makeConstantRefNode,
 )
@@ -104,7 +102,7 @@ from .InternalModule import (
     once_decorator,
 )
 from .ReformulationDictionaryCreation import buildDictionaryUnpacking
-from .ReformulationFunctionStatements import makeDeferredAnnotateFunctionObject
+from .ReformulationFunctionStatements import makeDeferredAnnotateFunctionBody
 from .ReformulationSequenceCreation import buildTupleUnpacking
 from .ReformulationTryExceptStatements import makeTryExceptSingleHandlerNode
 from .ReformulationTryFinallyStatements import (
@@ -112,6 +110,7 @@ from .ReformulationTryFinallyStatements import (
     makeTryFinallyStatement,
 )
 from .TreeHelpers import (
+    buildAnnotationNode,
     buildFrameNode,
     buildNode,
     buildNodeTuple,
@@ -319,27 +318,45 @@ def buildClassNode3(provider, node, source_ref):
         )
 
     if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
-        keys = []
-        values = []
-        for key, value in class_dict_creation_function.deferred_annotations.items():
-            keys.append(key)
-            values.append(value)
-        statements.append(
-            StatementLocalsDictOperationSet(
-                locals_scope=locals_scope,
-                variable_name="__annotate__",
-                source=makeDeferredAnnotateFunctionObject(
-                    provider=class_dict_creation_function,
-                    annotations=makeDictCreationOrConstant2(
-                        keys=keys,
-                        values=values,
+        if class_dict_creation_function.deferred_annotations:
+            outer_body, return_statement = makeDeferredAnnotateFunctionBody(
+                provider=class_dict_creation_function,
+                source_ref=source_ref,
+            )
+
+            keys = []
+            values = []
+            for (
+                var_name,
+                ast_node,
+            ) in class_dict_creation_function.deferred_annotations.items():
+                keys.append(var_name)
+                values.append(buildAnnotationNode(outer_body, ast_node, source_ref))
+
+            return_statement.subnode_expression = makeDictCreationOrConstant2(
+                keys=keys,
+                values=values,
+                source_ref=source_ref,
+            )
+            return_statement.subnode_expression.parent = return_statement
+
+            statements.append(
+                StatementLocalsDictOperationSet(
+                    locals_scope=locals_scope,
+                    variable_name="__annotate_func__",
+                    source=makeExpressionFunctionCreation(
+                        function_ref=ExpressionFunctionRef(
+                            function_body=outer_body,
+                            source_ref=source_ref,
+                        ),
+                        defaults=(),
+                        kw_defaults=None,
+                        annotations=None,
                         source_ref=source_ref,
                     ),
                     source_ref=source_ref,
-                ),
-                source_ref=source_ref,
+                )
             )
-        )
     elif (
         python_version >= 0x360
         and class_dict_creation_function.needsAnnotationsDictionary()

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -645,7 +645,7 @@ def buildParameterKwDefaults(provider, node, function_body, source_ref):
     return kw_defaults
 
 
-def makeDeferredAnnotateFunctionBody(provider, annotations, source_ref):
+def makeDeferredAnnotateFunctionBody(provider, source_ref):
     function_name = "__annotate__"
     parameters = ParameterSpec(
         ps_name=function_name,
@@ -685,6 +685,13 @@ def makeDeferredAnnotateFunctionBody(provider, annotations, source_ref):
         source_ref=source_ref,
     )
 
+    return_statement = StatementReturn(
+        expression=makeConstantRefNode(
+            constant=None, source_ref=source_ref, user_provided=False
+        ),
+        source_ref=source_ref,
+    )
+
     body = makeStatementConditional(
         condition=ExpressionComparisonGt(
             ExpressionVariableLocalNameRef(outer_body, "format", source_ref=source_ref),
@@ -700,36 +707,16 @@ def makeDeferredAnnotateFunctionBody(provider, annotations, source_ref):
             exception_trace=None,
             source_ref=source_ref,
         ),
-        no_branch=StatementReturn(
-            expression=annotations,
-            source_ref=source_ref,
-        ),
+        no_branch=return_statement,
         source_ref=source_ref,
     )
 
     outer_body.setChildBody(body)
-    return outer_body
-
-
-def makeDeferredAnnotateFunctionObject(provider, annotations, source_ref):
-    return makeExpressionFunctionCreation(
-        function_ref=ExpressionFunctionRef(
-            function_body=makeDeferredAnnotateFunctionBody(
-                provider=provider,
-                annotations=annotations,
-                source_ref=source_ref,
-            ),
-            source_ref=source_ref,
-        ),
-        defaults=(),
-        kw_defaults=None,
-        annotations=None,
-        source_ref=source_ref,
-    )
+    return outer_body, return_statement
 
 
 def buildParameterAnnotations(provider, node, source_ref):
-    # Too many branches, because there is too many cases, pylint: disable=too-many-branches
+    # Too many branches, because there is too many cases, pylint: disable=too-many-branches,too-many-locals,too-many-statements
 
     # The ast uses funny names a bunch.
     # spell-checker: ignore elts,posonlyargs,kwonlyargs,varargannotation,vararg
@@ -739,13 +726,34 @@ def buildParameterAnnotations(provider, node, source_ref):
     if not getFutureSpec().use_annotations:
         return None
 
-    keys = []
-    values = []
+    use_deferred = python_version >= 0x3E0 and isExperimental("deferred-annotations")
 
-    # The names of parameters are mangled in annotations as well.
-    def addAnnotation(key, value):
-        keys.append(mangleName(key, provider))
-        values.append(value)
+    if use_deferred:
+        annotation_specs = []
+
+        def addAnnotation(key, ast_node):
+            annotation_specs.append((mangleName(key, provider), ast_node, False))
+
+        def addStarredAnnotation(key, ast_node):
+            annotation_specs.append((mangleName(key, provider), ast_node, True))
+
+    else:
+        keys = []
+        values = []
+
+        def addAnnotation(key, value):
+            keys.append(mangleName(key, provider))
+            values.append(value)
+
+    def _buildAnnotationValue(annot_provider, ast_node, is_starred):
+        if is_starred:
+            value = buildAnnotationNode(annot_provider, ast_node, source_ref)
+            return ExpressionBuiltinNext1(
+                value=ExpressionBuiltinIterForUnpack(value, source_ref),
+                source_ref=source_ref,
+            )
+        else:
+            return buildAnnotationNode(annot_provider, ast_node, source_ref)
 
     def extractArgAnnotation(arg):
         if getKind(arg) == "Name":
@@ -753,22 +761,25 @@ def buildParameterAnnotations(provider, node, source_ref):
         elif getKind(arg) == "arg":
             if arg.annotation is not None:
                 if python_version >= 0x3B0 and getKind(arg.annotation) == "Starred":
-                    value = buildAnnotationNode(
-                        provider, arg.annotation.value, source_ref
-                    )
-
-                    result = ExpressionBuiltinNext1(
-                        value=ExpressionBuiltinIterForUnpack(value, source_ref),
-                        source_ref=source_ref,
-                    )
-
+                    if use_deferred:
+                        addStarredAnnotation(arg.arg, arg.annotation.value)
+                    else:
+                        addAnnotation(
+                            key=arg.arg,
+                            value=_buildAnnotationValue(
+                                provider, arg.annotation.value, True
+                            ),
+                        )
                 else:
-                    result = buildAnnotationNode(provider, arg.annotation, source_ref)
-
-                addAnnotation(
-                    key=arg.arg,
-                    value=result,
-                )
+                    if use_deferred:
+                        addAnnotation(arg.arg, arg.annotation)
+                    else:
+                        addAnnotation(
+                            key=arg.arg,
+                            value=_buildAnnotationValue(
+                                provider, arg.annotation, False
+                            ),
+                        )
         elif getKind(arg) == "Tuple":
             for sub_arg in arg.elts:
                 extractArgAnnotation(sub_arg)
@@ -787,16 +798,22 @@ def buildParameterAnnotations(provider, node, source_ref):
 
     if python_version < 0x300:
         if node.args.varargannotation is not None:
-            addAnnotation(
-                key=node.args.vararg,
-                value=buildNode(provider, node.args.varargannotation, source_ref),
-            )
+            if use_deferred:
+                addAnnotation(node.args.vararg, node.args.varargannotation)
+            else:
+                addAnnotation(
+                    key=node.args.vararg,
+                    value=buildNode(provider, node.args.varargannotation, source_ref),
+                )
 
         if node.args.kwargannotation is not None:
-            addAnnotation(
-                key=node.args.kwarg,
-                value=buildNode(provider, node.args.kwargannotation, source_ref),
-            )
+            if use_deferred:
+                addAnnotation(node.args.kwarg, node.args.kwargannotation)
+            else:
+                addAnnotation(
+                    key=node.args.kwarg,
+                    value=buildNode(provider, node.args.kwargannotation, source_ref),
+                )
     else:
         if node.args.vararg is not None:
             extractArgAnnotation(node.args.vararg)
@@ -805,30 +822,54 @@ def buildParameterAnnotations(provider, node, source_ref):
 
     # Return value annotation (not there for lambdas)
     if hasattr(node, "returns") and node.returns is not None:
-        addAnnotation(
-            key="return", value=buildAnnotationNode(provider, node.returns, source_ref)
-        )
+        if use_deferred:
+            addAnnotation("return", node.returns)
+        else:
+            addAnnotation(
+                key="return",
+                value=buildAnnotationNode(provider, node.returns, source_ref),
+            )
 
-    if keys:
-        # On 3.14+, annotations are deferred by default. TODO: But we guard it
-        # with an experimental flag due to the large overhead until we can
-        # generate more compact code for them
-        if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
-            return makeDeferredAnnotateFunctionObject(
+    if use_deferred:
+        if annotation_specs:
+            outer_body, return_statement = makeDeferredAnnotateFunctionBody(
                 provider=provider,
-                annotations=makeDictCreationOrConstant2(
-                    keys=keys, values=values, source_ref=source_ref
+                source_ref=source_ref,
+            )
+
+            keys = []
+            values = []
+            for key, ast_node, is_starred in annotation_specs:
+                keys.append(key)
+                values.append(_buildAnnotationValue(outer_body, ast_node, is_starred))
+
+            annotations = makeDictCreationOrConstant2(
+                keys=keys, values=values, source_ref=source_ref
+            )
+            return_statement.subnode_expression = annotations
+            annotations.parent = return_statement
+
+            return makeExpressionFunctionCreation(
+                function_ref=ExpressionFunctionRef(
+                    function_body=outer_body,
+                    source_ref=source_ref,
                 ),
+                defaults=(),
+                kw_defaults=None,
+                annotations=None,
                 source_ref=source_ref,
             )
         else:
+            return None
+    else:
+        if keys:
             return makeDictCreationOrConstant2(
                 keys=keys,
                 values=values,
                 source_ref=source_ref,
             )
-    else:
-        return None
+        else:
+            return None
 
 
 def _wrapFunctionWithSpecialNestedArgs(

--- a/nuitka/tree/ReformulationFunctionStatements.py
+++ b/nuitka/tree/ReformulationFunctionStatements.py
@@ -645,7 +645,7 @@ def buildParameterKwDefaults(provider, node, function_body, source_ref):
     return kw_defaults
 
 
-def makeDeferredAnnotateFunctionBody(provider, keys, values, source_ref):
+def makeDeferredAnnotateFunctionBody(provider, annotations, source_ref):
     function_name = "__annotate__"
     parameters = ParameterSpec(
         ps_name=function_name,
@@ -701,9 +701,7 @@ def makeDeferredAnnotateFunctionBody(provider, keys, values, source_ref):
             source_ref=source_ref,
         ),
         no_branch=StatementReturn(
-            expression=makeDictCreationOrConstant2(
-                keys=keys, values=values, source_ref=source_ref
-            ),
+            expression=annotations,
             source_ref=source_ref,
         ),
         source_ref=source_ref,
@@ -713,13 +711,12 @@ def makeDeferredAnnotateFunctionBody(provider, keys, values, source_ref):
     return outer_body
 
 
-def makeDeferredAnnotateFunctionObject(provider, keys, values, source_ref):
+def makeDeferredAnnotateFunctionObject(provider, annotations, source_ref):
     return makeExpressionFunctionCreation(
         function_ref=ExpressionFunctionRef(
             function_body=makeDeferredAnnotateFunctionBody(
                 provider=provider,
-                keys=keys,
-                values=values,
+                annotations=annotations,
                 source_ref=source_ref,
             ),
             source_ref=source_ref,
@@ -819,8 +816,9 @@ def buildParameterAnnotations(provider, node, source_ref):
         if python_version >= 0x3E0 and isExperimental("deferred-annotations"):
             return makeDeferredAnnotateFunctionObject(
                 provider=provider,
-                keys=keys,
-                values=values,
+                annotations=makeDictCreationOrConstant2(
+                    keys=keys, values=values, source_ref=source_ref
+                ),
                 source_ref=source_ref,
             )
         else:

--- a/tests/basics/FunctionAnnotateTest314.py
+++ b/tests/basics/FunctionAnnotateTest314.py
@@ -51,6 +51,58 @@ print(
     singledispatchTest("x"),
 )
 
+
+# Test class-level deferred annotations
+
+
+class TestClassAnnotations:
+    x: int = 1
+    y: str
+
+    def method(self, a: int) -> str:
+        return str(a)
+
+
+print(
+    "Class annotations:",
+    displayDict(TestClassAnnotations.__annotations__),
+)
+print("Class annotation attribute x:", TestClassAnnotations.x)
+print(
+    "Class annotation method result:",
+    TestClassAnnotations().method(42),
+)
+
+
+class TestNoClassAnnotations:
+    z = 42
+
+    def method(self, a: int) -> str:
+        return str(a)
+
+
+print(
+    "Class annotations (no class-level):",
+    displayDict(TestNoClassAnnotations.__annotations__),
+)
+print("Class attribute z:", TestNoClassAnnotations.z)
+
+
+class TestParent:
+    parent_attr: str = "hello"
+
+
+class TestChild(TestParent):
+    child_attr: int = 10
+
+
+print(
+    "Child annotations:",
+    displayDict(TestChild.__annotations__),
+)
+print("Child attr:", TestChild.child_attr)
+print("Parent attr:", TestChild.parent_attr)
+
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.
 #


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

Adds support for deferred annotations (via the `__annotate__` function) for classes.

## 🧐 Why was it initiated? Any relevant Issues?

- #3868

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Add support for deferred annotations via a generated __annotate__ function, including class-level annotations, under the experimental deferred-annotations mode.

Bug Fixes:
- Ensure function and class annotations are handled correctly when deferred annotations are enabled on Python 3.14+.

Enhancements:
- Refactor annotation building to support both immediate and deferred evaluation paths, including starred annotations.
- Extend class body representation to track deferred annotations for later realization into __annotations__.

Tests:
- Add tests covering deferred annotations on classes, including inheritance and cases with and without class-level annotations.