### PR TITLE
pefile: Prevent a latent resource leak

### DIFF
--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -1257,29 +1257,27 @@ def getPEFileUsedDllNames(filename):
     """
 
     pefile = importFromInlineCopy("pefile", must_exist=True)
-
     try:
-        pe_info = pefile.PE(filename)
+        with pefile.PE(filename) as pe_info:
+            pe_info.parse_data_directories(
+                directories=(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"],),
+                import_dllnames_only=True,  # spell-checker: ignore import_dllnames_only
+            )
+            pe_info.parse_data_directories(
+                directories=(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT"],)
+            )
+
+            result = OrderedSet()
+
+            for entry_name in ("DIRECTORY_ENTRY_IMPORT", "DIRECTORY_ENTRY_DELAY_IMPORT"):
+                for dll_entry in getattr(pe_info, entry_name, ()):
+                    # TODO: The PE/COFF docs describe these names as ASCII, but
+                    # they do not actually specify the encoding here.
+                    result.add(dll_entry.dll.decode("utf8"))
+
+            return result
     except pefile.PEFormatError:
         return None
-
-    pe_info.parse_data_directories(
-        directories=(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"],),
-        import_dllnames_only=True,  # spell-checker: ignore import_dllnames_only
-    )
-    pe_info.parse_data_directories(
-        directories=(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT"],)
-    )
-
-    result = OrderedSet()
-
-    for entry_name in ("DIRECTORY_ENTRY_IMPORT", "DIRECTORY_ENTRY_DELAY_IMPORT"):
-        for dll_entry in getattr(pe_info, entry_name, ()):
-            # TODO: The PE/COFF docs describe these names as ASCII, but
-            # they do not actually specify the encoding here.
-            result.add(dll_entry.dll.decode("utf8"))
-
-    return result
 
 
 def getDllExportedSymbols(logger, filename):
@@ -1287,15 +1285,14 @@ def getDllExportedSymbols(logger, filename):
         pefile = importFromInlineCopy("pefile", must_exist=True)
 
         try:
-            pe_info = pefile.PE(filename)
+            with pefile.PE(filename) as pe_info:
+                return tuple(
+                    _decodeWin32EntryPoint(entry_point.name)
+                    for entry_point in pe_info.DIRECTORY_ENTRY_EXPORT.symbols
+                    if entry_point.name is not None
+                )
         except pefile.PEFormatError:
             return None
-
-        return tuple(
-            _decodeWin32EntryPoint(entry_point.name)
-            for entry_point in pe_info.DIRECTORY_ENTRY_EXPORT.symbols
-            if entry_point.name is not None
-        )
     else:
         if isLinux() or isCoffUsingPlatform() or isBSD():
             command = ("nm", "-D", filename)

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -1264,12 +1264,17 @@ def getPEFileUsedDllNames(filename):
                 import_dllnames_only=True,  # spell-checker: ignore import_dllnames_only
             )
             pe_info.parse_data_directories(
-                directories=(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT"],)
+                directories=(
+                    pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT"],
+                )
             )
 
             result = OrderedSet()
 
-            for entry_name in ("DIRECTORY_ENTRY_IMPORT", "DIRECTORY_ENTRY_DELAY_IMPORT"):
+            for entry_name in (
+                "DIRECTORY_ENTRY_IMPORT",
+                "DIRECTORY_ENTRY_DELAY_IMPORT",
+            ):
                 for dll_entry in getattr(pe_info, entry_name, ()):
                     # TODO: The PE/COFF docs describe these names as ASCII, but
                     # they do not actually specify the encoding here.


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

### Summary
This PR wraps `pefile.PE` within a context manager to guarantee proper resource cleanup and prevent a latent resource leak in Nuitka.

### The Problem
Previously, Nuitka did not call `pefile.PE.close()` at the correct time. In most cases, this defect remained hidden because parsing a sufficiently large PE file would eventually trigger Python's implicit object destruction

However, if that large PE file happened to sit after the executable in the `dist` directory, the file handle remained locked. This caused a defect where removing the `dist` directory would fail because the file was still occupied by the process.

```
Nuitka:WARNING: Failed to delete 'test.dist' in attempt 1.
Disable Anti-Virus, e.g. Windows Defender for build folders.
Retrying after a second of delay.
Nuitka:WARNING: Failed to delete 'test.dist' in attempt 2.
Disable Anti-Virus, e.g. Windows Defender for build folders.
Retrying after a second of delay.
Nuitka:WARNING: Failed to delete 'test.dist' in attempt 3.
Disable Anti-Virus, e.g. Windows Defender for build folders.
Retrying after a second of delay.
Nuitka:WARNING: Failed to delete 'test.dist' in attempt 4.
Disable Anti-Virus, e.g. Windows Defender for build folders.
Retrying after a second of delay.
Nuitka:WARNING: Failed to delete 'test.dist' in attempt 5.
Disable Anti-Virus, e.g. Windows Defender for build folders.
Retrying after a second of delay.
FATAL: Failed to delete 'test.dist', the path is not fully removed.
```

### The Solution
By utilizing a standard context manager (`with` statement), we ensure that the PE file handle is closed explicitly and immediately after parsing, completely mitigating the resource leak.

## 🧐 Why was it initiated? Any relevant Issues?

<!-- Link to the issue or explain the motivation. -->

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Ensure PE files used for DLL name detection are processed via a context manager to guarantee timely resource cleanup and avoid lingering file locks.

Bug Fixes:
- Prevent latent file handle leaks when parsing PE files, eliminating failures when deleting build output directories on Windows.

Enhancements:
- Replace use of ruamel_yaml.compat._F with standard string formatting in YAML scalar construction error messages for simpler dependency usage.

Chores:
- Update private requirements file (contents not shown in diff).