### PR TITLE
iterative tree traversal in ops

### DIFF
--- a/nuitka/tree/Operations.py
+++ b/nuitka/tree/Operations.py
@@ -10,15 +10,19 @@ You can visit a scope, a tree (module), or every scope of a tree (module).
 
 
 def visitTree(tree, visitor):
-    visitor.onEnterNode(tree)
+    stack = [(tree, False)]
+    while stack:
+        node, phase = stack.pop()
+        if not phase:
+            visitor.onEnterNode(node)
+            stack.append((node, True))
+            for child in reversed(list(node.getVisitableNodes())):
+                if child is None:
+                    raise AssertionError("'None' child encountered", tree, node.source_ref)
+                stack.append((child, False))
+        else:
+            visitor.onLeaveNode(node)
 
-    for visitable in tree.getVisitableNodes():
-        if visitable is None:
-            raise AssertionError("'None' child encountered", tree, tree.source_ref)
-
-        visitTree(visitable, visitor)
-
-    visitor.onLeaveNode(tree)
 
 
 class VisitorNoopMixin(object):

--- a/nuitka/tree/Operations.py
+++ b/nuitka/tree/Operations.py
@@ -18,7 +18,7 @@ def visitTree(tree, visitor):
             stack.append((node, True))
             for child in reversed(list(node.getVisitableNodes())):
                 if child is None:
-                    raise AssertionError("'None' child encountered", tree, node.source_ref)
+                    raise AssertionError("'None' child encountered", node, node.source_ref)
                 stack.append((child, False))
         else:
             visitor.onLeaveNode(node)


### PR DESCRIPTION
iterative tree traversal

## Summary by Sourcery

Replace recursive tree traversal with an iterative stack-based traversal in the visitor.

Bug Fixes:
- Strengthen validation for 'None' child nodes during tree traversal by checking each child node before visiting.

Enhancements:
- Use an explicit stack to traverse the tree iteratively instead of relying on recursion, preserving enter/leave node callbacks and improving robustness for deep trees.