### PR TITLE
Cache normalized import directory entries

### DIFF
--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -600,6 +600,7 @@ ImportScanFinding = collections.namedtuple(
 )
 
 _list_dir_cache = {}
+_normalized_list_dir_cache = {}
 
 
 def listDirCached(path):
@@ -611,6 +612,20 @@ def listDirCached(path):
     return _list_dir_cache[path]
 
 
+def normalizedListDirCached(path):
+    """Cached normalized listing of a directory."""
+
+    if path not in _normalized_list_dir_cache:
+        normalized_entries = {}
+
+        for fullname, _filename in listDirCached(path):
+            normalized_entries[os.path.normcase(fullname)] = fullname
+
+        _normalized_list_dir_cache[path] = normalized_entries
+
+    return _normalized_list_dir_cache[path]
+
+
 def flushImportCache():
     """Clear import related caches.
 
@@ -619,6 +634,7 @@ def flushImportCache():
     as it throws away so much.
     """
     _list_dir_cache.clear()
+    _normalized_list_dir_cache.clear()
     module_search_cache.clear()
 
 
@@ -808,9 +824,13 @@ def _pickBestModuleScanCandidate(candidates):
         if candidate.found_in is None:
             return candidate
 
-        for fullname, _filename in listDirCached(candidate.found_in):
-            if fullname == candidate.full_path:
-                return candidate
+        if (
+            normalizedListDirCached(candidate.found_in).get(
+                os.path.normcase(candidate.full_path)
+            )
+            == candidate.full_path
+        ):
+            return candidate
 
     return None
 

--- a/nuitka/importing/Importing.py
+++ b/nuitka/importing/Importing.py
@@ -619,7 +619,12 @@ def normalizedListDirCached(path):
         normalized_entries = {}
 
         for fullname, _filename in listDirCached(path):
-            normalized_entries[os.path.normcase(fullname)] = fullname
+            normalized_fullname = os.path.normcase(fullname)
+
+            if normalized_fullname not in normalized_entries:
+                normalized_entries[normalized_fullname] = []
+
+            normalized_entries[normalized_fullname].append(fullname)
 
         _normalized_list_dir_cache[path] = normalized_entries
 
@@ -824,12 +829,11 @@ def _pickBestModuleScanCandidate(candidates):
         if candidate.found_in is None:
             return candidate
 
-        if (
-            normalizedListDirCached(candidate.found_in).get(
-                os.path.normcase(candidate.full_path)
-            )
-            == candidate.full_path
-        ):
+        normalized_entries = normalizedListDirCached(candidate.found_in).get(
+            os.path.normcase(candidate.full_path)
+        )
+
+        if normalized_entries is not None and candidate.full_path in normalized_entries:
             return candidate
 
     return None

--- a/nuitka/specs/ParameterSpecs.py
+++ b/nuitka/specs/ParameterSpecs.py
@@ -398,6 +398,11 @@ def matchCall(
     num_pos = len(positional)
     num_total = num_pos + len([p for p in pairs if p[0] not in kw_only_args])
     num_args = len(args)
+    arg_names = args + kw_only_args
+    arg_name_to_index = {}
+
+    for index, arg_name in enumerate(arg_names):
+        arg_name_to_index[arg_name] = index
 
     for arg, value in zip(args, positional):
         assign(arg, value)
@@ -406,8 +411,8 @@ def matchCall(
     if python_version >= 0x300 and not star_dict_arg:
         for pair in pairs:
             try:
-                arg_index = (args + kw_only_args).index(pair[0])
-            except ValueError:
+                arg_index = arg_name_to_index[pair[0]]
+            except KeyError:
                 if python_version < 0x370 and not improved:
                     template = "'%(arg_name)s' is an invalid keyword argument for this function"
                 elif python_version < 0x3D0 and not improved:

--- a/nuitka/specs/ParameterSpecs.py
+++ b/nuitka/specs/ParameterSpecs.py
@@ -148,11 +148,13 @@ class ParameterSpec(object):
 
     def checkParametersValid(self):
         arg_names = self.getParameterNames()
+        seen_names = set()
 
         # Check for duplicate arguments, could happen.
         for arg_name in arg_names:
-            if arg_names.count(arg_name) != 1:
+            if arg_name in seen_names:
                 return "duplicate argument '%s' in function definition" % arg_name
+            seen_names.add(arg_name)
 
         return None
 

--- a/nuitka/specs/ParameterSpecs.py
+++ b/nuitka/specs/ParameterSpecs.py
@@ -398,11 +398,9 @@ def matchCall(
     num_pos = len(positional)
     num_total = num_pos + len([p for p in pairs if p[0] not in kw_only_args])
     num_args = len(args)
-    arg_names = args + kw_only_args
-    arg_name_to_index = {}
-
-    for index, arg_name in enumerate(arg_names):
-        arg_name_to_index[arg_name] = index
+    arg_name_to_index = dict(
+        (arg_name, index) for index, arg_name in enumerate(args + kw_only_args)
+    )
 
     for arg, value in zip(args, positional):
         assign(arg, value)

--- a/tests/basics/ImportingTest.py
+++ b/tests/basics/ImportingTest.py
@@ -3,6 +3,51 @@
 
 from __future__ import print_function
 
+import os
+
+from nuitka.importing import Importing as ImportingModule
+from nuitka.importing.Importing import (
+    flushImportCache,
+    normalizedListDirCached,
+)
+
+
+def testNormalizedListDirCacheKeepsCaseVariants():
+    original_list_dir_cached = ImportingModule.listDirCached
+    original_normcase = ImportingModule.os.path.normcase
+
+    try:
+
+        def fakeListDirCached(path):
+            return (
+                (os.path.join(path, "Spam.py"), "Spam.py"),
+                (os.path.join(path, "spam.py"), "spam.py"),
+            )
+
+        def fakeNormcase(path):
+            return path.lower()
+
+        ImportingModule.listDirCached = fakeListDirCached
+        ImportingModule.os.path.normcase = fakeNormcase
+        flushImportCache()
+
+        temp_dir = "/virtual/import-test"
+        normalized_entries = normalizedListDirCached(temp_dir)
+        case_key = fakeNormcase(os.path.join(temp_dir, "Spam.py"))
+
+        assert case_key in normalized_entries
+        assert normalized_entries[case_key] == [
+            os.path.join(temp_dir, "Spam.py"),
+            os.path.join(temp_dir, "spam.py"),
+        ]
+    finally:
+        ImportingModule.listDirCached = original_list_dir_cached
+        ImportingModule.os.path.normcase = original_normcase
+
+
+testNormalizedListDirCacheKeepsCaseVariants()
+print("Normalized import directory cache keeps case variants")
+
 
 def localImporter1():
     import os


### PR DESCRIPTION
Follow-up to https://github.com/Nuitka/Nuitka/pull/3942.

This adds a normalized-name cache for directory entries in `nuitka/importing/Importing.py` so case-insensitive module resolution can do constant-time lookups instead of rescanning the directory entries for each candidate.

## Summary by Sourcery

Cache normalized directory entries for case-insensitive module resolution and streamline parameter validation logic.

Enhancements:
- Add a cached, normalized directory listing to speed up case-insensitive module candidate selection during import resolution.
- Optimize function parameter validation by avoiding repeated linear scans for duplicate argument names and keyword argument indices.