### PR TITLE
Comparisons: Reduce generated helpers via INT/CLONG shortcuts and safe inversion

### DIFF
--- a/nuitka/build/include/nuitka/helper/comparisons_ge.h
+++ b/nuitka/build/include/nuitka/helper/comparisons_ge.h
@@ -157,16 +157,6 @@ extern PyObject *RICH_COMPARE_GE_OBJECT_LONG_INT(PyObject *operand1, PyObject *o
 extern bool RICH_COMPARE_GE_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2);
 #endif
 
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern PyObject *RICH_COMPARE_GE_OBJECT_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern bool RICH_COMPARE_GE_CBOOL_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
 /* Code referring to "LONG" corresponds to Python2 'long', Python3 'int' and "DIGIT" to C platform digit value for long
  * Python objects. */
 extern PyObject *RICH_COMPARE_GE_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2);

--- a/nuitka/build/include/nuitka/helper/comparisons_gt.h
+++ b/nuitka/build/include/nuitka/helper/comparisons_gt.h
@@ -157,16 +157,6 @@ extern PyObject *RICH_COMPARE_GT_OBJECT_LONG_INT(PyObject *operand1, PyObject *o
 extern bool RICH_COMPARE_GT_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2);
 #endif
 
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern PyObject *RICH_COMPARE_GT_OBJECT_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern bool RICH_COMPARE_GT_CBOOL_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
 /* Code referring to "LONG" corresponds to Python2 'long', Python3 'int' and "DIGIT" to C platform digit value for long
  * Python objects. */
 extern PyObject *RICH_COMPARE_GT_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2);

--- a/nuitka/build/include/nuitka/helper/comparisons_ne.h
+++ b/nuitka/build/include/nuitka/helper/comparisons_ne.h
@@ -157,16 +157,6 @@ extern PyObject *RICH_COMPARE_NE_OBJECT_LONG_INT(PyObject *operand1, PyObject *o
 extern bool RICH_COMPARE_NE_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2);
 #endif
 
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern PyObject *RICH_COMPARE_NE_OBJECT_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-extern bool RICH_COMPARE_NE_CBOOL_INT_CLONG(PyObject *operand1, long operand2);
-#endif
-
 /* Code referring to "LONG" corresponds to Python2 'long', Python3 'int' and "DIGIT" to C platform digit value for long
  * Python objects. */
 extern PyObject *RICH_COMPARE_NE_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2);

--- a/nuitka/build/static_src/HelpersComparisonGe.c
+++ b/nuitka/build/static_src/HelpersComparisonGe.c
@@ -11687,54 +11687,6 @@ bool RICH_COMPARE_GE_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2) {
 }
 #endif
 
-#if PYTHON_VERSION < 0x300
-static PyObject *COMPARE_GE_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a >= b;
-
-    // Convert to target type.
-    PyObject *result = BOOL_FROM(r);
-    Py_INCREF_IMMORTAL(result);
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-PyObject *RICH_COMPARE_GE_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_GE_OBJECT_INT_CLONG(operand1, operand2);
-}
-#endif
-
-#if PYTHON_VERSION < 0x300
-static bool COMPARE_GE_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a >= b;
-
-    // Convert to target type.
-    bool result = r;
-
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-bool RICH_COMPARE_GE_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_GE_CBOOL_INT_CLONG(operand1, operand2);
-}
-#endif
-
 static PyObject *COMPARE_GE_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2) {
     CHECK_OBJECT(operand1);
     assert(PyLong_CheckExact(operand1));

--- a/nuitka/build/static_src/HelpersComparisonGt.c
+++ b/nuitka/build/static_src/HelpersComparisonGt.c
@@ -11671,54 +11671,6 @@ bool RICH_COMPARE_GT_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2) {
 }
 #endif
 
-#if PYTHON_VERSION < 0x300
-static PyObject *COMPARE_GT_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a > b;
-
-    // Convert to target type.
-    PyObject *result = BOOL_FROM(r);
-    Py_INCREF_IMMORTAL(result);
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-PyObject *RICH_COMPARE_GT_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_GT_OBJECT_INT_CLONG(operand1, operand2);
-}
-#endif
-
-#if PYTHON_VERSION < 0x300
-static bool COMPARE_GT_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a > b;
-
-    // Convert to target type.
-    bool result = r;
-
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-bool RICH_COMPARE_GT_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_GT_CBOOL_INT_CLONG(operand1, operand2);
-}
-#endif
-
 static PyObject *COMPARE_GT_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2) {
     CHECK_OBJECT(operand1);
     assert(PyLong_CheckExact(operand1));

--- a/nuitka/build/static_src/HelpersComparisonNe.c
+++ b/nuitka/build/static_src/HelpersComparisonNe.c
@@ -11805,54 +11805,6 @@ bool RICH_COMPARE_NE_CBOOL_LONG_INT(PyObject *operand1, PyObject *operand2) {
 }
 #endif
 
-#if PYTHON_VERSION < 0x300
-static PyObject *COMPARE_NE_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a != b;
-
-    // Convert to target type.
-    PyObject *result = BOOL_FROM(r);
-    Py_INCREF_IMMORTAL(result);
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-PyObject *RICH_COMPARE_NE_OBJECT_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_NE_OBJECT_INT_CLONG(operand1, operand2);
-}
-#endif
-
-#if PYTHON_VERSION < 0x300
-static bool COMPARE_NE_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-    CHECK_OBJECT(operand1);
-    assert(PyInt_CheckExact(operand1));
-
-    const long a = PyInt_AS_LONG(operand1);
-    const long b = operand2;
-
-    bool r = a != b;
-
-    // Convert to target type.
-    bool result = r;
-
-    return result;
-}
-#endif
-#if PYTHON_VERSION < 0x300
-/* Code referring to "INT" corresponds to Python2 'int' and "CLONG" to C platform long value. */
-bool RICH_COMPARE_NE_CBOOL_INT_CLONG(PyObject *operand1, long operand2) {
-
-    return COMPARE_NE_CBOOL_INT_CLONG(operand1, operand2);
-}
-#endif
-
 static PyObject *COMPARE_NE_OBJECT_LONG_DIGIT(PyObject *operand1, long operand2) {
     CHECK_OBJECT(operand1);
     assert(PyLong_CheckExact(operand1));

--- a/nuitka/code_generation/ComparisonCodes.py
+++ b/nuitka/code_generation/ComparisonCodes.py
@@ -9,8 +9,13 @@ Rich comparisons, "in", and "not in", also "is", and "is not", and the
 
 from nuitka.nodes.shapes.BuiltinTypeShapes import (
     tshape_bool,
+    tshape_bytes,
     tshape_frozenset,
+    tshape_int,
+    tshape_long,
     tshape_set,
+    tshape_str,
+    tshape_unicode,
 )
 from nuitka.nodes.shapes.StandardShapes import tshape_unknown
 from nuitka.PythonOperators import (
@@ -19,6 +24,7 @@ from nuitka.PythonOperators import (
 )
 
 from .c_types.CTypeBooleans import CTypeBool
+from .c_types.CTypeCLongs import CTypeCLong
 from .c_types.CTypeNuitkaBooleans import CTypeNuitkaBoolEnum
 from .c_types.CTypeNuitkaVoids import CTypeNuitkaVoidEnum
 from .c_types.CTypePyObjectPointers import CTypePyObjectPtr
@@ -39,20 +45,53 @@ from .ErrorCodes import (
 from .ExpressionCTypeSelectionHelpers import decideExpressionCTypes
 
 
+def _canInvertComparisonToHelperSubset(
+    left_shape, right_shape, left_c_type, right_c_type
+):
+    if left_c_type is CTypePyObjectPtr and right_c_type is CTypeCLong:
+        return True
+
+    if left_c_type is not right_c_type:
+        return False
+
+    if left_c_type is not CTypePyObjectPtr:
+        return False
+
+    safe_shape_families = (
+        (tshape_int, tshape_long),
+        (tshape_str, tshape_unicode),
+        (tshape_bytes,),
+    )
+
+    return any(
+        left_shape in safe_shape_family and right_shape in safe_shape_family
+        for safe_shape_family in safe_shape_families
+    )
+
+
 def _handleArgumentSwapAndInversion(
-    comparator, needs_argument_swap, left_c_type, right_c_type
+    comparator, needs_argument_swap, left_shape, right_shape, left_c_type, right_c_type
 ):
     needs_result_inversion = False
     if needs_argument_swap:
         comparator = rich_comparison_arg_swaps[comparator]
-    else:
-        # Same types, we can swap too, but this time to avoid the comparator variety.
-        if (
-            left_c_type is right_c_type
-            and comparator not in rich_comparison_subset_codes
-        ):
-            needs_result_inversion = True
-            comparator = comparison_inversions[comparator]
+        left_shape, right_shape = right_shape, left_shape
+        left_c_type, right_c_type = right_c_type, left_c_type
+
+    can_invert_to_helper_subset = _canInvertComparisonToHelperSubset(
+        left_shape=left_shape,
+        right_shape=right_shape,
+        left_c_type=left_c_type,
+        right_c_type=right_c_type,
+    )
+
+    # Reduce to the subset of comparators {Lt, LtE, Eq} where helper generation
+    # also uses shortcuts. This is deliberately narrow: float comparisons with
+    # NaN, and container comparisons involving NaN elements, are not complements
+    # of their inverse comparisons.
+    if comparator not in rich_comparison_subset_codes and can_invert_to_helper_subset:
+        needs_result_inversion = True
+        comparator = comparison_inversions[comparator]
 
     return comparator, needs_result_inversion
 
@@ -86,7 +125,12 @@ def getRichComparisonCode(
     else:
         # Same types, we can swap too, but this time to avoid the comparator variety.
         comparator, needs_result_inversion = _handleArgumentSwapAndInversion(
-            comparator, needs_argument_swap, left_c_type, right_c_type
+            comparator,
+            needs_argument_swap,
+            left_shape,
+            right_shape,
+            left_c_type,
+            right_c_type,
         )
 
     # If a more specific C type was picked that "PyObject *" then we can use that to have the helper.

--- a/nuitka/code_generation/ComparisonCodes.py
+++ b/nuitka/code_generation/ComparisonCodes.py
@@ -49,7 +49,7 @@ def _canInvertComparisonToHelperSubset(
     left_shape, right_shape, left_c_type, right_c_type
 ):
     if left_c_type is CTypePyObjectPtr and right_c_type is CTypeCLong:
-        return True
+        return left_shape in (tshape_int, tshape_long)
 
     if left_c_type is not right_c_type:
         return False

--- a/nuitka/code_generation/ComparisonHelperDefinitions.py
+++ b/nuitka/code_generation/ComparisonHelperDefinitions.py
@@ -106,11 +106,11 @@ specialized_cmp_helpers_set = buildOrderedSet(
     _makeTypeOps("TUPLE", may_raise_same_type=True, shortcut=False),
     _makeTypeOps("LIST", may_raise_same_type=True, shortcut=False),
     # Mixed Python types:
-    # TODO: Absolutely possible to shortcut, why aren't we doing it?
+    # TODO: Removing GT/GE/NE for this also removes LONG_CLONG internal helpers
+    # still used by dual NILONG helpers.
     _makeFriendOps("LONG", "INT", may_raise=False, shortcut=False),
-    # Partial Python with C types
-    # TODO: Absolutely possible to shortcut, why aren't we doing it?
-    _makeFriendOps("INT", "CLONG", may_raise=False, shortcut=False),
+    # Partial Python with C types: same inversion applies.
+    _makeFriendOps("INT", "CLONG", may_raise=False, shortcut=True),
     _makeFriendOps("LONG", "DIGIT", may_raise=False, shortcut=False),
     _makeFriendOps("FLOAT", "CFLOAT", may_raise=False, shortcut=False),
     # Partial dual types with C types, cannot shortcut as reverse argument versions are used.

--- a/tests/basics/BuiltinsTest.py
+++ b/tests/basics/BuiltinsTest.py
@@ -432,6 +432,107 @@ if a != a:
 else:
     print("isn't nan")
 
+
+def getRuntimeValue(value):
+    return value
+
+
+print("Ordered comparisons involving nan floats:")
+nan_value = float(getRuntimeValue("nan"))
+print([nan_value < 1.0, nan_value <= 1.0, nan_value > 1.0, nan_value >= 1.0])
+print([1.0 < nan_value, 1.0 <= nan_value, 1.0 > nan_value, 1.0 >= nan_value])
+print(
+    [
+        1 if nan_value < 1.0 else 0,
+        1 if nan_value <= 1.0 else 0,
+        1 if nan_value > 1.0 else 0,
+        1 if nan_value >= 1.0 else 0,
+    ]
+)
+print(
+    [
+        1 if 1.0 < nan_value else 0,
+        1 if 1.0 <= nan_value else 0,
+        1 if 1.0 > nan_value else 0,
+        1 if 1.0 >= nan_value else 0,
+    ]
+)
+print([not (nan_value <= 1.0), not (nan_value < 1.0)])
+print([not (1.0 <= nan_value), not (1.0 < nan_value)])
+
+int_value = int(getRuntimeValue("1"))
+print([int_value < nan_value, int_value <= nan_value])
+print([int_value > nan_value, int_value >= nan_value])
+print(
+    [
+        1 if int_value < nan_value else 0,
+        1 if int_value <= nan_value else 0,
+        1 if int_value > nan_value else 0,
+        1 if int_value >= nan_value else 0,
+    ]
+)
+
+if str is bytes:
+    print("Mixed int and long comparisons:")
+
+    int_value = int(getRuntimeValue("40"))
+    long_value = type(1 << 100)(getRuntimeValue("42"))
+
+    print(
+        [
+            long_value < int_value,
+            long_value <= int_value,
+            long_value > int_value,
+            long_value >= int_value,
+            long_value != int_value,
+        ]
+    )
+    print(
+        [
+            int_value < long_value,
+            int_value <= long_value,
+            int_value > long_value,
+            int_value >= long_value,
+            int_value != long_value,
+        ]
+    )
+    print(
+        [
+            int_value < 41,
+            int_value <= 41,
+            int_value > 41,
+            int_value >= 41,
+            int_value != 41,
+        ]
+    )
+    print(
+        [
+            1 if long_value < int_value else 0,
+            1 if long_value <= int_value else 0,
+            1 if long_value > int_value else 0,
+            1 if long_value >= int_value else 0,
+            1 if long_value != int_value else 0,
+        ]
+    )
+    print(
+        [
+            1 if int_value < long_value else 0,
+            1 if int_value <= long_value else 0,
+            1 if int_value > long_value else 0,
+            1 if int_value >= long_value else 0,
+            1 if int_value != long_value else 0,
+        ]
+    )
+    print(
+        [
+            1 if int_value < 41 else 0,
+            1 if int_value <= 41 else 0,
+            1 if int_value > 41 else 0,
+            1 if int_value >= 41 else 0,
+            1 if int_value != 41 else 0,
+        ]
+    )
+
 print("inf and -inf sign checks:")
 
 print("inf:", float("inf"), copysign(1.0, float("inf")))


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Enable the codegen to emit fewer comparison helper functions for `INT`/`CLONG` pairs by using the existing shortcut mechanism. Previously `INT`/`CLONG` generated all six comparison variants (`LT`, `LE`, `EQ`, `NE`, `GT`, `GE`); with `shortcut=True` only the three-element subset `{LT, LE, EQ}` is generated, and `GT`/`GE`/`NE` are handled at codegen time by inverting to the matching subset helper and negating the result.

The inversion logic in `_handleArgumentSwapAndInversion` was previously too broad. It would also invert float and container comparisons, which is wrong because `not (a > b) != a <= b` when NaN is involved. A new guard `_canInvertComparisonToHelperSubset` restricts inversion to type families with a guaranteed total order (integer and string shapes), making the optimization safe to enable for `INT`/`CLONG` without regressing float/container correctness.

### What changed

#### `ComparisonHelperDefinitions.py` - enable shortcut for INT/CLONG

```python
# before
_makeFriendOps("INT", "CLONG", may_raise=False, shortcut=False)
# after
_makeFriendOps("INT", "CLONG", may_raise=False, shortcut=True)
```

`shortcut=True` tells the helper set to include only `{LT, LE, EQ}` for this pair. `GT`/`GE`/`NE` are no longer in `specialized_cmp_helpers_set`, so their implementations are deleted (~188 lines across `.c`/`.h`).

`LONG`/`INT` mixed pairs remain `shortcut=False` because enabling shortcuts there would also drop the internal `LONG_CLONG` GT/GE/NE helpers that the NILONG dual-type helpers still require.

#### `ComparisonCodes.py` - restrict inversion to safe shapes

`_canInvertComparisonToHelperSubset` returns `True` only when inversion is known-safe:

- `PyObject * / CTypeCLong` mixed pair - the new INT/CLONG case
- Same `PyObject *` type where both shapes are in a totally-ordered family: `(tshape_int, tshape_long)`, `(tshape_str, tshape_unicode)`, `(tshape_bytes,)`

Float, unknown, container, and all other shapes return `False`. The codegen no longer inverts those comparators, so NaN cannot produce wrong results.

#### Dead code removed (`.c` / `.h`)

`RICH_COMPARE_{GE,GT,NE}_{OBJECT,CBOOL}_INT_CLONG` and their extern declarations are deleted. They are now unreachable since the helper set no longer includes GT/GE/NE for INT/CLONG.

#### `BuiltinsTest.py` - runtime coverage

- Ordered NaN comparisons in object-result and condition-result contexts, both operand orders, and `not (nan <= x)` / `not (x <= nan)` inversion forms.
- `int` object vs `nan` comparisons.
- Python 2-only mixed `int`/`long` coverage, guarded by `if str is bytes:` to avoid `long` literal syntax errors on Python 3.

## 🧐 Why was it initiated? Any relevant Issues?

This was initiated to reduce generated comparison helpers while keeping comparison inversion safe for values such as NaN and containers where the logical inversion is not equivalent.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - See validation commands below.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## Validation

Property-based exploration with `crosshair-tool` and `hypothesis` in `tests/scratch/` confirmed which inversions are unsafe.

CrossHair found NaN counterexamples for scalar float and tuple comparisons:

```bash
uv run crosshair diffbehavior --per_condition_timeout=10 tests.scratch.crosshair_compare.gt_original tests.scratch.crosshair_compare.gt_inverted
uv run crosshair diffbehavior --per_condition_timeout=10 tests.scratch.crosshair_compare.ge_original tests.scratch.crosshair_compare.ge_inverted
uv run crosshair diffbehavior --per_condition_timeout=10 tests.scratch.crosshair_compare.tuple_gt_original tests.scratch.crosshair_compare.tuple_gt_inverted
```

Examples found:

```text
gt_original(-1.0, nan) -> False
gt_inverted(-1.0, nan) -> True

ge_original(7.4050824148778e-304, nan) -> False
ge_inverted(7.4050824148778e-304, nan) -> True

tuple_gt_original((1.184418094435452e-308,), (nan,)) -> False
tuple_gt_inverted((1.184418094435452e-308,), (nan,)) -> True
```

Hypothesis found minimized counterexamples, including the list case:

```bash
uv run python tests/scratch/hypothesis_compare.py
```

Minimized examples:

```text
float gt: (0.0, nan)
float ge: (0.0, nan)
tuple gt: ((0.0,), (nan,))
list gt: ([0.0], [nan])
```

Testing performed:

- `./bin/autoformat-nuitka-source --un-pushed`
- `./.venv/bin/python ./tests/basics/run_all.py only BuiltinsTest.py`
- `./bin/check-nuitka-with-pylint --un-pushed`
- `git diff --check`
- `NUITKA_CACHE_DIR=tests/scratch/nuitka-cache python3 tests/basics/run_all.py only BuiltinsTest`
- `NUITKA_CACHE_DIR=tests/scratch/nuitka-cache PYTHON=python NUITKA_EXTRA_OPTIONS="--lto=no --disable-cache=ccache" python tests/basics/run_all.py only BuiltinsTest`

Python 2.7.18 validation passed after disabling local LTO/ccache due to an unrelated LLVM bitcode linker mismatch with the default macOS toolchain.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
  - [ ] **Evidence**: I have included test evidence that the change is effective.