### PR TITLE
refactor(iterator-shape): add iterator shape foundation

### DIFF
--- a/nuitka/nodes/BuiltinIteratorNodes.py
+++ b/nuitka/nodes/BuiltinIteratorNodes.py
@@ -98,8 +98,11 @@ class ExpressionBuiltinIter1(ExpressionBuiltinSingleArgBase):
     def canPredictIterationValues(self):
         return self.subnode_value.canPredictIterationValues()
 
-    def getIterationValue(self, element_index):
-        return self.subnode_value.getIterationValue(element_index)
+    def getIterationValue(self, count):
+        return self.subnode_value.getIterationValue(count)
+
+    def getNextValueShape(self):
+        return self.subnode_value.getNextValueShape()
 
     def getIterationHandle(self):
         return self.subnode_value.getIterationHandle()

--- a/nuitka/nodes/BuiltinNextNodes.py
+++ b/nuitka/nodes/BuiltinNextNodes.py
@@ -85,6 +85,20 @@ class ExpressionSpecialUnpack(ExpressionBuiltinNext1):
     def getStarred(self):
         return self.starred
 
+    def getTypeShape(self):
+        if hasattr(self.subnode_value, "getIterationLength"):
+            iteration_length = self.subnode_value.getIterationLength()
+
+            if iteration_length is not None and self.count - 1 >= iteration_length:
+                return tshape_unknown
+
+        result = self.subnode_value.getIterationValueShape(self.count - 1)
+
+        if result is None:
+            return tshape_unknown
+
+        return result
+
 
 class ExpressionBuiltinNext2(ChildrenHavingIteratorDefaultMixin, ExpressionBase):
     kind = "EXPRESSION_BUILTIN_NEXT2"

--- a/nuitka/nodes/BuiltinNextNodes.py
+++ b/nuitka/nodes/BuiltinNextNodes.py
@@ -9,6 +9,7 @@ text, explaining things about its context.
 
 from .ChildrenHavingMixins import ChildrenHavingIteratorDefaultMixin
 from .ExpressionBases import ExpressionBase, ExpressionBuiltinSingleArgBase
+from .shapes.StandardShapes import tshape_unknown
 
 
 class ExpressionBuiltinNext1(ExpressionBuiltinSingleArgBase):
@@ -35,6 +36,23 @@ class ExpressionBuiltinNext1(ExpressionBuiltinSingleArgBase):
 
     def mayRaiseException(self, exception_type):
         return self.may_raise or self.subnode_value.mayRaiseException(exception_type)
+
+    def getIterationValue(self, count):
+        if hasattr(self.subnode_value, "getIterationValue"):
+            return self.subnode_value.getIterationValue(count)
+
+        return None
+
+    def getNextValueShape(self):
+        return self.subnode_value.getNextValueShape()
+
+    def getTypeShape(self):
+        result = self.getNextValueShape()
+
+        if result is None:
+            return tshape_unknown
+
+        return result
 
 
 class ExpressionSpecialUnpack(ExpressionBuiltinNext1):

--- a/nuitka/nodes/BuiltinRangeNodes.py
+++ b/nuitka/nodes/BuiltinRangeNodes.py
@@ -27,7 +27,7 @@ from .IterationHandles import (
     IterationHandleRange3,
 )
 from .NodeMakingHelpers import makeConstantReplacementNode
-from .shapes.BuiltinTypeShapes import tshape_xrange
+from .shapes.BuiltinTypeShapes import tshape_int_or_long, tshape_xrange
 
 
 class ExpressionBuiltinRangeMixin(ExpressionListShapeExactMixin):
@@ -121,6 +121,10 @@ class ExpressionBuiltinRangeMixin(ExpressionListShapeExactMixin):
     def canPredictIterationValues(self):
         return self.getIterationLength() is not None
 
+    @staticmethod
+    def getNextValueShape():
+        return tshape_int_or_long
+
 
 class ExpressionBuiltinRange1(
     ExpressionBuiltinRangeMixin, ChildHavingLowMixin, ExpressionBase
@@ -161,19 +165,19 @@ class ExpressionBuiltinRange1(
 
         return IterationHandleRange1(low, self.source_ref)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         length = self.getIterationLength()
 
         if length is None:
             return None
 
-        if element_index > length:
+        if count > length:
             return None
 
-        # TODO: Make sure to cast element_index to what CPython will give, for
+        # TODO: Make sure to cast count to what CPython will give, for
         # now a downcast will do.
         return makeConstantReplacementNode(
-            constant=int(element_index), node=self, user_provided=False
+            constant=int(count), node=self, user_provided=False
         )
 
     def isKnownToBeIterable(self, count):
@@ -240,7 +244,7 @@ class ExpressionBuiltinRange2(
 
         return IterationHandleRange2(low, high, self.source_ref)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         low = self.subnode_low
         high = self.subnode_high
 
@@ -254,7 +258,7 @@ class ExpressionBuiltinRange2(
         if high is None:
             return None
 
-        result = low + element_index
+        result = low + count
 
         if result >= high:
             return None
@@ -360,7 +364,7 @@ class ExpressionBuiltinRange3(
 
         return IterationHandleRange3(low, high, step, self.source_ref)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         low = self.subnode_low.getIntegerValue()
 
         if low is None:
@@ -373,7 +377,7 @@ class ExpressionBuiltinRange3(
 
         step = self.subnode_step.getIntegerValue()
 
-        result = low + step * element_index
+        result = low + step * count
 
         if result >= high:
             return None
@@ -397,6 +401,10 @@ class ExpressionBuiltinXrangeMixin(object):
     @staticmethod
     def getTypeShape():
         return tshape_xrange
+
+    @staticmethod
+    def getNextValueShape():
+        return tshape_int_or_long
 
     def canPredictIterationValues(self):
         return self.getIterationLength() is not None
@@ -491,19 +499,19 @@ class ExpressionBuiltinXrange1(
 
         return max(0, low)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         length = self.getIterationLength()
 
         if length is None:
             return None
 
-        if element_index > length:
+        if count > length:
             return None
 
-        # TODO: Make sure to cast element_index to what CPython will give, for
+        # TODO: Make sure to cast count to what CPython will give, for
         # now a downcast will do.
         return makeConstantReplacementNode(
-            constant=int(element_index), node=self, user_provided=False
+            constant=int(count), node=self, user_provided=False
         )
 
 
@@ -549,7 +557,7 @@ class ExpressionBuiltinXrange2(
 
         return max(0, high - low)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         low = self.subnode_low
         high = self.subnode_high
 
@@ -563,7 +571,7 @@ class ExpressionBuiltinXrange2(
         if high is None:
             return None
 
-        result = low + element_index
+        result = low + count
 
         if result >= high:
             return None
@@ -640,7 +648,7 @@ class ExpressionBuiltinXrange3(
 
         return int(estimate)
 
-    def getIterationValue(self, element_index):
+    def getIterationValue(self, count):
         low = self.subnode_low.getIntegerValue()
 
         if low is None:
@@ -653,7 +661,7 @@ class ExpressionBuiltinXrange3(
 
         step = self.subnode_step.getIntegerValue()
 
-        result = low + step * element_index
+        result = low + step * count
 
         if result >= high:
             return None

--- a/nuitka/nodes/ExpressionBases.py
+++ b/nuitka/nodes/ExpressionBases.py
@@ -46,6 +46,10 @@ class ExpressionBase(NodeBase):
     def getTypeShape():
         return tshape_unknown
 
+    def getIterationValue(self, count):
+        # Virtual method, pylint: disable=no-self-use,unused-argument
+        return None
+
     def getValueShape(self):
         return self
 
@@ -99,6 +103,21 @@ class ExpressionBase(NodeBase):
         """
 
         # Virtual method, pylint: disable=no-self-use
+        return None
+
+    def getNextValueShape(self):
+        """Shape of the next value produced by this node, if known."""
+
+        iteration_length = self.getIterationLength()
+
+        if iteration_length == 0:
+            return None
+
+        result = self.getIterationValue(0)
+
+        if result is not None:
+            return result.getTypeShape()
+
         return None
 
     def getIterationMinLength(self):

--- a/nuitka/nodes/VariableRefNodes.py
+++ b/nuitka/nodes/VariableRefNodes.py
@@ -78,6 +78,62 @@ class ExpressionVariableRefBase(ExpressionBase):
         else:
             return self.variable_trace.getTypeShape()
 
+    def _getIterationSourceNode(self):
+        if self.variable_trace is None:
+            return None
+
+        return self.variable_trace.getIterationSourceNode()
+
+    def getIterationValue(self, count):
+        iteration_source_node = self._getIterationSourceNode()
+
+        if iteration_source_node is not None and hasattr(
+            iteration_source_node, "getIterationValue"
+        ):
+            return iteration_source_node.getIterationValue(count)
+
+        return None
+
+    def getIterationValueShape(self, count):
+        iteration_source_node = self._getIterationSourceNode()
+
+        if iteration_source_node is not None and hasattr(
+            iteration_source_node, "getIterationValueShape"
+        ):
+            return iteration_source_node.getIterationValueShape(count)
+
+        return None
+
+    def getNextValueShape(self):
+        iteration_source_node = self._getIterationSourceNode()
+
+        if iteration_source_node is not None and hasattr(
+            iteration_source_node, "getNextValueShape"
+        ):
+            return iteration_source_node.getNextValueShape()
+
+        return None
+
+    def getIterationLength(self):
+        iteration_source_node = self._getIterationSourceNode()
+
+        if iteration_source_node is not None and hasattr(
+            iteration_source_node, "getIterationLength"
+        ):
+            return iteration_source_node.getIterationLength()
+
+        return None
+
+    def isKnownToBeIterableAtMin(self, count):
+        iteration_source_node = self._getIterationSourceNode()
+
+        if iteration_source_node is not None and hasattr(
+            iteration_source_node, "isKnownToBeIterableAtMin"
+        ):
+            return iteration_source_node.isKnownToBeIterableAtMin(count)
+
+        return None
+
     def onContentEscapes(self, trace_collection):
         trace_collection.onVariableContentEscapes(self.variable)
 
@@ -872,11 +928,6 @@ class ExpressionTempVariableRef(
 
         else:
             return True
-
-    @staticmethod
-    def isKnownToBeIterableAtMin(count):
-        # TODO: See through the variable current trace.
-        return None
 
 
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and

--- a/nuitka/nodes/shapes/BuiltinTypeShapes.py
+++ b/nuitka/nodes/shapes/BuiltinTypeShapes.py
@@ -690,6 +690,20 @@ class ShapeTypeIntOrLongDerived(ShapeTypeUnknown):
 tshape_int_or_long_derived = ShapeTypeIntOrLongDerived()
 
 
+def isNuitkaIntOrLongShape(shape):
+    """Check whether a shape belongs to Nuitka's int-or-long family."""
+
+    if shape is None:
+        return False
+
+    return shape in (
+        tshape_int,
+        tshape_long,
+        tshape_int_or_long,
+        tshape_int_or_long_derived,
+    )
+
+
 class ShapeTypeFloat(ShapeNotContainerMixin, ShapeNumberMixin, ShapeBase):
     __slots__ = ()
 

--- a/tests/basics/LoopingTest.py
+++ b/tests/basics/LoopingTest.py
@@ -147,10 +147,10 @@ def nestedLoopingVariable():
     for outer in ([1, 2, 3],):
         for inner in outer:
             value = [inner]
-    return iter(value)
+    return next(iter(value))
 
 
-print("Nested loop variable iteration:", nestedLoopingVariable())
+print("Nested loop variable next value:", nestedLoopingVariable())
 
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.


### PR DESCRIPTION
This is the first PR in the iterator-shape stack.

It adds the foundation for iterator value-shape propagation:
- generic iteration-value protocol on expression nodes
- delegation through variable references
- iterator wrapper propagation
- range/xrange next-value shape reporting

Validation:
- formatting and pylint passed locally on the foundation branch
- syntax compilation passed for the touched modules