### PR TITLE
Fix finalization of dead trailing statements

### DIFF
--- a/nuitka/nodes/FrameNodes.py
+++ b/nuitka/nodes/FrameNodes.py
@@ -201,9 +201,7 @@ class StatementsFrameBase(StatementsSequenceMixin, StatementsSequenceBase):
                         "Removed dead statements.",
                     )
 
-                    dead_statements = statements[count + 1 :]
-
-                    for s in dead_statements:
+                    for s in statements[count + 1 :]:
                         s.finalize()
 
                     break

--- a/nuitka/nodes/FrameNodes.py
+++ b/nuitka/nodes/FrameNodes.py
@@ -201,6 +201,11 @@ class StatementsFrameBase(StatementsSequenceMixin, StatementsSequenceBase):
                         "Removed dead statements.",
                     )
 
+                    dead_statements = statements[count + 1 :]
+
+                    for s in dead_statements:
+                        s.finalize()
+
                     break
 
         if not new_statements:

--- a/nuitka/nodes/StatementNodes.py
+++ b/nuitka/nodes/StatementNodes.py
@@ -154,7 +154,9 @@ class StatementsSequence(StatementsSequenceMixin, StatementsSequenceBase):
                         "Removed dead statements.",
                     )
 
-                    for s in statements[statements.index(statement) + 1 :]:
+                    dead_statements = statements[count + 1 :]
+
+                    for s in dead_statements:
                         s.finalize()
 
                     break

--- a/nuitka/nodes/StatementNodes.py
+++ b/nuitka/nodes/StatementNodes.py
@@ -154,9 +154,7 @@ class StatementsSequence(StatementsSequenceMixin, StatementsSequenceBase):
                         "Removed dead statements.",
                     )
 
-                    dead_statements = statements[count + 1 :]
-
-                    for s in dead_statements:
+                    for s in statements[count + 1 :]:
                         s.finalize()
 
                     break


### PR DESCRIPTION
When an aborting statement removes the remaining statements in a sequence, those removed statement nodes need to be finalized.

The plain statement sequence path already attempted this, but used a lookup from the statement object back into the list. This now uses the current loop position directly and names the removed tail as dead_statements.

The frame statement sequence path had the same dead-statement removal logic but did not finalize the removed trailing statements at all. This makes both paths consistent.

Verification:
- ./bin/autoformat-nuitka-source --diff --python
- uv run --with pylint==4.0.5 --with astroid==4.0.4 ./bin/check-nuitka-with-pylint --diff
- git diff --check
- uv run python -m py_compile nuitka/nodes/FrameNodes.py nuitka/nodes/StatementNodes.py

## Summary by Sourcery

Finalize dead trailing statements consistently in statement and frame sequences when an aborting statement removes the remaining sequence.

Bug Fixes:
- Ensure trailing dead statements in plain statement sequences are properly finalized after an aborting statement removes them.
- Finalize removed trailing statements in frame statement sequences to match the behavior of plain statement sequences.