### PR TITLE
MSYS2 Fix paths which are not normalized

### DIFF
--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -16,6 +16,7 @@ from nuitka.Tracing import scons_details_logger, scons_logger
 from nuitka.utils.Download import getCachedDownloadedMinGW64
 from nuitka.utils.FileOperations import (
     getFileSize,
+    getNormalizedPath,
     getNormalizedPathJoin,
     getReportPath,
     listDir,
@@ -846,9 +847,11 @@ def _addConstantBlobFileCode(env, blob_filename):
 
     blob_basename = os.path.basename(blob_filename)
     assert blob_basename.endswith(".bin"), blob_basename
-    constants_generated_filename = os.path.join(
-        env.source_dir,
-        "__constants_data_%s.c" % blob_basename[:-4],
+    constants_generated_filename = getNormalizedPath(
+        os.path.join(
+            env.source_dir,
+            "__constants_data_%s.c" % blob_basename[:-4],
+        )
     )
 
     def writeConstantsDataSource():

--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -16,7 +16,6 @@ from nuitka.Tracing import scons_details_logger, scons_logger
 from nuitka.utils.Download import getCachedDownloadedMinGW64
 from nuitka.utils.FileOperations import (
     getFileSize,
-    getNormalizedPath,
     getNormalizedPathJoin,
     getReportPath,
     listDir,
@@ -847,11 +846,9 @@ def _addConstantBlobFileCode(env, blob_filename):
 
     blob_basename = os.path.basename(blob_filename)
     assert blob_basename.endswith(".bin"), blob_basename
-    constants_generated_filename = getNormalizedPath(
-        os.path.join(
-            env.source_dir,
-            "__constants_data_%s.c" % blob_basename[:-4],
-        )
+    constants_generated_filename = getNormalizedPathJoin(
+        env.source_dir,
+        "__constants_data_%s.c" % blob_basename[:-4],
     )
 
     def writeConstantsDataSource():

--- a/nuitka/freezer/DllDependenciesWin32.py
+++ b/nuitka/freezer/DllDependenciesWin32.py
@@ -19,7 +19,7 @@ from nuitka.options.Options import (
     isShowProgress,
 )
 from nuitka.plugins.Hooks import getPluginsCacheContributionValues
-from nuitka.PythonFlavors import isAnacondaPython
+from nuitka.PythonFlavors import isAnacondaPython, isMSYS2MingwPython
 from nuitka.PythonVersions import getSystemPrefixPath
 from nuitka.Tracing import inclusion_logger
 from nuitka.utils.AppDirs import getCacheDir
@@ -524,6 +524,9 @@ def _getScanDirectories(package_name, original_dir, use_path):
         return _scan_dir_cache[cache_key]
 
     scan_dirs = [os.path.dirname(sys.executable), getSystemPrefixPath()]
+
+    if isMSYS2MingwPython():
+        scan_dirs.append(getNormalizedPathJoin(getSystemPrefixPath(), "bin"))
 
     # Add the VCRedist path to the list of directories to search if it exists
     msvc_redist_path = getMSVCRedistPath(logger=inclusion_logger)

--- a/nuitka/options/PathSpecs.py
+++ b/nuitka/options/PathSpecs.py
@@ -6,7 +6,7 @@
 import os
 
 from nuitka.Tracing import onefile_logger, options_logger
-from nuitka.utils.FileOperations import getUserInputNormalizedPath, isLegalPath
+from nuitka.utils.FileOperations import getNormalizedPathSep, getUserInputNormalizedPath, isLegalPath
 
 from .OptionParsing import run_time_variable_names
 
@@ -160,7 +160,7 @@ Absolute run time paths of '%s' can only be at the start of \
 start of '%s=%s', using that alone is not allowed.""" % (candidate, arg_name, value))
 
         if value.startswith(candidate) and candidate != "{PROGRAM_BASE}":
-            if value[len(candidate)] != os.path.sep:
+            if value[len(candidate)] != getNormalizedPathSep():
                 return options_logger.sysexit(
                     """Cannot use general system folder %s, without a path \
 separator '%s=%s', just appending to these is not allowed, needs to be \

--- a/nuitka/options/PathSpecs.py
+++ b/nuitka/options/PathSpecs.py
@@ -4,7 +4,11 @@
 """Path specifications and templating."""
 
 from nuitka.Tracing import onefile_logger, options_logger
-from nuitka.utils.FileOperations import getNormalizedPathSep, getUserInputNormalizedPath, isLegalPath
+from nuitka.utils.FileOperations import (
+    getNormalizedPathSep,
+    getUserInputNormalizedPath,
+    isLegalPath,
+)
 
 from .OptionParsing import run_time_variable_names
 

--- a/nuitka/options/PathSpecs.py
+++ b/nuitka/options/PathSpecs.py
@@ -3,8 +3,6 @@
 
 """Path specifications and templating."""
 
-import os
-
 from nuitka.Tracing import onefile_logger, options_logger
 from nuitka.utils.FileOperations import getNormalizedPathSep, getUserInputNormalizedPath, isLegalPath
 

--- a/nuitka/plugins/standard/DllFilesPlugin.py
+++ b/nuitka/plugins/standard/DllFilesPlugin.py
@@ -21,6 +21,7 @@ from nuitka.utils.Distributions import (
     isDistributionSystemPackage,
 )
 from nuitka.utils.FileOperations import (
+    getNormalizedPath,
     listDllFilesFromDirectory,
     listExeFilesFromDirectory,
 )
@@ -211,7 +212,7 @@ class NuitkaPluginDllFiles(NuitkaYamlPluginBase):
 
     def _handleDllConfigByCodeResult(self, filename, full_name, dest_path, executable):
         # Expecting absolute paths internally for DLL sources.
-        filename = os.path.abspath(filename)
+        filename = getNormalizedPath(os.path.abspath(filename))
 
         if dest_path is None:
             module_filename = self.locateModule(full_name)

--- a/nuitka/plugins/standard/DllFilesPlugin.py
+++ b/nuitka/plugins/standard/DllFilesPlugin.py
@@ -22,6 +22,7 @@ from nuitka.utils.Distributions import (
 )
 from nuitka.utils.FileOperations import (
     getNormalizedPath,
+    getNormalizedPathJoin,
     listDllFilesFromDirectory,
     listExeFilesFromDirectory,
 )
@@ -217,19 +218,17 @@ class NuitkaPluginDllFiles(NuitkaYamlPluginBase):
             if os.path.isdir(module_filename):
                 dest_path = full_name.asPath()
             else:
-                dest_path = os.path.join(full_name.asPath(), "..")
+                dest_path = getNormalizedPathJoin(full_name.asPath(), "..")
 
-            dest_path = os.path.join(
+            dest_path = getNormalizedPathJoin(
                 dest_path,
                 os.path.relpath(filename, os.path.dirname(module_filename)),
             )
         else:
-            dest_path = os.path.join(
+            dest_path = getNormalizedPathJoin(
                 dest_path,
                 os.path.basename(filename),
             )
-
-        dest_path = os.path.normpath(dest_path)
 
         if executable:
             return self.makeExeEntryPoint(
@@ -291,6 +290,8 @@ conditions are missing, or this version of the module needs treatment added."""
 
     def _handleDllConfig(self, dll_config, full_name, count):
         dest_path = dll_config.get("dest_path")
+        if dest_path is not None:
+            dest_path = getNormalizedPath(dest_path)
 
         found = False
 

--- a/nuitka/plugins/standard/DllFilesPlugin.py
+++ b/nuitka/plugins/standard/DllFilesPlugin.py
@@ -21,7 +21,7 @@ from nuitka.utils.Distributions import (
     isDistributionSystemPackage,
 )
 from nuitka.utils.FileOperations import (
-    getNormalizedAbsPath,
+    getNormalizedPath,
     listDllFilesFromDirectory,
     listExeFilesFromDirectory,
 )
@@ -280,7 +280,7 @@ conditions are missing, or this version of the module needs treatment added."""
         for filename in filenames:
             # We are otherwise expecting absolute paths internally for DLL sources, but we
             # shall tolerate relative paths by the config.
-            filename = getNormalizedAbsPath(filename)
+            filename = getNormalizedPath(os.path.abspath(filename))
 
             yield self._handleDllConfigByCodeResult(
                 filename=filename,

--- a/nuitka/plugins/standard/DllFilesPlugin.py
+++ b/nuitka/plugins/standard/DllFilesPlugin.py
@@ -211,9 +211,6 @@ class NuitkaPluginDllFiles(NuitkaYamlPluginBase):
                     )
 
     def _handleDllConfigByCodeResult(self, filename, full_name, dest_path, executable):
-        # Expecting absolute paths internally for DLL sources.
-        filename = getNormalizedAbsPath(filename)
-
         if dest_path is None:
             module_filename = self.locateModule(full_name)
 
@@ -281,6 +278,10 @@ conditions are missing, or this version of the module needs treatment added."""
             filenames = (filename,)
 
         for filename in filenames:
+            # We are otherwise expecting absolute paths internally for DLL sources, but we
+            # shall tolerate relative paths by the config.
+            filename = getNormalizedAbsPath(filename)
+
             yield self._handleDllConfigByCodeResult(
                 filename=filename,
                 full_name=full_name,

--- a/nuitka/plugins/standard/DllFilesPlugin.py
+++ b/nuitka/plugins/standard/DllFilesPlugin.py
@@ -21,7 +21,7 @@ from nuitka.utils.Distributions import (
     isDistributionSystemPackage,
 )
 from nuitka.utils.FileOperations import (
-    getNormalizedPath,
+    getNormalizedAbsPath,
     listDllFilesFromDirectory,
     listExeFilesFromDirectory,
 )
@@ -212,7 +212,7 @@ class NuitkaPluginDllFiles(NuitkaYamlPluginBase):
 
     def _handleDllConfigByCodeResult(self, filename, full_name, dest_path, executable):
         # Expecting absolute paths internally for DLL sources.
-        filename = getNormalizedPath(os.path.abspath(filename))
+        filename = getNormalizedAbsPath(filename)
 
         if dest_path is None:
             module_filename = self.locateModule(full_name)

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -2090,15 +2090,6 @@ def getNormalizedPathSep():
     return getNormalizedPath(os.path.sep)
 
 
-def getNormalizedAbsPath(path):
-    """Return abspath of path elements as a normalized path that is also a native path,
-       i.e. only legal characters.
-
-    Needed, because MSYS2 likes to keep "/" in normalized paths.
-    """
-    return getNormalizedPath(os.path.abspath(path))
-
-
 def doesFileContainBytes(filename, search):
     """Check if a file contains a specific byte sequence.
 

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -2082,10 +2082,9 @@ def getNormalizedPathJoin(*paths):
 
 
 def getNormalizedPathSep():
-    """Return the path separator as a normalized path that is also a native path,
-       i.e. only legal characters.
+    """Return the normalized native path separator.
 
-    Needed, because MSYS2 likes to keep "/" in normalized paths.
+    Needed, because on MSYS2 'os.path.sep' is '/' rather than the native '\\'.
     """
     return getNormalizedPath(os.path.sep)
 

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -2080,6 +2080,14 @@ def getNormalizedPathJoin(*paths):
     """
     return getNormalizedPath(os.path.join(*paths))
 
+def getNormalizedPathSep():
+    """Return the path separator as a normalized path that is also a native path,
+       i.e. only legal characters.
+
+    Needed, because MSYS2 likes to keep "/" in normalized paths.
+    """
+    return getNormalizedPath(os.path.sep)
+
 def getNormalizedAbsPath(path):
     """Return abspath of path elements as a normalized path that is also a native path,
        i.e. only legal characters.

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -2080,6 +2080,14 @@ def getNormalizedPathJoin(*paths):
     """
     return getNormalizedPath(os.path.join(*paths))
 
+def getNormalizedAbsPath(path):
+    """Return abspath of path elements as a normalized path that is also a native path,
+       i.e. only legal characters.
+
+    Needed, because MSYS2 likes to keep "/" in normalized paths.
+    """
+    return getNormalizedPath(os.path.abspath(path))
+
 
 def doesFileContainBytes(filename, search):
     """Check if a file contains a specific byte sequence.

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -2080,6 +2080,7 @@ def getNormalizedPathJoin(*paths):
     """
     return getNormalizedPath(os.path.join(*paths))
 
+
 def getNormalizedPathSep():
     """Return the path separator as a normalized path that is also a native path,
        i.e. only legal characters.
@@ -2087,6 +2088,7 @@ def getNormalizedPathSep():
     Needed, because MSYS2 likes to keep "/" in normalized paths.
     """
     return getNormalizedPath(os.path.sep)
+
 
 def getNormalizedAbsPath(path):
     """Return abspath of path elements as a normalized path that is also a native path,


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Just like https://github.com/Nuitka/nuitka/commit/9fa5e1df6ca1a07399d7959b15bc3801c5d83f04, We should apply that workaround on these places as well.

## 🧐 Why was it initiated? Any relevant Issues?

Trying to compile something on MSYS2. But it fails.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Normalize generated C source and DLL configuration paths to improve path handling on MSYS2 and similar environments.

Bug Fixes:
- Ensure the generated __constants_data.c path is normalized to avoid issues on MSYS2 builds.
- Normalize absolute DLL source paths in the standard DLL files plugin to prevent path-related failures on MSYS2.