### PR TITLE
Use `PyImport_CreateModuleFromInitfunc` for the meta path loader

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -177,14 +177,14 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.15 python3.15-dev python3.15-venv
-          echo "PYTHON=python3.15" >> $GITHUB_ENV
+          python3.15 -m venv .venv-3.15
+          echo "VIRTUAL_ENV=$PWD/.venv-3.15" >> $GITHUB_ENV
+          echo "$PWD/.venv-3.15/bin" >> $GITHUB_PATH
 
       - name: 🧳 Install Nuitka
         run: |
-          ${PYTHON:-python} -m ensurepip --upgrade
-          ${PYTHON:-python} -m pip install --upgrade --no-python-version-warning --disable-pip-version-check setuptools wheel
-          export PYTHONPATH="$(${PYTHON:-python} -m site --user-site):$PYTHONPATH"
-          ${PYTHON:-python} -m pip install --no-python-version-warning --disable-pip-version-check .
+          python -m pip install --upgrade --no-python-version-warning --disable-pip-version-check pip setuptools wheel
+          python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,6 +119,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
     name: Ubuntu Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout (Attempt 1)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,6 +183,7 @@ jobs:
         run: |
           ${PYTHON:-python} -m ensurepip --upgrade
           ${PYTHON:-python} -m pip install --upgrade --no-python-version-warning --disable-pip-version-check setuptools wheel
+          export PYTHONPATH="$(${PYTHON:-python} -m site --user-site):$PYTHONPATH"
           ${PYTHON:-python} -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -177,26 +177,23 @@ jobs:
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.15 python3.15-dev python3.15-venv
-          mkdir -p "$HOME/.local/python3.15/bin"
-          ln -s /usr/bin/python3.15 "$HOME/.local/python3.15/bin/python"
-          ln -s /usr/bin/python3.15 "$HOME/.local/python3.15/bin/python3"
-          echo "$HOME/.local/python3.15/bin" >> $GITHUB_PATH
+          echo "PYTHON=python3.15" >> $GITHUB_ENV
 
       - name: 🧳 Install Nuitka
         run: |
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade --no-python-version-warning --disable-pip-version-check setuptools wheel
-          python -m pip install --no-python-version-warning --disable-pip-version-check .
+          ${PYTHON:-python} -m ensurepip --upgrade
+          ${PYTHON:-python} -m pip install --upgrade --no-python-version-warning --disable-pip-version-check setuptools wheel
+          ${PYTHON:-python} -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation
         run: |
           set -x
-          python -m nuitka --mode=module --show-scons --run --report=compilation-report-module.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
-          python -m nuitka --mode=accelerated --show-scons --run --report=compilation-report-accelerated.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
-          python -m nuitka --mode=standalone --show-scons --run --report=compilation-report-standalone.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
+          ${PYTHON:-python} -m nuitka --mode=module --show-scons --run --report=compilation-report-module.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
+          ${PYTHON:-python} -m nuitka --mode=accelerated --show-scons --run --report=compilation-report-accelerated.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
+          ${PYTHON:-python} -m nuitka --mode=standalone --show-scons --run --report=compilation-report-standalone.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
           readelf -d EmptyModuleTest.dist/EmptyModuleTest.bin | tee standalone-binary-readelf.txt
           ldd EmptyModuleTest.dist/EmptyModuleTest.bin | tee standalone-binary-ldd.txt
-          python -m nuitka --mode=onefile --show-scons --run --report=compilation-report-onefile.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
+          ${PYTHON:-python} -m nuitka --mode=onefile --show-scons --run --report=compilation-report-onefile.xml --assume-yes-for-downloads --experimental=debug-report-traceback tests/basics/EmptyModuleTest.py
         shell: bash
 
       - name: 📤 Archive compilation reports for empty modules
@@ -219,9 +216,9 @@ jobs:
 
       - name: 🧪 Run Nuitka test suite
         run: |
-          python -m nuitka --version
+          ${PYTHON:-python} -m nuitka --version
           env | sort
-          python ./tests/run-tests --no-other-python --skip-reflection-test --skip-all-cpython-tests --assume-yes-for-downloads
+          ${PYTHON:-python} ./tests/run-tests --no-other-python --skip-reflection-test --skip-all-cpython-tests --assume-yes-for-downloads
 
   mac-python3:
     needs: linux

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -161,9 +161,19 @@ jobs:
         id: checkout_retry_2
 
       - name: 🐍 Use Python ${{ matrix.python_version }}
+        if: matrix.python_version != '3.15'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
+
+      - name: 🐍 Use Python 3.15 (deadsnakes)
+        if: matrix.python_version == '3.15'
+        run: |
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.15 python3.15-dev python3.15-venv
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.15 1
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.15 1
 
       - name: 🧳 Install Nuitka and dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -184,6 +184,8 @@ jobs:
 
       - name: 🧳 Install Nuitka
         run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade --no-python-version-warning --disable-pip-version-check setuptools wheel
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -166,19 +166,24 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: 🐍 Use Python 3.15 (deadsnakes)
+      - name: 🎒 Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf gdb ccache libfuse2
+
+      - name: 🐍 Install Python 3.15 (deadsnakes)
         if: matrix.python_version == '3.15'
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update
           sudo apt-get install -y python3.15 python3.15-dev python3.15-venv
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.15 1
-          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.15 1
+          mkdir -p "$HOME/.local/python3.15/bin"
+          ln -s /usr/bin/python3.15 "$HOME/.local/python3.15/bin/python"
+          ln -s /usr/bin/python3.15 "$HOME/.local/python3.15/bin/python3"
+          echo "$HOME/.local/python3.15/bin" >> $GITHUB_PATH
 
-      - name: 🧳 Install Nuitka and dependencies
+      - name: 🧳 Install Nuitka
         run: |
-          sudo apt-get update
-          sudo apt-get install patchelf gdb ccache libfuse2
           python -m pip install --no-python-version-warning --disable-pip-version-check .
 
       - name: ⚙️ Verbose scons output in compilation

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -138,6 +138,9 @@ NUITKA_MAY_BE_UNUSED static inline void Nuitka_GC_UnTrack(void *raw_op);
 #ifdef NUITKA_USE_PYCORE_THREAD_STATE
 #undef Py_BUILD_CORE
 #define Py_BUILD_CORE
+#if PYTHON_VERSION >= 0x3f0
+#define Py_BUILD_CORE_MODULE
+#endif
 #undef _PyGC_FINALIZED
 
 #if PYTHON_VERSION < 0x380

--- a/nuitka/build/include/nuitka/python_internals_access.h
+++ b/nuitka/build/include/nuitka/python_internals_access.h
@@ -117,7 +117,7 @@ struct _Nuitka_perf_trampoline_missing_delta {
     void *trampoline_api[5];
     FILE *map_file;
 };
-#elif PYTHON_VERSION >= 0x3d0
+#elif PYTHON_VERSION >= 0x3d0 && PYTHON_VERSION < 0x3f0
 struct _Nuitka_perf_trampoline_missing_delta_early {
     int status;
     int perf_trampoline_type;
@@ -133,6 +133,19 @@ struct _Nuitka_perf_trampoline_missing_delta_late {
     Py_ssize_t extra_code_index;
     void *code_arena;
     void *trampoline_api[5];
+    FILE *map_file;
+    Py_ssize_t persist_after_fork;
+    void *prev_eval_frame;
+    Py_ssize_t trampoline_refcount;
+    int code_watcher_id;
+};
+#elif PYTHON_VERSION >= 0x3f0
+struct _Nuitka_perf_trampoline_missing_delta {
+    int status;
+    int perf_trampoline_type;
+    Py_ssize_t extra_code_index;
+    void *code_arena;
+    char _trampoline_api_padding[48];
     FILE *map_file;
     Py_ssize_t persist_after_fork;
     void *prev_eval_frame;

--- a/nuitka/build/static_src/MetaPathBasedLoader.c
+++ b/nuitka/build/static_src/MetaPathBasedLoader.c
@@ -883,6 +883,93 @@ static entrypoint_t _loadExtensionModuleInitAddress(PyThreadState *tstate, char 
     return entrypoint;
 }
 
+#if PYTHON_VERSION >= 0x30f0
+// Python 3.15 comes with PyImport_CreateModuleFromInitfunc, which saves us
+// from a lot of the hacks that we're doing in other versions. Most importantly,
+// we don't need access to the package context (which isn't exported anywhere
+// starting in 3.15).
+static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full_name, const filename_char_t *filename,
+                                         bool is_package) {
+    entrypoint_t entrypoint = _loadExtensionModuleInitAddress(tstate, full_name, filename);
+
+    if (entrypoint == NULL) {
+        return NULL;
+    }
+
+    PyObject *full_name_obj = Nuitka_String_FromString(full_name);
+    PyObject *origin = Nuitka_String_FromFilename(filename);
+
+    PyObject *spec_value = createModuleSpec(tstate, full_name_obj, origin, is_package);
+    CHECK_OBJECT(spec_value);
+
+    PGO_onModuleEntered(full_name);
+
+    if (isVerbose()) {
+        PySys_WriteStderr("import %s # calling entrypoint\n", full_name);
+    }
+
+    Nuitka_DelModuleString(tstate, full_name);
+
+    // Fancy new function in 3.15!
+    // For single-phase modules, this will return the fully constructed module
+    // object, and for multi-phase this returns the moduledef.
+    PyObject *module = PyImport_CreateModuleFromInitfunc(spec_value, entrypoint);
+
+    if (isVerbose()) {
+        PySys_WriteStderr("import %s # return from entrypoint\n", full_name);
+    }
+
+    PGO_onModuleExit(full_name, module == NULL);
+
+    if (unlikely(module == NULL)) {
+        Py_DECREF(spec_value);
+        Py_DECREF(full_name_obj);
+        Py_DECREF(origin);
+
+        if (unlikely(!HAS_ERROR_OCCURRED(tstate))) {
+            PyErr_Format(PyExc_SystemError, "dynamic module '%s' not initialized properly", full_name);
+        }
+
+        return NULL;
+    }
+
+    if (unlikely(PyModule_Exec(module) != 0)) {
+        Py_DECREF(module);
+        Py_DECREF(spec_value);
+        Py_DECREF(full_name_obj);
+        Py_DECREF(origin);
+
+        return NULL;
+    }
+
+    SET_ATTRIBUTE(tstate, module, const_str_plain___spec__, spec_value);
+    setModuleFileValue(tstate, module, filename);
+
+    if (is_package) {
+        PyObject *path_list = _makeDunderPathObject(tstate, origin);
+
+        int res = PyObject_SetAttr(module, const_str_plain___path__, path_list);
+        Py_DECREF(path_list);
+
+        if (unlikely(res != 0)) {
+            Py_DECREF(module);
+            Py_DECREF(spec_value);
+            Py_DECREF(full_name_obj);
+            Py_DECREF(origin);
+
+            return NULL;
+        }
+    }
+
+    Nuitka_SetModule(full_name_obj, module);
+
+    Py_DECREF(spec_value);
+    Py_DECREF(full_name_obj);
+    Py_DECREF(origin);
+
+    return module;
+}
+#else
 static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full_name, const filename_char_t *filename,
                                          bool is_package) {
     // Determine the package name and basename of the module to load.
@@ -1275,6 +1362,7 @@ static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full
 
     return module;
 }
+#endif
 
 static void loadTriggeredModule(PyThreadState *tstate, char const *name, char const *trigger_name) {
     char trigger_module_name[2048];

--- a/nuitka/build/static_src/MetaPathBasedLoader.c
+++ b/nuitka/build/static_src/MetaPathBasedLoader.c
@@ -883,13 +883,35 @@ static entrypoint_t _loadExtensionModuleInitAddress(PyThreadState *tstate, char 
     return entrypoint;
 }
 
-#if PYTHON_VERSION >= 0x30f0
+#if PYTHON_VERSION >= 0x300
 // Python 3.15 comes with PyImport_CreateModuleFromInitfunc, which saves us
 // from a lot of the hacks that we're doing in other versions. Most importantly,
 // we don't need access to the package context (which isn't exported anywhere
 // starting in 3.15).
+static int _finalizeExtensionModule(PyThreadState *tstate, PyObject *module, PyObject *spec_value, PyObject *origin,
+                                    const filename_char_t *filename, PyObject *full_name_obj, bool is_package) {
+    SET_ATTRIBUTE(tstate, module, const_str_plain___spec__, spec_value);
+    setModuleFileValue(tstate, module, filename);
+
+    if (is_package) {
+        PyObject *path_list = _makeDunderPathObject(tstate, origin);
+        bool res = SET_ATTRIBUTE(tstate, module, const_str_plain___path__, path_list);
+        Py_DECREF(path_list);
+        if (unlikely(res == false)) {
+            return -1;
+        }
+    }
+
+    Nuitka_SetModule(full_name_obj, module);
+    return 0;
+}
+#endif
+
 static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full_name, const filename_char_t *filename,
                                          bool is_package) {
+#if PYTHON_VERSION >= 0x3f0
+    // For single-phase modules, this will return the fully constructed module
+    // object, and for multi-phase this returns the moduledef.
     entrypoint_t entrypoint = _loadExtensionModuleInitAddress(tstate, full_name, filename);
 
     if (entrypoint == NULL) {
@@ -910,9 +932,6 @@ static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full
 
     Nuitka_DelModuleString(tstate, full_name);
 
-    // Fancy new function in 3.15!
-    // For single-phase modules, this will return the fully constructed module
-    // object, and for multi-phase this returns the moduledef.
     PyObject *module = PyImport_CreateModuleFromInitfunc(spec_value, entrypoint);
 
     if (isVerbose()) {
@@ -922,56 +941,36 @@ static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full
     PGO_onModuleExit(full_name, module == NULL);
 
     if (unlikely(module == NULL)) {
-        Py_DECREF(spec_value);
-        Py_DECREF(full_name_obj);
-        Py_DECREF(origin);
-
         if (unlikely(!HAS_ERROR_OCCURRED(tstate))) {
             PyErr_Format(PyExc_SystemError, "dynamic module '%s' not initialized properly", full_name);
         }
 
-        return NULL;
+        goto error;
     }
 
     if (unlikely(PyModule_Exec(module) != 0)) {
         Py_DECREF(module);
-        Py_DECREF(spec_value);
-        Py_DECREF(full_name_obj);
-        Py_DECREF(origin);
-
-        return NULL;
+        goto error;
     }
 
-    SET_ATTRIBUTE(tstate, module, const_str_plain___spec__, spec_value);
-    setModuleFileValue(tstate, module, filename);
-
-    if (is_package) {
-        PyObject *path_list = _makeDunderPathObject(tstate, origin);
-
-        int res = PyObject_SetAttr(module, const_str_plain___path__, path_list);
-        Py_DECREF(path_list);
-
-        if (unlikely(res != 0)) {
-            Py_DECREF(module);
-            Py_DECREF(spec_value);
-            Py_DECREF(full_name_obj);
-            Py_DECREF(origin);
-
-            return NULL;
-        }
+    if (_finalizeExtensionModule(tstate, module, spec_value, origin, filename, full_name_obj, is_package) != 0) {
+        Py_DECREF(module);
+        goto error;
     }
-
-    Nuitka_SetModule(full_name_obj, module);
 
     Py_DECREF(spec_value);
     Py_DECREF(full_name_obj);
     Py_DECREF(origin);
 
     return module;
-}
+
+error:
+    Py_XDECREF(spec_value);
+    Py_XDECREF(full_name_obj);
+    Py_XDECREF(origin);
+    return NULL;
+
 #else
-static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full_name, const filename_char_t *filename,
-                                         bool is_package) {
     // Determine the package name and basename of the module to load.
     char const *dot = strrchr(full_name, '.');
     char const *package;
@@ -1107,21 +1106,11 @@ static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full
             return NULL;
         }
 
-        SET_ATTRIBUTE(tstate, module, const_str_plain___spec__, spec_value);
-
-        setModuleFileValue(tstate, module, filename);
-
-        /* Set __path__ properly, unlike frozen module importer does. */
-        PyObject *path_list = _makeDunderPathObject(tstate, origin);
-
-        int res = PyObject_SetAttr(module, const_str_plain___path__, path_list);
+        int res = _finalizeExtensionModule(tstate, module, spec_value, origin, filename, full_name_obj, is_package);
         if (unlikely(res != 0)) {
             return NULL;
         }
 
-        Py_DECREF(path_list);
-
-        Nuitka_SetModule(full_name_obj, module);
         Py_DECREF(full_name_obj);
 
 #if _NUITKA_EXPERIMENTAL_OLD_EXTENSION_MODULE_LOADING
@@ -1361,8 +1350,8 @@ static PyObject *callIntoExtensionModule(PyThreadState *tstate, char const *full
 #endif
 
     return module;
-}
 #endif
+}
 
 static void loadTriggeredModule(PyThreadState *tstate, char const *name, char const *trigger_name) {
     char trigger_module_name[2048];

--- a/nuitka/plugins/PluginBase.py
+++ b/nuitka/plugins/PluginBase.py
@@ -197,7 +197,9 @@ def _getEvaluationContext():
             # Getting data files contents
             "get_data": _getPackageData,
             # Querying package properties
-            "has_builtin_module": isBuiltinModuleName,
+            "has_builtin_module": lambda module_name: isBuiltinModuleName(
+                ModuleName(module_name)
+            ),
             # Architectures
             "arch_x86": getArchitecture() == "x86",
             "arch_amd64": getArchitecture() == "x86_64",

--- a/nuitka/tools/general/generate_header/templates_c/python_internals_access.h.j2
+++ b/nuitka/tools/general/generate_header/templates_c/python_internals_access.h.j2
@@ -86,7 +86,7 @@ struct _Nuitka_perf_trampoline_missing_delta {
     void *trampoline_api[5];
     FILE *map_file;
 };
-#elif PYTHON_VERSION >= 0x3d0
+#elif PYTHON_VERSION >= 0x3d0 && PYTHON_VERSION < 0x3f0
 struct _Nuitka_perf_trampoline_missing_delta_early {
     int status;
     int perf_trampoline_type;
@@ -102,6 +102,19 @@ struct _Nuitka_perf_trampoline_missing_delta_late {
     Py_ssize_t extra_code_index;
     void *code_arena;
     void *trampoline_api[5];
+    FILE *map_file;
+    Py_ssize_t persist_after_fork;
+    void *prev_eval_frame;
+    Py_ssize_t trampoline_refcount;
+    int code_watcher_id;
+};
+#elif PYTHON_VERSION >= 0x3f0
+struct _Nuitka_perf_trampoline_missing_delta {
+    int status;
+    int perf_trampoline_type;
+    Py_ssize_t extra_code_index;
+    void *code_arena;
+    char _trampoline_api_padding[48];
     FILE *map_file;
     Py_ssize_t persist_after_fork;
     void *prev_eval_frame;

--- a/nuitka/utils/Importing.py
+++ b/nuitka/utils/Importing.py
@@ -215,6 +215,17 @@ def importFromCompileTime(module_name, must_exist):
 
 
 def isBuiltinModuleName(module_name):
+    """Check if a module name refers to a built-in or frozen module.
+
+    Also recognizes submodules of built-in packages, e.g. "math.integer"
+    where "math" is built-in.
+
+    Args:
+        module_name: ModuleName of the module to check.
+
+    Returns:
+        bool
+    """
     result = bool(imp.is_builtin(module_name) or imp.is_frozen(module_name))
 
     # Some frozen modules are not actually in that list, e.g.
@@ -231,6 +242,14 @@ def isBuiltinModuleName(module_name):
                 result = loader.__name__ == "FrozenImporter"
             except AttributeError:
                 pass
+
+    # Submodules of built-in packages are effectively built-in, e.g.
+    # "math.integer" is a submodule of the built-in "math" package.
+    if result is False:
+        parent_package = module_name.getPackageName()
+
+        if parent_package is not None and isBuiltinModuleName(parent_package):
+            result = True
 
     return result
 


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

In Python 3.15, we lost access to `pkgcontext`, which broke our importer in some scenarios where the module name is wrong. Luckily, Python 3.15 introduces a new function that should help avoid much of the complexity and hacks we were implementing ourselves, thereby circumventing the problem entirely.

## 🧐 Why was it initiated? Any relevant Issues?

- #3929

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Adapt Nuitka’s meta path extension module loading and internals access to support Python 3.15 while keeping existing behavior for older versions.

Bug Fixes:
- Fix extension module importing in Python 3.15+ by using PyImport_CreateModuleFromInitfunc and avoiding reliance on non-exported package context.
- Treat submodules of built-in/frozen packages as built-in for import-related checks in plugins.

Enhancements:
- Refactor extension module finalization into a shared helper used across Python versions.
- Update perf trampoline internal structures and core build flags for compatibility with Python 3.15’s interpreter internals.
- Adjust plugin evaluation context to pass ModuleName objects into builtin module detection.

CI:
- Extend Linux CI matrix to test against Python 3.15 using deadsnakes and a virtualenv, and run Nuitka via a configurable PYTHON environment variable.