### PR TITLE
Implement more str operation nodes

### DIFF
--- a/nuitka/nodes/AttributeNodesGenerated.py
+++ b/nuitka/nodes/AttributeNodesGenerated.py
@@ -105,6 +105,7 @@ from nuitka.specs.BuiltinListOperationSpecs import (
 from nuitka.specs.BuiltinParameterSpecs import extractBuiltinArgs
 from nuitka.specs.BuiltinStrOperationSpecs import (
     str_capitalize_spec,
+    str_casefold_spec,
     str_center_spec,
     str_count_spec,
     str_decode_spec,
@@ -116,8 +117,12 @@ from nuitka.specs.BuiltinStrOperationSpecs import (
     str_index_spec,
     str_isalnum_spec,
     str_isalpha_spec,
+    str_isdecimal_spec,
     str_isdigit_spec,
+    str_isidentifier_spec,
     str_islower_spec,
+    str_isnumeric_spec,
+    str_isprintable_spec,
     str_isspace_spec,
     str_istitle_spec,
     str_isupper_spec,
@@ -266,6 +271,7 @@ from .NodeMakingHelpers import (
 )
 from .StrNodes import (
     ExpressionStrOperationCapitalize,
+    ExpressionStrOperationCasefold,
     ExpressionStrOperationCenter2,
     ExpressionStrOperationCenter3,
     ExpressionStrOperationCount2,
@@ -290,8 +296,12 @@ from .StrNodes import (
     ExpressionStrOperationIndex4,
     ExpressionStrOperationIsalnum,
     ExpressionStrOperationIsalpha,
+    ExpressionStrOperationIsdecimal,
     ExpressionStrOperationIsdigit,
+    ExpressionStrOperationIsidentifier,
     ExpressionStrOperationIslower,
+    ExpressionStrOperationIsnumeric,
+    ExpressionStrOperationIsprintable,
     ExpressionStrOperationIsspace,
     ExpressionStrOperationIstitle,
     ExpressionStrOperationIsupper,
@@ -781,7 +791,45 @@ class ExpressionAttributeLookupStrCasefold(
     def computeExpression(self, trace_collection):
         return self, None, None
 
-    # No computeExpressionCall as str operation ExpressionStrOperationCasefold is not yet implemented
+    @staticmethod
+    def _computeExpressionCall(call_node, str_arg, trace_collection):
+        def wrapExpressionStrOperationCasefold(source_ref):
+            return ExpressionStrOperationCasefold(
+                str_arg=str_arg, source_ref=source_ref
+            )
+
+        # Anything may happen. On next pass, if replaced, we might be better
+        # but not now.
+        trace_collection.onExceptionRaiseExit(BaseException)
+
+        result = extractBuiltinArgs(
+            node=call_node,
+            builtin_class=wrapExpressionStrOperationCasefold,
+            builtin_spec=str_casefold_spec,
+        )
+
+        return result, "new_expression", "Call to 'casefold' of str recognized."
+
+    def computeExpressionCall(self, call_node, call_args, call_kw, trace_collection):
+        return self._computeExpressionCall(
+            call_node, self.subnode_expression, trace_collection
+        )
+
+    def computeExpressionCallViaVariable(
+        self, call_node, variable_ref_node, call_args, call_kw, trace_collection
+    ):
+        str_node = makeExpressionAttributeLookup(
+            expression=variable_ref_node,
+            attribute_name="__self__",
+            # TODO: Would be nice to have the real source reference here, but it feels
+            # a bit expensive.
+            source_ref=variable_ref_node.source_ref,
+        )
+
+        return self._computeExpressionCall(call_node, str_node, trace_collection)
+
+    def mayRaiseException(self, exception_type):
+        return self.subnode_expression.mayRaiseException(exception_type)
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupStrCasefold)
@@ -3972,7 +4020,45 @@ class ExpressionAttributeLookupStrIsdecimal(
     def computeExpression(self, trace_collection):
         return self, None, None
 
-    # No computeExpressionCall as str operation ExpressionStrOperationIsdecimal is not yet implemented
+    @staticmethod
+    def _computeExpressionCall(call_node, str_arg, trace_collection):
+        def wrapExpressionStrOperationIsdecimal(source_ref):
+            return ExpressionStrOperationIsdecimal(
+                str_arg=str_arg, source_ref=source_ref
+            )
+
+        # Anything may happen. On next pass, if replaced, we might be better
+        # but not now.
+        trace_collection.onExceptionRaiseExit(BaseException)
+
+        result = extractBuiltinArgs(
+            node=call_node,
+            builtin_class=wrapExpressionStrOperationIsdecimal,
+            builtin_spec=str_isdecimal_spec,
+        )
+
+        return result, "new_expression", "Call to 'isdecimal' of str recognized."
+
+    def computeExpressionCall(self, call_node, call_args, call_kw, trace_collection):
+        return self._computeExpressionCall(
+            call_node, self.subnode_expression, trace_collection
+        )
+
+    def computeExpressionCallViaVariable(
+        self, call_node, variable_ref_node, call_args, call_kw, trace_collection
+    ):
+        str_node = makeExpressionAttributeLookup(
+            expression=variable_ref_node,
+            attribute_name="__self__",
+            # TODO: Would be nice to have the real source reference here, but it feels
+            # a bit expensive.
+            source_ref=variable_ref_node.source_ref,
+        )
+
+        return self._computeExpressionCall(call_node, str_node, trace_collection)
+
+    def mayRaiseException(self, exception_type):
+        return self.subnode_expression.mayRaiseException(exception_type)
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupStrIsdecimal)
@@ -4204,7 +4290,45 @@ class ExpressionAttributeLookupStrIsidentifier(
     def computeExpression(self, trace_collection):
         return self, None, None
 
-    # No computeExpressionCall as str operation ExpressionStrOperationIsidentifier is not yet implemented
+    @staticmethod
+    def _computeExpressionCall(call_node, str_arg, trace_collection):
+        def wrapExpressionStrOperationIsidentifier(source_ref):
+            return ExpressionStrOperationIsidentifier(
+                str_arg=str_arg, source_ref=source_ref
+            )
+
+        # Anything may happen. On next pass, if replaced, we might be better
+        # but not now.
+        trace_collection.onExceptionRaiseExit(BaseException)
+
+        result = extractBuiltinArgs(
+            node=call_node,
+            builtin_class=wrapExpressionStrOperationIsidentifier,
+            builtin_spec=str_isidentifier_spec,
+        )
+
+        return result, "new_expression", "Call to 'isidentifier' of str recognized."
+
+    def computeExpressionCall(self, call_node, call_args, call_kw, trace_collection):
+        return self._computeExpressionCall(
+            call_node, self.subnode_expression, trace_collection
+        )
+
+    def computeExpressionCallViaVariable(
+        self, call_node, variable_ref_node, call_args, call_kw, trace_collection
+    ):
+        str_node = makeExpressionAttributeLookup(
+            expression=variable_ref_node,
+            attribute_name="__self__",
+            # TODO: Would be nice to have the real source reference here, but it feels
+            # a bit expensive.
+            source_ref=variable_ref_node.source_ref,
+        )
+
+        return self._computeExpressionCall(call_node, str_node, trace_collection)
+
+    def mayRaiseException(self, exception_type):
+        return self.subnode_expression.mayRaiseException(exception_type)
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupStrIsidentifier)
@@ -4436,7 +4560,45 @@ class ExpressionAttributeLookupStrIsnumeric(
     def computeExpression(self, trace_collection):
         return self, None, None
 
-    # No computeExpressionCall as str operation ExpressionStrOperationIsnumeric is not yet implemented
+    @staticmethod
+    def _computeExpressionCall(call_node, str_arg, trace_collection):
+        def wrapExpressionStrOperationIsnumeric(source_ref):
+            return ExpressionStrOperationIsnumeric(
+                str_arg=str_arg, source_ref=source_ref
+            )
+
+        # Anything may happen. On next pass, if replaced, we might be better
+        # but not now.
+        trace_collection.onExceptionRaiseExit(BaseException)
+
+        result = extractBuiltinArgs(
+            node=call_node,
+            builtin_class=wrapExpressionStrOperationIsnumeric,
+            builtin_spec=str_isnumeric_spec,
+        )
+
+        return result, "new_expression", "Call to 'isnumeric' of str recognized."
+
+    def computeExpressionCall(self, call_node, call_args, call_kw, trace_collection):
+        return self._computeExpressionCall(
+            call_node, self.subnode_expression, trace_collection
+        )
+
+    def computeExpressionCallViaVariable(
+        self, call_node, variable_ref_node, call_args, call_kw, trace_collection
+    ):
+        str_node = makeExpressionAttributeLookup(
+            expression=variable_ref_node,
+            attribute_name="__self__",
+            # TODO: Would be nice to have the real source reference here, but it feels
+            # a bit expensive.
+            source_ref=variable_ref_node.source_ref,
+        )
+
+        return self._computeExpressionCall(call_node, str_node, trace_collection)
+
+    def mayRaiseException(self, exception_type):
+        return self.subnode_expression.mayRaiseException(exception_type)
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupStrIsnumeric)
@@ -4498,7 +4660,45 @@ class ExpressionAttributeLookupStrIsprintable(
     def computeExpression(self, trace_collection):
         return self, None, None
 
-    # No computeExpressionCall as str operation ExpressionStrOperationIsprintable is not yet implemented
+    @staticmethod
+    def _computeExpressionCall(call_node, str_arg, trace_collection):
+        def wrapExpressionStrOperationIsprintable(source_ref):
+            return ExpressionStrOperationIsprintable(
+                str_arg=str_arg, source_ref=source_ref
+            )
+
+        # Anything may happen. On next pass, if replaced, we might be better
+        # but not now.
+        trace_collection.onExceptionRaiseExit(BaseException)
+
+        result = extractBuiltinArgs(
+            node=call_node,
+            builtin_class=wrapExpressionStrOperationIsprintable,
+            builtin_spec=str_isprintable_spec,
+        )
+
+        return result, "new_expression", "Call to 'isprintable' of str recognized."
+
+    def computeExpressionCall(self, call_node, call_args, call_kw, trace_collection):
+        return self._computeExpressionCall(
+            call_node, self.subnode_expression, trace_collection
+        )
+
+    def computeExpressionCallViaVariable(
+        self, call_node, variable_ref_node, call_args, call_kw, trace_collection
+    ):
+        str_node = makeExpressionAttributeLookup(
+            expression=variable_ref_node,
+            attribute_name="__self__",
+            # TODO: Would be nice to have the real source reference here, but it feels
+            # a bit expensive.
+            source_ref=variable_ref_node.source_ref,
+        )
+
+        return self._computeExpressionCall(call_node, str_node, trace_collection)
+
+    def mayRaiseException(self, exception_type):
+        return self.subnode_expression.mayRaiseException(exception_type)
 
 
 attribute_typed_classes.add(ExpressionAttributeLookupStrIsprintable)

--- a/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
+++ b/nuitka/nodes/BuiltinOperationNodeBasesGenerated.py
@@ -183,7 +183,9 @@ class ExpressionBytesOperationCapitalizeBase(
         """Does the operation part raise an exception possibly."""
 
 
-class ExpressionStrOperationCasefoldBase(ChildHavingStrArgMixin, ExpressionBase):
+class ExpressionStrOperationCasefoldBase(
+    ExpressionStrShapeExactMixin, ChildHavingStrArgMixin, ExpressionBase
+):
     named_children = ("str_arg",)
 
     def __init__(self, str_arg, source_ref):
@@ -2742,7 +2744,9 @@ class ExpressionStrOperationIsasciiBase(ChildHavingStrArgMixin, ExpressionBase):
         """Does the operation part raise an exception possibly."""
 
 
-class ExpressionStrOperationIsdecimalBase(ChildHavingStrArgMixin, ExpressionBase):
+class ExpressionStrOperationIsdecimalBase(
+    ExpressionBoolShapeExactMixin, ChildHavingStrArgMixin, ExpressionBase
+):
     named_children = ("str_arg",)
 
     def __init__(self, str_arg, source_ref):
@@ -2860,7 +2864,9 @@ class ExpressionBytesOperationIsdigitBase(
         """Does the operation part raise an exception possibly."""
 
 
-class ExpressionStrOperationIsidentifierBase(ChildHavingStrArgMixin, ExpressionBase):
+class ExpressionStrOperationIsidentifierBase(
+    ExpressionBoolShapeExactMixin, ChildHavingStrArgMixin, ExpressionBase
+):
     named_children = ("str_arg",)
 
     def __init__(self, str_arg, source_ref):
@@ -2978,7 +2984,9 @@ class ExpressionBytesOperationIslowerBase(
         """Does the operation part raise an exception possibly."""
 
 
-class ExpressionStrOperationIsnumericBase(ChildHavingStrArgMixin, ExpressionBase):
+class ExpressionStrOperationIsnumericBase(
+    ExpressionBoolShapeExactMixin, ChildHavingStrArgMixin, ExpressionBase
+):
     named_children = ("str_arg",)
 
     def __init__(self, str_arg, source_ref):
@@ -3016,7 +3024,9 @@ class ExpressionStrOperationIsnumericBase(ChildHavingStrArgMixin, ExpressionBase
         """Does the operation part raise an exception possibly."""
 
 
-class ExpressionStrOperationIsprintableBase(ChildHavingStrArgMixin, ExpressionBase):
+class ExpressionStrOperationIsprintableBase(
+    ExpressionBoolShapeExactMixin, ChildHavingStrArgMixin, ExpressionBase
+):
     named_children = ("str_arg",)
 
     def __init__(self, str_arg, source_ref):

--- a/nuitka/nodes/ChildrenHavingMixins.py
+++ b/nuitka/nodes/ChildrenHavingMixins.py
@@ -17723,7 +17723,7 @@ class ChildHavingStrArgMixin(object):
     # This is generated for use in
     #   ExpressionStrOperationCapitalize
     #   ExpressionStrOperationCapitalizeBase
-    #   ExpressionStrOperationCasefoldBase
+    #   ExpressionStrOperationCasefold
     #   ExpressionStrOperationDecode1
     #   ExpressionStrOperationEncode1
     #   ExpressionStrOperationExpandtabs1
@@ -17732,11 +17732,12 @@ class ChildHavingStrArgMixin(object):
     #   ExpressionStrOperationIsalpha
     #   ExpressionStrOperationIsalphaBase
     #   ExpressionStrOperationIsasciiBase
-    #   ExpressionStrOperationIsdecimalBase
+    #   ExpressionStrOperationIsdecimal
     #   ExpressionStrOperationIsdigit
-    #   ExpressionStrOperationIsidentifierBase
+    #   ExpressionStrOperationIsidentifier
     #   ExpressionStrOperationIslower
-    #   ExpressionStrOperationIsnumericBase
+    #   ExpressionStrOperationIsnumeric
+    #   ExpressionStrOperationIsprintable
     #   ExpressionStrOperationIsprintableBase
     #   ExpressionStrOperationIsspace
     #   ExpressionStrOperationIsspaceBase
@@ -17851,7 +17852,7 @@ class ChildHavingStrArgMixin(object):
 # Assign the names that are easier to import with a stable name.
 ChildrenExpressionStrOperationCapitalizeMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationCapitalizeBaseMixin = ChildHavingStrArgMixin
-ChildrenExpressionStrOperationCasefoldBaseMixin = ChildHavingStrArgMixin
+ChildrenExpressionStrOperationCasefoldMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationDecode1Mixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationEncode1Mixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationExpandtabs1Mixin = ChildHavingStrArgMixin
@@ -17860,11 +17861,12 @@ ChildrenExpressionStrOperationIsalnumMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsalphaMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsalphaBaseMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsasciiBaseMixin = ChildHavingStrArgMixin
-ChildrenExpressionStrOperationIsdecimalBaseMixin = ChildHavingStrArgMixin
+ChildrenExpressionStrOperationIsdecimalMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsdigitMixin = ChildHavingStrArgMixin
-ChildrenExpressionStrOperationIsidentifierBaseMixin = ChildHavingStrArgMixin
+ChildrenExpressionStrOperationIsidentifierMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIslowerMixin = ChildHavingStrArgMixin
-ChildrenExpressionStrOperationIsnumericBaseMixin = ChildHavingStrArgMixin
+ChildrenExpressionStrOperationIsnumericMixin = ChildHavingStrArgMixin
+ChildrenExpressionStrOperationIsprintableMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsprintableBaseMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsspaceMixin = ChildHavingStrArgMixin
 ChildrenExpressionStrOperationIsspaceBaseMixin = ChildHavingStrArgMixin

--- a/nuitka/nodes/StrNodes.py
+++ b/nuitka/nodes/StrNodes.py
@@ -5,6 +5,7 @@
 
 from .BuiltinOperationNodeBasesGenerated import (
     ExpressionStrOperationCapitalizeBase,
+    ExpressionStrOperationCasefoldBase,
     ExpressionStrOperationCenter2Base,
     ExpressionStrOperationCenter3Base,
     ExpressionStrOperationCount2Base,
@@ -30,8 +31,12 @@ from .BuiltinOperationNodeBasesGenerated import (
     ExpressionStrOperationIndex4Base,
     ExpressionStrOperationIsalnumBase,
     ExpressionStrOperationIsalphaBase,
+    ExpressionStrOperationIsdecimalBase,
     ExpressionStrOperationIsdigitBase,
+    ExpressionStrOperationIsidentifierBase,
     ExpressionStrOperationIslowerBase,
+    ExpressionStrOperationIsnumericBase,
+    ExpressionStrOperationIsprintableBase,
     ExpressionStrOperationIsspaceBase,
     ExpressionStrOperationIstitleBase,
     ExpressionStrOperationIsupperBase,
@@ -338,6 +343,16 @@ class ExpressionStrOperationCapitalize(ExpressionStrOperationCapitalizeBase):
         return False
 
 
+class ExpressionStrOperationCasefold(ExpressionStrOperationCasefoldBase):
+    """This operation represents s.casefold()."""
+
+    kind = "EXPRESSION_STR_OPERATION_CASEFOLD"
+
+    @staticmethod
+    def mayRaiseExceptionOperation():
+        return False
+
+
 class ExpressionStrOperationUpper(ExpressionStrOperationUpperBase):
     """This operation represents s.upper()."""
 
@@ -408,10 +423,50 @@ class ExpressionStrOperationIsdigit(ExpressionStrOperationIsdigitBase):
         return False
 
 
+class ExpressionStrOperationIsdecimal(ExpressionStrOperationIsdecimalBase):
+    """This operation represents s.isdecimal()."""
+
+    kind = "EXPRESSION_STR_OPERATION_ISDECIMAL"
+
+    @staticmethod
+    def mayRaiseExceptionOperation():
+        return False
+
+
+class ExpressionStrOperationIsidentifier(ExpressionStrOperationIsidentifierBase):
+    """This operation represents s.isidentifier()."""
+
+    kind = "EXPRESSION_STR_OPERATION_ISIDENTIFIER"
+
+    @staticmethod
+    def mayRaiseExceptionOperation():
+        return False
+
+
 class ExpressionStrOperationIslower(ExpressionStrOperationIslowerBase):
     """This operation represents s.islower()."""
 
     kind = "EXPRESSION_STR_OPERATION_ISLOWER"
+
+    @staticmethod
+    def mayRaiseExceptionOperation():
+        return False
+
+
+class ExpressionStrOperationIsnumeric(ExpressionStrOperationIsnumericBase):
+    """This operation represents s.isnumeric()."""
+
+    kind = "EXPRESSION_STR_OPERATION_ISNUMERIC"
+
+    @staticmethod
+    def mayRaiseExceptionOperation():
+        return False
+
+
+class ExpressionStrOperationIsprintable(ExpressionStrOperationIsprintableBase):
+    """This operation represents s.isprintable()."""
+
+    kind = "EXPRESSION_STR_OPERATION_ISPRINTABLE"
 
     @staticmethod
     def mayRaiseExceptionOperation():

--- a/nuitka/specs/BuiltinStrOperationSpecs.py
+++ b/nuitka/specs/BuiltinStrOperationSpecs.py
@@ -95,6 +95,9 @@ str_format_spec = StrMethodSpec(
 str_capitalize_spec = StrMethodSpecNoKeywords(
     "capitalize", arg_names=(), type_shape=tshape_str
 )
+str_casefold_spec = StrMethodSpecNoKeywords(
+    "casefold", arg_names=(), type_shape=tshape_str
+)
 str_upper_spec = StrMethodSpecNoKeywords("upper", arg_names=(), type_shape=tshape_str)
 str_lower_spec = StrMethodSpecNoKeywords("lower", arg_names=(), type_shape=tshape_str)
 str_swapcase_spec = StrMethodSpecNoKeywords(
@@ -110,8 +113,20 @@ str_isalpha_spec = StrMethodSpecNoKeywords(
 str_isdigit_spec = StrMethodSpecNoKeywords(
     "isdigit", arg_names=(), type_shape=tshape_bool
 )
+str_isdecimal_spec = StrMethodSpecNoKeywords(
+    "isdecimal", arg_names=(), type_shape=tshape_bool
+)
+str_isidentifier_spec = StrMethodSpecNoKeywords(
+    "isidentifier", arg_names=(), type_shape=tshape_bool
+)
 str_islower_spec = StrMethodSpecNoKeywords(
     "islower", arg_names=(), type_shape=tshape_bool
+)
+str_isnumeric_spec = StrMethodSpecNoKeywords(
+    "isnumeric", arg_names=(), type_shape=tshape_bool
+)
+str_isprintable_spec = StrMethodSpecNoKeywords(
+    "isprintable", arg_names=(), type_shape=tshape_bool
 )
 str_isupper_spec = StrMethodSpecNoKeywords(
     "isupper", arg_names=(), type_shape=tshape_bool


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This adds the missing handwritten operation specs and node classes for several no-argument Python 3 `str` methods that already had generated base operation classes:

- `str.casefold()`
- `str.isdecimal()`
- `str.isidentifier()`
- `str.isnumeric()`
- `str.isprintable()`

After adding the specs/classes, the specialized Python code was regenerated so the corresponding generated attribute lookup nodes now lower calls to concrete `ExpressionStrOperation*` nodes instead of leaving them marked as not implemented.

## 🧐 Why was it initiated? Any relevant Issues?

Closes #3950.

The gap was found by checking the generated attribute-node comments for operations that were listed in `nuitka/tools/specialize/Common.py` and had generated base classes, but lacked handwritten operation nodes/specs.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - Checked generated specialized Python code and pylint for unpushed changes.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: I have created an issue explaining the problem *before* using AI to generate a fix, ensuring the direction is correct.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
  - [x] **Evidence**: I have included test evidence that the change is effective.

Prompts used:

- "use chiasmus"
- "no, use it on src/"
- "are we missing any more int / bytes etc nodes?"
- "let's switch to develop and let's draft up an issue for 8cb074b193a9de9d90f053317537cd02749a5c87 and let's draft up the independent PR"

Validation:

- `uv run --frozen --no-sync python ./bin/generate-specialized-python-code --check`
- `uv run --frozen --no-sync --with pylint==4.0.5 -m nuitka.tools.quality.pylint --un-pushed --assume-yes-for-downloads`

## Summary by Sourcery

Add missing operation nodes and specs for several no-argument string methods so their attribute lookups are fully supported and lowered to concrete operations.

Bug Fixes:
- Enable proper lowering and handling of str.casefold(), str.isdecimal(), str.isidentifier(), str.isnumeric(), and str.isprintable() calls by wiring attribute lookups to concrete expression nodes.

Enhancements:
- Define concrete expression node classes and precise type shapes for additional str operations and update associated child mixins and method specs to reflect their return types.