### PR TITLE
Use setup-uv in testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,17 +48,8 @@ jobs:
             requirements-devel.txt
             requirements.txt
 
-      - name: 📦 Cache apt packages
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-${{ runner.os }}-patchelf-gdb-ccache-libfuse2
-          restore-keys: apt-${{ runner.os }}-
-
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install patchelf gdb ccache libfuse2
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           python ./bin/check-nuitka-with-pylint
 
+
   check-format:
     runs-on: ubuntu-24.04
     name: Check / Format & Codegen

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,6 @@ jobs:
           with: |
             fetch-depth: 1
             fetch-tags: false
-            filter: blob:none
           attempt_limit: 3
           attempt_delay: 120000
 
@@ -111,7 +110,6 @@ jobs:
           with: |
             fetch-depth: 1
             fetch-tags: false
-            filter: blob:none
           attempt_limit: 3
           attempt_delay: 120000
 
@@ -212,7 +210,6 @@ jobs:
           with: |
             fetch-depth: 1
             fetch-tags: false
-            filter: blob:none
           attempt_limit: 3
           attempt_delay: 120000
 
@@ -338,7 +335,6 @@ jobs:
           with: |
             fetch-depth: 1
             fetch-tags: false
-            filter: blob:none
           attempt_limit: 3
           attempt_delay: 120000
 
@@ -409,7 +405,6 @@ jobs:
           with: |
             fetch-depth: 1
             fetch-tags: false
-            filter: blob:none
           attempt_limit: 3
           attempt_delay: 120000
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,6 +59,13 @@ jobs:
           key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
+      - name: 🔧 Cache PyLint results
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pylint
+          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
+          restore-keys: pylint-${{ runner.os }}-
+
       - name: 🔎 PyLint on Nuitka source code
         run: |
           python ./bin/check-nuitka-with-pylint

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,8 +52,7 @@ jobs:
       - name: 🧳 Install Nuitka and dependencies
         run: |
           sudo rm -f /usr/bin/clang-format
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r nuitka/utils/requirements-private.txt -r requirements-devel.txt -r requirements.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
         shell: bash
 
       - name: 🔧 Cache PyLint results

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
@@ -119,7 +119,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
@@ -220,7 +220,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
@@ -346,7 +346,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
@@ -417,7 +417,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,14 +29,10 @@ jobs:
     name: Check / All
     steps:
       - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v4
         with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: 🐍 Use Python 3.11
         uses: actions/setup-python@v5
@@ -121,14 +117,10 @@ jobs:
     name: Ubuntu Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v4
         with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -154,7 +146,7 @@ jobs:
           if [ "${{ steps.apt-cache.outputs.cache-hit }}" != "true" ]; then
             sudo apt-get update
           fi
-          sudo apt-get install -y --no-upgrade --no-install-recommends patchelf gdb ccache libfuse2
+          sudo apt-get install patchelf gdb ccache libfuse2
           uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
           uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
         shell: bash
@@ -176,8 +168,6 @@ jobs:
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: ⚙️ Verbose scons output in compilation
-        env:
-          CCACHE_MAXSIZE: 200M
         run: |
           set -x
           python -m nuitka --mode=module --show-scons --run --report=compilation-report-module.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
@@ -229,14 +219,10 @@ jobs:
     name: macOS Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v4
         with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -292,8 +278,6 @@ jobs:
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
-        env:
-          CCACHE_MAXSIZE: 200M
         run: |
           set -x
 
@@ -371,14 +355,10 @@ jobs:
     name: Windows Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v4
         with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -444,14 +424,10 @@ jobs:
     name: Windows ARM Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: actions/checkout@v4
         with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   NUITKA_UPDATE_CHECK: "never"
+  UV_SYSTEM_PYTHON: "1"
 
 jobs:
   checks:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,15 +42,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache PyLint results
         uses: actions/cache@v4
@@ -82,17 +85,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: |
-            nuitka/utils/requirements-private.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
           sudo rm -f /usr/bin/clang-format
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r nuitka/utils/requirements-private.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r nuitka/utils/requirements-private.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache Nuitka downloads
         uses: actions/cache@v4
@@ -130,13 +136,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: 🧳 Install Nuitka
         run: |
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔎 Specialized C code check
         run: |
@@ -164,15 +175,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔎 RestLint on Nuitka source code
         run: |
@@ -216,10 +230,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ matrix.python_version }}
+          enable-cache: true
 
       - name: 📦 Cache apt packages
         id: apt-cache
@@ -235,8 +251,9 @@ jobs:
             sudo apt-get update
           fi
           sudo apt-get install -y --no-upgrade --no-install-recommends patchelf gdb ccache libfuse2
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache ccache data
         uses: actions/cache@v4
@@ -321,10 +338,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ matrix.python_version }}
+          enable-cache: true
 
       - name: ⚙️ Verbose installation output for Python
         run: |
@@ -348,8 +367,9 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache ccache data
         uses: actions/cache@v4
@@ -460,17 +480,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ matrix.python_version }}
+          enable-cache: true
 
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache Nuitka downloads
         uses: actions/cache@v4
@@ -530,10 +553,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements-devel.txt
-            requirements.txt
+
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ matrix.python_version }}
+          enable-cache: true
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -541,8 +566,9 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
+        shell: bash
 
       - name: 🔧 Cache Nuitka downloads
         uses: actions/cache@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+          uv pip install -r requirements-devel.txt .
         shell: bash
 
       - name: 🔎 PyLint on Nuitka source code
@@ -177,7 +177,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+          uv pip install -r requirements-devel.txt .
         shell: bash
 
       - name: ⚙️ Verbose scons output in compilation
@@ -287,7 +287,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+          uv pip install -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation
@@ -417,7 +417,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+          uv pip install -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation
@@ -509,7 +509,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+          uv pip install -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          uv pip install -r requirements-devel.txt .
+          uv pip install --system -r requirements-devel.txt .
         shell: bash
 
       - name: 🔎 PyLint on Nuitka source code
@@ -178,7 +178,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          uv pip install -r requirements-devel.txt .
+          uv pip install --system -r requirements-devel.txt .
         shell: bash
 
       - name: ⚙️ Verbose scons output in compilation
@@ -288,7 +288,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install -r requirements-devel.txt .
+          uv pip install --system -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation
@@ -418,7 +418,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install -r requirements-devel.txt .
+          uv pip install --system -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation
@@ -510,7 +510,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install -r requirements-devel.txt .
+          uv pip install --system -r requirements-devel.txt .
         shell: bash
 
       - name: Verbose scons output in compilation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt', 'requirements-devel.txt') }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ matrix.python_version }}-
             ccache-${{ runner.os }}-
@@ -303,7 +303,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt', 'requirements-devel.txt') }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ matrix.python_version }}-
             ccache-${{ runner.os }}-

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,6 +62,13 @@ jobs:
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 
+      - name: 🔧 Cache Nuitka downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/downloads
+          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: nuitka-downloads-${{ runner.os }}-
+
       - name: 🔎 PyLint on Nuitka source code
         run: |
           python ./bin/check-nuitka-with-pylint

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,9 +24,48 @@ env:
   NUITKA_CACHE_DIR: ~/.cache/Nuitka
 
 jobs:
-  checks:
+  check-pylint:
     runs-on: ubuntu-24.04
-    name: Checks
+    name: Check / PyLint
+    steps:
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        with:
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+          attempt_limit: 3
+          attempt_delay: 120000
+
+      - name: 🐍 Use Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
+
+      - name: 🧳 Install Nuitka and dependencies
+        run: |
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
+
+      - name: 🔧 Cache PyLint results
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pylint
+          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
+          restore-keys: pylint-${{ runner.os }}-
+
+      - name: 🔎 PyLint on Nuitka source code
+        run: |
+          python ./bin/check-nuitka-with-pylint
+
+  check-format:
+    runs-on: ubuntu-24.04
+    name: Check / Format & Codegen
     steps:
       - name: 🛎️ Checkout
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
@@ -59,17 +98,45 @@ jobs:
           key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
-      - name: 🔧 Cache PyLint results
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pylint
-          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
-          restore-keys: pylint-${{ runner.os }}-
-
-
-      - name: 🔎 PyLint on Nuitka source code
+      - name: 🔎 Auto-format check on Nuitka source code
         run: |
-          python ./bin/check-nuitka-with-pylint
+          python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
+
+      - name: 🔎 Specialized C code check
+        run: |
+          python ./bin/generate-specialized-c-code --check
+
+      - name: 🔎 Specialized Python code check
+        run: |
+          python ./bin/generate-specialized-python-code --check
+
+  check-lint:
+    runs-on: ubuntu-24.04
+    name: Check / Lint
+    steps:
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        with:
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+          attempt_limit: 3
+          attempt_delay: 120000
+
+      - name: 🐍 Use Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
+
+      - name: 🧳 Install Nuitka and dependencies
+        run: |
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: 🔎 RestLint on Nuitka source code
         run: |
@@ -83,20 +150,8 @@ jobs:
         run: |
           python ./bin/check-nuitka-with-codespell
 
-      - name: 🔎 Auto-format check on Nuitka source code
-        run: |
-          python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
-
-      - name: 🔎 Specialized C code check
-        run: |
-          python ./bin/generate-specialized-c-code --check
-
-      - name: 🔎 Specialized Python code check
-        run: |
-          python ./bin/generate-specialized-python-code --check
-
   linux:
-    needs: checks
+    needs: [check-pylint, check-format, check-lint]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,6 +102,32 @@ jobs:
         run: |
           python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
 
+  check-codegen:
+    runs-on: ubuntu-24.04
+    name: Check / Codegen
+    steps:
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        with:
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+          attempt_limit: 3
+          attempt_delay: 120000
+
+      - name: 🐍 Use Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: 🧳 Install Nuitka
+        run: |
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
+
       - name: 🔎 Specialized C code check
         run: |
           python ./bin/generate-specialized-c-code --check
@@ -151,7 +177,7 @@ jobs:
           python ./bin/check-nuitka-with-codespell
 
   linux:
-    needs: [check-pylint, check-format, check-lint]
+    needs: [check-pylint, check-format, check-codegen, check-lint]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -292,6 +318,18 @@ jobs:
           otool -L $(which python)
           otool -l $(which python)
           ls -lR $(dirname $(dirname $(which python)))
+
+      - name: 📦 Cache Homebrew downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: homebrew-${{ runner.os }}-${{ runner.arch }}-ccache
+
+      - name: 📦 Install system dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
+        run: brew install ccache
 
       - name: 🧳 Install Nuitka and dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -234,7 +234,7 @@ jobs:
           if [ "${{ steps.apt-cache.outputs.cache-hit }}" != "true" ]; then
             sudo apt-get update
           fi
-          sudo apt-get install -y --no-upgrade patchelf gdb ccache libfuse2
+          sudo apt-get install -y --no-upgrade --no-install-recommends patchelf gdb ccache libfuse2
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 
@@ -255,6 +255,8 @@ jobs:
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: ⚙️ Verbose scons output in compilation
+        env:
+          CCACHE_MAXSIZE: 200M
         run: |
           set -x
           python -m nuitka --mode=module --show-scons --run --report=compilation-report-module.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
@@ -366,6 +368,8 @@ jobs:
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
+        env:
+          CCACHE_MAXSIZE: 200M
         run: |
           set -x
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,52 +24,9 @@ env:
   NUITKA_CACHE_DIR: ~/.cache/Nuitka
 
 jobs:
-  check-pylint:
+  checks:
     runs-on: ubuntu-24.04
-    name: Check / PyLint
-    steps:
-      - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-        with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
-
-      - name: 🐍 Use Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.11"
-          enable-cache: true
-
-      - name: 🧳 Install Nuitka and dependencies
-        run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
-      - name: 🔧 Cache PyLint results
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pylint
-          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
-          restore-keys: pylint-${{ runner.os }}-
-
-      - name: 🔎 PyLint on Nuitka source code
-        run: |
-          python ./bin/check-nuitka-with-pylint
-
-
-  check-format:
-    runs-on: ubuntu-24.04
-    name: Check / Format & Codegen
+    name: Check / All
     steps:
       - name: 🛎️ Checkout
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
@@ -95,10 +52,20 @@ jobs:
       - name: 🧳 Install Nuitka and dependencies
         run: |
           sudo rm -f /usr/bin/clang-format
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r nuitka/utils/requirements-private.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements.txt
+          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r nuitka/utils/requirements-private.txt -r requirements-devel.txt -r requirements.txt
           uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
         shell: bash
+
+      - name: 🔧 Cache PyLint results
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pylint
+          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
+          restore-keys: pylint-${{ runner.os }}-
+
+      - name: 🔎 PyLint on Nuitka source code
+        run: |
+          python ./bin/check-nuitka-with-pylint
 
       - name: 🔧 Cache Nuitka downloads
         uses: actions/cache@v4
@@ -118,37 +85,6 @@ jobs:
         run: |
           python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
 
-  check-codegen:
-    runs-on: ubuntu-24.04
-    name: Check / Codegen
-    steps:
-      - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-        with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
-
-      - name: 🐍 Use Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.11"
-          enable-cache: true
-
-      - name: 🧳 Install Nuitka
-        run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
       - name: 🔎 Specialized C code check
         run: |
           python ./bin/generate-specialized-c-code --check
@@ -156,37 +92,6 @@ jobs:
       - name: 🔎 Specialized Python code check
         run: |
           python ./bin/generate-specialized-python-code --check
-
-  check-lint:
-    runs-on: ubuntu-24.04
-    name: Check / Lint
-    steps:
-      - name: 🛎️ Checkout
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-        with:
-          action: actions/checkout@v4
-          with: |
-            fetch-depth: 1
-            fetch-tags: false
-          attempt_limit: 3
-          attempt_delay: 120000
-
-      - name: 🐍 Use Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.11"
-          enable-cache: true
-
-      - name: 🧳 Install Nuitka and dependencies
-        run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
 
       - name: 🔎 RestLint on Nuitka source code
         run: |
@@ -201,7 +106,7 @@ jobs:
           python ./bin/check-nuitka-with-codespell
 
   linux:
-    needs: [check-pylint, check-format, check-codegen, check-lint]
+    needs: checks
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -555,3 +555,5 @@ jobs:
           Get-ChildItem env:
           python -m nuitka --version
           python .\tests\run-tests --no-other-python --no-debug --skip-reflection-test --skip-all-cpython-tests --assume-yes-for-downloads
+
+          warm cache

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -212,6 +212,7 @@ jobs:
             requirements.txt
 
       - name: 📦 Cache apt packages
+        id: apt-cache
         uses: actions/cache@v4
         with:
           path: /var/cache/apt/archives
@@ -220,8 +221,10 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install patchelf gdb ccache libfuse2
+          if [ "${{ steps.apt-cache.outputs.cache-hit }}" != "true" ]; then
+            sudo apt-get update
+          fi
+          sudo apt-get install -y --no-upgrade patchelf gdb ccache libfuse2
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,12 +21,11 @@ permissions:
 
 env:
   NUITKA_UPDATE_CHECK: "never"
-  NUITKA_CACHE_DIR: ~/.cache/Nuitka
 
 jobs:
   checks:
     runs-on: ubuntu-24.04
-    name: Check / All
+    name: Checks
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,6 +88,7 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
+          sudo rm -f /usr/bin/clang-format
           python -m pip install --no-python-version-warning --disable-pip-version-check -r nuitka/utils/requirements-private.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   NUITKA_UPDATE_CHECK: "never"
+  NUITKA_CACHE_DIR: ~/.cache/Nuitka
 
 jobs:
   checks:
@@ -30,7 +31,7 @@ jobs:
       - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -45,7 +46,7 @@ jobs:
         if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -60,7 +61,7 @@ jobs:
         if: steps.checkout_retry_1.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         id: checkout_retry_2
@@ -73,6 +74,13 @@ jobs:
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
+
+      - name: 📦 Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-${{ runner.os }}-patchelf-gdb-ccache-libfuse2
+          restore-keys: apt-${{ runner.os }}-
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
@@ -128,7 +136,7 @@ jobs:
       - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -143,7 +151,7 @@ jobs:
         if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -158,7 +166,7 @@ jobs:
         if: steps.checkout_retry_1.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         id: checkout_retry_2
@@ -171,6 +179,13 @@ jobs:
           cache-dependency-path: |
             requirements-devel.txt
             requirements.txt
+
+      - name: 📦 Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-${{ runner.os }}-patchelf-gdb-ccache-libfuse2
+          restore-keys: apt-${{ runner.os }}-
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
@@ -187,6 +202,13 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ matrix.python_version }}-
             ccache-${{ runner.os }}-
+
+      - name: 🔧 Cache Nuitka downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/downloads
+          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: ⚙️ Verbose scons output in compilation
         run: |
@@ -242,7 +264,7 @@ jobs:
       - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -257,7 +279,7 @@ jobs:
         if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -272,7 +294,7 @@ jobs:
         if: steps.checkout_retry_1.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         id: checkout_retry_2
@@ -307,6 +329,13 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ matrix.python_version }}-
             ccache-${{ runner.os }}-
+
+      - name: 🔧 Cache Nuitka downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/downloads
+          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
         run: |
@@ -388,7 +417,7 @@ jobs:
       - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -403,7 +432,7 @@ jobs:
         if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -418,7 +447,7 @@ jobs:
         if: steps.checkout_retry_1.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         id: checkout_retry_2
@@ -438,6 +467,13 @@ jobs:
         run: |
           pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           pip install --no-python-version-warning --disable-pip-version-check .
+
+      - name: 🔧 Cache Nuitka downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/downloads
+          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
         run: |
@@ -479,7 +515,7 @@ jobs:
       - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -494,7 +530,7 @@ jobs:
         if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         continue-on-error: true
@@ -509,7 +545,7 @@ jobs:
         if: steps.checkout_retry_1.outcome == 'failure'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           filter: blob:none
         id: checkout_retry_2
@@ -531,6 +567,13 @@ jobs:
         run: |
           pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           pip install --no-python-version-warning --disable-pip-version-check .
+
+      - name: 🔧 Cache Nuitka downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/downloads
+          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
+          restore-keys: nuitka-downloads-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,43 +28,16 @@ jobs:
     runs-on: ubuntu-24.04
     name: Checks
     steps:
-      - name: 🛎️ Checkout (Attempt 1)
-        uses: actions/checkout@v4
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout
-
-      - name: ⏳ Wait for checkout retry 1
-        if: steps.checkout.outcome == 'failure'
-        run: sleep 120s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 2)
-        if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout_retry_1
-
-      - name: ⏳ Wait for checkout retry 2
-        if: steps.checkout_retry_1.outcome == 'failure'
-        run: sleep 300s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 3)
-        if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        id: checkout_retry_2
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+            filter: blob:none
+          attempt_limit: 3
+          attempt_delay: 120000
 
       - name: 🐍 Use Python 3.11
         uses: actions/setup-python@v5
@@ -133,43 +106,16 @@ jobs:
           - "3.14"
     name: Ubuntu Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout (Attempt 1)
-        uses: actions/checkout@v4
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout
-
-      - name: ⏳ Wait for checkout retry 1
-        if: steps.checkout.outcome == 'failure'
-        run: sleep 120s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 2)
-        if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout_retry_1
-
-      - name: ⏳ Wait for checkout retry 2
-        if: steps.checkout_retry_1.outcome == 'failure'
-        run: sleep 300s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 3)
-        if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        id: checkout_retry_2
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+            filter: blob:none
+          attempt_limit: 3
+          attempt_delay: 120000
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -261,43 +207,16 @@ jobs:
           - "3.14"
     name: macOS Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout (Attempt 1)
-        uses: actions/checkout@v4
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout
-
-      - name: ⏳ Wait for checkout retry 1
-        if: steps.checkout.outcome == 'failure'
-        run: sleep 120s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 2)
-        if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout_retry_1
-
-      - name: ⏳ Wait for checkout retry 2
-        if: steps.checkout_retry_1.outcome == 'failure'
-        run: sleep 300s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 3)
-        if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        id: checkout_retry_2
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+            filter: blob:none
+          attempt_limit: 3
+          attempt_delay: 120000
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -414,43 +333,16 @@ jobs:
           - "3.14"
     name: Windows Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout (Attempt 1)
-        uses: actions/checkout@v4
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout
-
-      - name: ⏳ Wait for checkout retry 1
-        if: steps.checkout.outcome == 'failure'
-        run: sleep 120s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 2)
-        if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout_retry_1
-
-      - name: ⏳ Wait for checkout retry 2
-        if: steps.checkout_retry_1.outcome == 'failure'
-        run: sleep 300s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 3)
-        if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        id: checkout_retry_2
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+            filter: blob:none
+          attempt_limit: 3
+          attempt_delay: 120000
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
@@ -512,43 +404,16 @@ jobs:
           - "3.14"
     name: Windows ARM Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout (Attempt 1)
-        uses: actions/checkout@v4
+      - name: 🛎️ Checkout
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout
-
-      - name: ⏳ Wait for checkout retry 1
-        if: steps.checkout.outcome == 'failure'
-        run: sleep 120s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 2)
-        if: steps.checkout.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        continue-on-error: true
-        id: checkout_retry_1
-
-      - name: ⏳ Wait for checkout retry 2
-        if: steps.checkout_retry_1.outcome == 'failure'
-        run: sleep 300s
-        shell: bash
-
-      - name: 🛎️ Checkout (Attempt 3)
-        if: steps.checkout_retry_1.outcome == 'failure'
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-          filter: blob:none
-        id: checkout_retry_2
+          action: actions/checkout@v4
+          with: |
+            fetch-depth: 1
+            fetch-tags: false
+            filter: blob:none
+          attempt_limit: 3
+          attempt_delay: 120000
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -66,6 +66,7 @@ jobs:
           key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
           restore-keys: pylint-${{ runner.os }}-
 
+
       - name: 🔎 PyLint on Nuitka source code
         run: |
           python ./bin/check-nuitka-with-pylint

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,6 +69,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
@@ -109,6 +113,7 @@ jobs:
     needs: checks
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         python_version:
           - "3.8"
@@ -162,6 +167,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
@@ -169,6 +178,15 @@ jobs:
           sudo apt-get install patchelf gdb ccache libfuse2
           python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
+
+      - name: 🔧 Cache ccache data
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ matrix.python_version }}-
+            ccache-${{ runner.os }}-
 
       - name: ⚙️ Verbose scons output in compilation
         run: |
@@ -186,6 +204,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
+
           path: |
             *.xml
             standalone-binary-readelf.txt
@@ -209,6 +228,7 @@ jobs:
     needs: linux
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version:
           - "3.9"
@@ -261,6 +281,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
 
       - name: ⚙️ Verbose installation output for Python
         run: |
@@ -274,6 +298,15 @@ jobs:
         run: |
           pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
           pip install --no-python-version-warning --disable-pip-version-check .
+
+      - name: 🔧 Cache ccache data
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ matrix.python_version }}-
+            ccache-${{ runner.os }}-
 
       - name: Verbose scons output in compilation
         run: |
@@ -313,6 +346,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
+
           path: |
             *.xml
 
@@ -338,6 +372,7 @@ jobs:
     needs: linux
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version:
           - "3.7"
@@ -392,6 +427,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
 
       - uses: ilammy/msvc-dev-cmd@v1
 
@@ -414,6 +453,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
+
           path: |
             *.xml
 
@@ -427,6 +467,7 @@ jobs:
     needs: linux
     runs-on: windows-11-arm
     strategy:
+      fail-fast: false
       matrix:
         python_version:
           - "3.11"
@@ -477,6 +518,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-devel.txt
+            requirements.txt
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -501,6 +546,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-arm64-${{ matrix.python_version }}
+
           path: |
             *.xml
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -555,5 +555,3 @@ jobs:
           Get-ChildItem env:
           python -m nuitka --version
           python .\tests\run-tests --no-other-python --no-debug --skip-reflection-test --skip-all-cpython-tests --assume-yes-for-downloads
-
-          warm cache

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,6 +100,13 @@ jobs:
           key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
           restore-keys: nuitka-downloads-${{ runner.os }}-
 
+      - name: 🔧 Cache autoformat results
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka/autoformat
+          key: nuitka-autoformat-${{ runner.os }}-${{ hashFiles('nuitka/utils/requirements-private.txt') }}
+          restore-keys: nuitka-autoformat-${{ runner.os }}-
+
       - name: 🔎 Auto-format check on Nuitka source code
         run: |
           python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,12 +70,17 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - name: 🧳 Install Nuitka and dependencies
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+        shell: bash
 
       - name: 🔎 PyLint on Nuitka source code
         run: |
@@ -163,12 +168,17 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - name: 🧳 Install Nuitka and dependencies
         run: |
           sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+        shell: bash
 
       - name: ⚙️ Verbose scons output in compilation
         run: |
@@ -262,6 +272,11 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - name: ⚙️ Verbose installation output for Python
         run: |
           set -x
@@ -272,8 +287,8 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+        shell: bash
 
       - name: Verbose scons output in compilation
         run: |
@@ -393,12 +408,17 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+        shell: bash
 
       - name: Verbose scons output in compilation
         run: |
@@ -478,14 +498,19 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      - name: 🧰 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: arm64
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
-          pip install --no-python-version-warning --disable-pip-version-check .
+          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
+        shell: bash
 
       - name: Verbose scons output in compilation
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,12 +83,13 @@ jobs:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: |
-            requirements-devel.txt
+            nuitka/utils/requirements-private.txt
             requirements.txt
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r nuitka/utils/requirements-private.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements.txt
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: 🔧 Cache Nuitka downloads

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,65 +27,59 @@ jobs:
     runs-on: ubuntu-24.04
     name: Checks
     steps:
-      - name: 🛎️ Checkout
+      - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: ⏳ Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: ⏳ Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
 
       - name: 🐍 Use Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.11"
-          enable-cache: true
-
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          sudo rm -f /usr/bin/clang-format
-          uv pip install --python "$(command -v python)" -r requirements-devel.txt .
-        shell: bash
-
-      - name: 🔧 Cache PyLint results
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pylint
-          key: pylint-${{ runner.os }}-${{ hashFiles('requirements-devel.txt') }}
-          restore-keys: pylint-${{ runner.os }}-
+          sudo apt-get update
+          sudo apt-get install patchelf gdb ccache libfuse2
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: 🔎 PyLint on Nuitka source code
         run: |
           python ./bin/check-nuitka-with-pylint
-
-      - name: 🔧 Cache Nuitka downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/downloads
-          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: nuitka-downloads-${{ runner.os }}-
-
-      - name: 🔧 Cache autoformat results
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/autoformat
-          key: nuitka-autoformat-${{ runner.os }}-${{ hashFiles('nuitka/utils/requirements-private.txt') }}
-          restore-keys: nuitka-autoformat-${{ runner.os }}-
-
-      - name: 🔎 Auto-format check on Nuitka source code
-        run: |
-          python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
-
-      - name: 🔎 Specialized C code check
-        run: |
-          python ./bin/generate-specialized-c-code --check
-
-      - name: 🔎 Specialized Python code check
-        run: |
-          python ./bin/generate-specialized-python-code --check
 
       - name: 🔎 RestLint on Nuitka source code
         run: |
@@ -99,11 +93,22 @@ jobs:
         run: |
           python ./bin/check-nuitka-with-codespell
 
+      - name: 🔎 Auto-format check on Nuitka source code
+        run: |
+          python ./bin/autoformat-nuitka-source --check-only --assume-yes-for-downloads
+
+      - name: 🔎 Specialized C code check
+        run: |
+          python ./bin/generate-specialized-c-code --check
+
+      - name: 🔎 Specialized Python code check
+        run: |
+          python ./bin/generate-specialized-python-code --check
+
   linux:
     needs: checks
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
       matrix:
         python_version:
           - "3.8"
@@ -115,56 +120,55 @@ jobs:
           - "3.14"
     name: Ubuntu Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout
+      - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: ⏳ Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: ⏳ Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: ${{ matrix.python_version }}
-          enable-cache: true
-
-      - name: 📦 Cache apt packages
-        id: apt-cache
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-${{ runner.os }}-patchelf-gdb-ccache-libfuse2
-          restore-keys: apt-${{ runner.os }}-
-
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          if [ "${{ steps.apt-cache.outputs.cache-hit }}" != "true" ]; then
-            sudo apt-get update
-          fi
+          sudo apt-get update
           sudo apt-get install patchelf gdb ccache libfuse2
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
-      - name: 🔧 Cache ccache data
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt', 'requirements-devel.txt') }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ matrix.python_version }}-
-            ccache-${{ runner.os }}-
-
-      - name: 🔧 Cache Nuitka downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/downloads
-          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: nuitka-downloads-${{ runner.os }}-
+          python -m pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation
         run: |
@@ -182,7 +186,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
-
           path: |
             *.xml
             standalone-binary-readelf.txt
@@ -206,7 +209,6 @@ jobs:
     needs: linux
     runs-on: macos-latest
     strategy:
-      fail-fast: false
       matrix:
         python_version:
           - "3.9"
@@ -217,22 +219,48 @@ jobs:
           - "3.14"
     name: macOS Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout
+      - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: ⏳ Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: ⏳ Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: ${{ matrix.python_version }}
-          enable-cache: true
 
       - name: ⚙️ Verbose installation output for Python
         run: |
@@ -242,39 +270,10 @@ jobs:
           otool -l $(which python)
           ls -lR $(dirname $(dirname $(which python)))
 
-      - name: 📦 Cache Homebrew downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Caches/Homebrew/downloads
-          key: homebrew-${{ runner.os }}-${{ runner.arch }}-ccache
-
-      - name: 📦 Install system dependencies
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
-        run: brew install ccache
-
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
-      - name: 🔧 Cache ccache data
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt', 'requirements-devel.txt') }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ matrix.python_version }}-
-            ccache-${{ runner.os }}-
-
-      - name: 🔧 Cache Nuitka downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/downloads
-          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: nuitka-downloads-${{ runner.os }}-
+          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: Verbose scons output in compilation
         run: |
@@ -314,7 +313,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
-
           path: |
             *.xml
 
@@ -340,7 +338,6 @@ jobs:
     needs: linux
     runs-on: windows-latest
     strategy:
-      fail-fast: false
       matrix:
         python_version:
           - "3.7"
@@ -353,37 +350,55 @@ jobs:
           - "3.14"
     name: Windows Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout
+      - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: ⏳ Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: ⏳ Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: ${{ matrix.python_version }}
-          enable-cache: true
-
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
-      - name: 🔧 Cache Nuitka downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/downloads
-          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: nuitka-downloads-${{ runner.os }}-
+          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: Verbose scons output in compilation
         run: |
@@ -399,7 +414,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-${{ matrix.python_version }}
-
           path: |
             *.xml
 
@@ -413,7 +427,6 @@ jobs:
     needs: linux
     runs-on: windows-11-arm
     strategy:
-      fail-fast: false
       matrix:
         python_version:
           - "3.11"
@@ -422,22 +435,48 @@ jobs:
           - "3.14"
     name: Windows ARM Python ${{ matrix.python_version }}
     steps:
-      - name: 🛎️ Checkout
+      - name: 🛎️ Checkout (Attempt 1)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout
+
+      - name: ⏳ Wait for checkout retry 1
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 120s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        continue-on-error: true
+        id: checkout_retry_1
+
+      - name: ⏳ Wait for checkout retry 2
+        if: steps.checkout_retry_1.outcome == 'failure'
+        run: sleep 300s
+        shell: bash
+
+      - name: 🛎️ Checkout (Attempt 3)
+        if: steps.checkout_retry_1.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+          filter: blob:none
+        id: checkout_retry_2
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-
-      - name: 🧰 Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: ${{ matrix.python_version }}
-          enable-cache: true
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -445,16 +484,8 @@ jobs:
 
       - name: 🧳 Install Nuitka and dependencies
         run: |
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" -r requirements-devel.txt
-          uv pip install --python "$(python -c 'import sys; print(sys.executable)')" .
-        shell: bash
-
-      - name: 🔧 Cache Nuitka downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Nuitka/downloads
-          key: nuitka-downloads-${{ runner.os }}-${{ runner.arch }}
-          restore-keys: nuitka-downloads-${{ runner.os }}-
+          pip install --no-python-version-warning --disable-pip-version-check -r requirements-devel.txt
+          pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: Verbose scons output in compilation
         run: |
@@ -470,7 +501,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compilation-reports-${{ runner.os }}-arm64-${{ matrix.python_version }}
-
           path: |
             *.xml
 

--- a/nuitka/tools/quality/pylint/PyLint.py
+++ b/nuitka/tools/quality/pylint/PyLint.py
@@ -180,7 +180,7 @@ redefined-slots-in-subclass
 --enable=useless-suppression
 --msg-template="{path}:{line} {msg_id} {symbol} {obj} {msg}"
 --reports=no
---persistent=no
+--persistent=yes
 --method-rgx=[a-z_][a-zA-Z0-9_]{2,55}$
 --module-rgx=.*
 --function-rgx=.*

--- a/nuitka/tools/quality/pylint/PyLint.py
+++ b/nuitka/tools/quality/pylint/PyLint.py
@@ -31,10 +31,10 @@ def checkVersion():
     if _pylint_version is None:
         try:
             import pylint
-
-            _pylint_version = getattr(pylint, "__version__", None)
-        except Exception:
+        except ImportError:
             _pylint_version = None
+        else:
+            _pylint_version = getattr(pylint, "__version__", None)
 
         if _pylint_version is None:
             with getNullOutput() as null_output:

--- a/nuitka/tools/quality/pylint/PyLint.py
+++ b/nuitka/tools/quality/pylint/PyLint.py
@@ -29,15 +29,24 @@ def checkVersion():
         )
 
     if _pylint_version is None:
-        with getNullOutput() as null_output:
-            _pylint_version = check_output(
-                [os.environ["PYTHON"], "-m", "pylint", "--version"], stderr=null_output
-            )
+        try:
+            import pylint
 
-        if str is not bytes:
-            _pylint_version = _pylint_version.decode("utf8")
+            _pylint_version = getattr(pylint, "__version__", None)
+        except Exception:
+            _pylint_version = None
 
-        _pylint_version = _pylint_version.split("\n")[0].split()[-1].strip(",")
+        if _pylint_version is None:
+            with getNullOutput() as null_output:
+                _pylint_version = check_output(
+                    [os.environ["PYTHON"], "-m", "pylint", "--version"],
+                    stderr=null_output,
+                )
+
+            if str is not bytes:
+                _pylint_version = _pylint_version.decode("utf8")
+
+            _pylint_version = _pylint_version.split("\n")[0].split()[-1].strip(",")
 
     my_print("Using PyLint version:", _pylint_version)
 

--- a/nuitka/tools/quality/pylint/PyLint.py
+++ b/nuitka/tools/quality/pylint/PyLint.py
@@ -189,7 +189,7 @@ redefined-slots-in-subclass
 --enable=useless-suppression
 --msg-template="{path}:{line} {msg_id} {symbol} {obj} {msg}"
 --reports=no
---persistent=yes
+--persistent=no
 --method-rgx=[a-z_][a-zA-Z0-9_]{2,55}$
 --module-rgx=.*
 --function-rgx=.*

--- a/nuitka/tools/quality/pyright/Pyright.py
+++ b/nuitka/tools/quality/pyright/Pyright.py
@@ -41,7 +41,10 @@ def _findPyrightBinary(basedpyright):
     pyright_binary = getExecutablePath(binary_name, extra_dir=extra_path)
 
     if pyright_binary is None:
-        return None
+        sys.exit(
+            "Error, %s is not installed. Install it with 'npm install -g %s'."
+            % (binary_name, binary_name)
+        )
 
     return pyright_binary
 
@@ -63,9 +66,6 @@ def getPyrightVersion(basedpyright):
 
     if _pyright_version is None:
         pyright_binary = _findPyrightBinary(basedpyright=basedpyright)
-
-        if pyright_binary is None:
-            return None
 
         version_output = check_output([pyright_binary, "--version"])
 
@@ -89,13 +89,6 @@ def _buildPyrightCommand(filenames, extra_options, basedpyright):
         List of command arguments.
     """
     pyright_binary = _findPyrightBinary(basedpyright=basedpyright)
-
-    if pyright_binary is None:
-        binary_name = "basedpyright" if basedpyright else "pyright"
-        sys.exit(
-            "Error, %s is not installed. Install it with 'npm install -g %s'."
-            % (binary_name, binary_name)
-        )
 
     command = [pyright_binary]
 
@@ -183,12 +176,6 @@ def executePyright(filenames, verbose, basedpyright):
     filenames = list(filenames)
 
     version = getPyrightVersion(basedpyright=basedpyright)
-    if version is None:
-        tool_name = "basedpyright" if basedpyright else "pyright"
-        sys.exit(
-            "Error, %s is not installed. Install it with 'npm install -g %s'."
-            % (tool_name, tool_name)
-        )
 
     tool_name = "basedpyright" if basedpyright else "pyright"
     my_print("Using %s version:" % tool_name, version)

--- a/nuitka/tools/quality/pyright/Pyright.py
+++ b/nuitka/tools/quality/pyright/Pyright.py
@@ -41,10 +41,7 @@ def _findPyrightBinary(basedpyright):
     pyright_binary = getExecutablePath(binary_name, extra_dir=extra_path)
 
     if pyright_binary is None:
-        sys.exit(
-            "Error, %s is not installed. Install it with 'npm install -g %s'."
-            % (binary_name, binary_name)
-        )
+        return None
 
     return pyright_binary
 
@@ -66,6 +63,9 @@ def getPyrightVersion(basedpyright):
 
     if _pyright_version is None:
         pyright_binary = _findPyrightBinary(basedpyright=basedpyright)
+
+        if pyright_binary is None:
+            return None
 
         version_output = check_output([pyright_binary, "--version"])
 
@@ -89,6 +89,13 @@ def _buildPyrightCommand(filenames, extra_options, basedpyright):
         List of command arguments.
     """
     pyright_binary = _findPyrightBinary(basedpyright=basedpyright)
+
+    if pyright_binary is None:
+        binary_name = "basedpyright" if basedpyright else "pyright"
+        sys.exit(
+            "Error, %s is not installed. Install it with 'npm install -g %s'."
+            % (binary_name, binary_name)
+        )
 
     command = [pyright_binary]
 
@@ -176,6 +183,12 @@ def executePyright(filenames, verbose, basedpyright):
     filenames = list(filenames)
 
     version = getPyrightVersion(basedpyright=basedpyright)
+    if version is None:
+        tool_name = "basedpyright" if basedpyright else "pyright"
+        sys.exit(
+            "Error, %s is not installed. Install it with 'npm install -g %s'."
+            % (tool_name, tool_name)
+        )
 
     tool_name = "basedpyright" if basedpyright else "pyright"
     my_print("Using %s version:" % tool_name, version)


### PR DESCRIPTION
## Summary

- Testing workflow uses `actions/setup-python@v5` to select the requested Python version and `astral-sh/setup-uv` to provide `uv`.
- Dependency installation uses `uv pip` as the pip-compatible install layer.
- PyLint version detection reads `pylint.__version__` when available and falls back to `python -m pylint --version`.
