### PR TITLE
[codex] Optimize code template emission

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -106,6 +106,10 @@ jobs:
         run: |
           python ./bin/generate-specialized-python-code --check
 
+      - name: 🔎 Prepared code template check
+        run: |
+          python ./bin/check-prepared-code-templates
+
   linux:
     needs: checks
     runs-on: ubuntu-24.04

--- a/bin/benchmark-prepared-code-templates
+++ b/bin/benchmark-prepared-code-templates
@@ -1,24 +1,21 @@
+#!/usr/bin/env python3
 #     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
 
 
-"""Indentation of code.
+"""Launcher for prepared code template benchmarking."""
 
-Language independent, the amount of the spaces is not configurable, as it needs
-to be the same as in templates.
-"""
+import os
+import sys
 
-from .Emission import getCodeString
+# Unchanged, running from checkout, use the parent directory, the nuitka
+# package ought to be there.
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), "..")))
 
+# isort:start
 
-def indented(codes):
-    if type(codes) is not str:
-        if hasattr(codes, "asCode"):
-            codes = codes.asCode()
-        else:
-            codes = "\n".join(getCodeString(code) for code in codes)
+from nuitka.tools.specialize.BenchmarkPreparedTemplates import main
 
-    return codes
-
+main()
 
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and
 #     integrates with CPython, but also works on its own.

--- a/bin/check-prepared-code-templates
+++ b/bin/check-prepared-code-templates
@@ -1,24 +1,21 @@
+#!/usr/bin/env python3
 #     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
 
 
-"""Indentation of code.
+"""Launcher for prepared code template validation."""
 
-Language independent, the amount of the spaces is not configurable, as it needs
-to be the same as in templates.
-"""
+import os
+import sys
 
-from .Emission import getCodeString
+# Unchanged, running from checkout, use the parent directory, the nuitka
+# package ought to be there.
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), "..")))
 
+# isort:start
 
-def indented(codes):
-    if type(codes) is not str:
-        if hasattr(codes, "asCode"):
-            codes = codes.asCode()
-        else:
-            codes = "\n".join(getCodeString(code) for code in codes)
+from nuitka.tools.specialize.CheckPreparedTemplates import main
 
-    return codes
-
+main()
 
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and
 #     integrates with CPython, but also works on its own.

--- a/nuitka/States.py
+++ b/nuitka/States.py
@@ -19,6 +19,7 @@ class GlobalState(object):
     __slots__ = (
         "is_debug",
         "is_non_debug",
+        "is_readable_code",
         "is_full_compat",
         "report_missing_code_helpers",
         "report_missing_trust",
@@ -30,6 +31,7 @@ class GlobalState(object):
     def __init__(self):
         self.is_debug = None
         self.is_non_debug = None
+        self.is_readable_code = None
         self.is_full_compat = None
         self.report_missing_code_helpers = None
         self.report_missing_trust = None

--- a/nuitka/code_generation/AsyncgenCodes.py
+++ b/nuitka/code_generation/AsyncgenCodes.py
@@ -23,6 +23,7 @@ from .templates.CodeTemplatesAsyncgens import (
     template_asyncgen_return_exit,
     template_make_asyncgen,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 from .YieldCodes import getYieldReturnDispatchCode
 
 
@@ -39,10 +40,20 @@ def getAsyncgenObjectDeclCode(function_identifier, closure_variables):
         type_params_name=None,
     )
 
-    return template_asyncgen_object_maker_template % {
-        "asyncgen_maker_identifier": _getAsyncgenMakerIdentifier(function_identifier),
-        "asyncgen_creation_args": ", ".join(asyncgen_creation_args),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_asyncgen_object_maker_template,
+        result,
+        {
+            "asyncgen_maker_identifier": _getAsyncgenMakerIdentifier(
+                function_identifier
+            ),
+            "asyncgen_creation_args": ", ".join(asyncgen_creation_args),
+        },
+    )
+
+    return result
 
 
 def getAsyncgenObjectCode(
@@ -84,17 +95,25 @@ def getAsyncgenObjectCode(
             _exception_lineno,
         ) = context.variable_storage.getExceptionVariableDescriptions()
 
-        generator_exit = template_asyncgen_exception_exit % {
-            "function_cleanup": indented(function_cleanup),
-            "exception_state_name": exception_state_name,
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_asyncgen_exception_exit,
+            generator_exit,
+            {
+                "function_cleanup": indented(function_cleanup),
+                "exception_state_name": exception_state_name,
+            },
+        )
     else:
-        generator_exit = template_asyncgen_no_exception_exit % {
-            "function_cleanup": indented(function_cleanup)
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_asyncgen_no_exception_exit,
+            generator_exit,
+            {"function_cleanup": indented(function_cleanup)},
+        )
 
     if needs_generator_return:
-        generator_exit += template_asyncgen_return_exit % {}
+        emitTemplate(template_asyncgen_return_exit, generator_exit, {})
 
     function_locals = context.variable_storage.makeCFunctionLevelDeclarations()
 
@@ -118,28 +137,40 @@ struct %(function_identifier)s_locals *asyncgen_heap = \
         type_params_name=None,
     )
 
-    return template_asyncgen_object_body % {
-        "function_identifier": function_identifier,
-        "function_body": indented(function_codes),
-        "heap_declaration": indented(heap_declaration),
-        "has_heap_declaration": 1 if heap_declaration != "" else 0,
-        "function_local_types": indented(local_type_decl),
-        "function_var_inits": indented(function_locals),
-        "function_dispatch": indented(getYieldReturnDispatchCode(context)),
-        "asyncgen_maker_identifier": _getAsyncgenMakerIdentifier(function_identifier),
-        "asyncgen_creation_args": ", ".join(asyncgen_creation_args),
-        "asyncgen_exit": generator_exit,
-        "asyncgen_module": getModuleAccessCode(context),
-        "asyncgen_name_obj": context.getConstantCode(
-            constant=asyncgen_object_body.getFunctionName()
-        ),
-        "asyncgen_qualname_obj": getFunctionQualnameObj(asyncgen_object_body, context),
-        "code_identifier": getCodeObjectAccessCode(
-            code_object=asyncgen_object_body.getCodeObject(), context=context
-        ),
-        "closure_name": "closure" if closure_variables else "NULL",
-        "closure_count": len(closure_variables),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_asyncgen_object_body,
+        result,
+        {
+            "function_identifier": function_identifier,
+            "function_body": function_codes,
+            "heap_declaration": indented(heap_declaration),
+            "has_heap_declaration": 1 if heap_declaration != "" else 0,
+            "function_local_types": indented(local_type_decl),
+            "function_var_inits": indented(function_locals),
+            "function_dispatch": indented(getYieldReturnDispatchCode(context)),
+            "asyncgen_maker_identifier": _getAsyncgenMakerIdentifier(
+                function_identifier
+            ),
+            "asyncgen_creation_args": ", ".join(asyncgen_creation_args),
+            "asyncgen_exit": generator_exit,
+            "asyncgen_module": getModuleAccessCode(context),
+            "asyncgen_name_obj": context.getConstantCode(
+                constant=asyncgen_object_body.getFunctionName()
+            ),
+            "asyncgen_qualname_obj": getFunctionQualnameObj(
+                asyncgen_object_body, context
+            ),
+            "code_identifier": getCodeObjectAccessCode(
+                code_object=asyncgen_object_body.getCodeObject(), context=context
+            ),
+            "closure_name": "closure" if closure_variables else "NULL",
+            "closure_count": len(closure_variables),
+        },
+    )
+
+    return result
 
 
 def generateMakeAsyncgenObjectCode(to_name, expression, emit, context):
@@ -155,16 +186,17 @@ def generateMakeAsyncgenObjectCode(to_name, expression, emit, context):
     if closure_name:
         args.append(closure_name)
 
-    emit(
-        template_make_asyncgen
-        % {
+    emitTemplate(
+        template_make_asyncgen,
+        emit,
+        {
             "to_name": to_name,
             "asyncgen_maker_identifier": _getAsyncgenMakerIdentifier(
                 asyncgen_object_body.getCodeName()
             ),
             "args": ", ".join(str(arg) for arg in args),
             "closure_copy": indented(closure_copy),
-        }
+        },
     )
 
     context.addCleanupTempName(to_name)

--- a/nuitka/code_generation/CallCodes.py
+++ b/nuitka/code_generation/CallCodes.py
@@ -17,12 +17,14 @@ from .CodeHelpers import (
     generateExpressionCode,
     withObjectCodeTemporaryAssignment,
 )
+from .Emission import SourceCodeCollector
 from .ErrorCodes import getErrorExitCode
 from .LineNumberCodes import emitLineNumberUpdateCode
 from .templates.CodeTemplatesModules import (
     template_header_guard,
     template_helper_impl_decl,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 
 
 def _generateCallCodePosOnly(
@@ -1208,9 +1210,9 @@ def getTemplateCodeDeclaredFunction(code):
 
 def getCallsCode():
     header_codes = []
-    body_codes = []
+    body_codes = SourceCodeCollector()
 
-    body_codes.append(template_helper_impl_decl % {})
+    emitTemplate(template_helper_impl_decl, body_codes, {})
 
     for quick_call_used in sorted(quick_calls_used.union(quick_instance_calls_used)):
         if quick_call_used <= max_quick_call:
@@ -1251,13 +1253,19 @@ def getCallsCode():
         body_codes.append(code)
         header_codes.append(getTemplateCodeDeclaredFunction(code))
 
-    return (
-        template_header_guard
-        % {
+    header = SourceCodeCollector()
+    emitTemplate(
+        template_header_guard,
+        header,
+        {
             "header_guard_name": "__NUITKA_CALLS_H__",
             "header_body": "\n".join(header_codes),
         },
-        "\n".join(body_codes),
+    )
+
+    return (
+        header.asCode(),
+        body_codes.asCode(),
     )
 
 

--- a/nuitka/code_generation/ConstantCodes.py
+++ b/nuitka/code_generation/ConstantCodes.py
@@ -35,12 +35,14 @@ from nuitka.utils.Distributions import (
 from nuitka.Version import getNuitkaVersionTuple
 
 from .CodeHelpers import withObjectCodeTemporaryAssignment
+from .Emission import SourceCodeCollector
 from .ErrorCodes import getAssertionCode
 from .GlobalConstants import getConstantDefaultPopulation
 from .Namify import namifyConstant
 from .SpecialConstantData import hasSpecialDetails
 from .templates.CodeTemplatesConstants import template_constants_reading
 from .templates.CodeTemplatesModules import template_header_guard
+from .templates.TemplateDebugWrapper import emitTemplate
 
 
 def generateConstantReferenceCode(to_name, expression, emit, context):
@@ -160,35 +162,45 @@ def getConstantsDefinitionCode():
         % constant_accessor.getConstantsCount(),
     )
 
-    header = template_header_guard % {
-        "header_guard_name": "__NUITKA_GLOBAL_CONSTANTS_H__",
-        "header_body": "\n".join(lines),
-    }
+    header = SourceCodeCollector()
+    emitTemplate(
+        template_header_guard,
+        header,
+        {
+            "header_guard_name": "__NUITKA_GLOBAL_CONSTANTS_H__",
+            "header_body": "\n".join(lines),
+        },
+    )
 
     major, minor, micro, is_final, _rc_number = getNuitkaVersionTuple()
 
-    body = template_constants_reading % {
-        "module_name_cstr": encodePythonStringToC(
-            getRootTopModule().getFullName().asString().encode("utf8")
-        ),
-        "global_constants_count": constant_accessor.getConstantsCount(),
-        "global_constants_blob_symbol_name": getConstantBlobSymbolName(
-            "__constants.const"
-        ),
-        "use_direct_constant_blobs": 1 if shallUseDirectConstantBlobs() else 0,
-        "sys_executable": sys_executable,
-        "sys_prefix": sys_prefix,
-        "sys_base_prefix": sys_base_prefix,
-        "sys_exec_prefix": sys_exec_prefix,
-        "sys_base_exec_prefix": sys_base_exec_prefix,
-        "nuitka_version_major": major,
-        "nuitka_version_minor": minor,
-        "nuitka_version_micro": micro,
-        "nuitka_version_level": "release" if is_final else "candidate",
-        "metadata_values": metadata_values_code,
-    }
+    body = SourceCodeCollector()
+    emitTemplate(
+        template_constants_reading,
+        body,
+        {
+            "module_name_cstr": encodePythonStringToC(
+                getRootTopModule().getFullName().asString().encode("utf8")
+            ),
+            "global_constants_count": constant_accessor.getConstantsCount(),
+            "global_constants_blob_symbol_name": getConstantBlobSymbolName(
+                "__constants.const"
+            ),
+            "use_direct_constant_blobs": 1 if shallUseDirectConstantBlobs() else 0,
+            "sys_executable": sys_executable,
+            "sys_prefix": sys_prefix,
+            "sys_base_prefix": sys_base_prefix,
+            "sys_exec_prefix": sys_exec_prefix,
+            "sys_base_exec_prefix": sys_base_exec_prefix,
+            "nuitka_version_major": major,
+            "nuitka_version_minor": minor,
+            "nuitka_version_micro": micro,
+            "nuitka_version_level": "release" if is_final else "candidate",
+            "metadata_values": metadata_values_code,
+        },
+    )
 
-    return header, body
+    return header.asCode(), body.asCode()
 
 
 def getModuleConstantsDeclAndChecks(context):

--- a/nuitka/code_generation/CoroutineCodes.py
+++ b/nuitka/code_generation/CoroutineCodes.py
@@ -29,6 +29,7 @@ from .templates.CodeTemplatesCoroutines import (
     template_coroutine_return_exit,
     template_make_coroutine,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 from .YieldCodes import getYieldReturnDispatchCode
 
 
@@ -45,10 +46,20 @@ def getCoroutineObjectDeclCode(function_identifier, closure_variables):
         type_params_name=None,
     )
 
-    return template_coroutine_object_maker % {
-        "coroutine_maker_identifier": _getCoroutineMakerIdentifier(function_identifier),
-        "coroutine_creation_args": ", ".join(coroutine_creation_args),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_coroutine_object_maker,
+        result,
+        {
+            "coroutine_maker_identifier": _getCoroutineMakerIdentifier(
+                function_identifier
+            ),
+            "coroutine_creation_args": ", ".join(coroutine_creation_args),
+        },
+    )
+
+    return result
 
 
 def getCoroutineObjectCode(
@@ -90,19 +101,29 @@ def getCoroutineObjectCode(
             _exception_lineno,
         ) = context.variable_storage.getExceptionVariableDescriptions()
 
-        generator_exit = template_coroutine_exception_exit % {
-            "function_cleanup": indented(function_cleanup),
-            "exception_state_name": exception_state_name,
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_coroutine_exception_exit,
+            generator_exit,
+            {
+                "function_cleanup": indented(function_cleanup),
+                "exception_state_name": exception_state_name,
+            },
+        )
     else:
-        generator_exit = template_coroutine_no_exception_exit % {
-            "function_cleanup": indented(function_cleanup)
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_coroutine_no_exception_exit,
+            generator_exit,
+            {"function_cleanup": indented(function_cleanup)},
+        )
 
     if needs_generator_return:
-        generator_exit += template_coroutine_return_exit % {
-            "return_value": context.getReturnValueName()
-        }
+        emitTemplate(
+            template_coroutine_return_exit,
+            generator_exit,
+            {"return_value": context.getReturnValueName()},
+        )
 
     function_locals = context.variable_storage.makeCFunctionLevelDeclarations()
 
@@ -126,30 +147,40 @@ struct %(function_identifier)s_locals *coroutine_heap = \
         type_params_name=None,
     )
 
-    return template_coroutine_object_body % {
-        "function_identifier": function_identifier,
-        "function_body": indented(function_codes),
-        "heap_declaration": indented(heap_declaration),
-        "has_heap_declaration": 1 if heap_declaration != "" else 0,
-        "function_local_types": indented(local_type_decl),
-        "function_var_inits": indented(function_locals),
-        "function_dispatch": indented(getYieldReturnDispatchCode(context)),
-        "coroutine_maker_identifier": _getCoroutineMakerIdentifier(function_identifier),
-        "coroutine_creation_args": ", ".join(coroutine_creation_args),
-        "coroutine_exit": generator_exit,
-        "coroutine_module": getModuleAccessCode(context),
-        "coroutine_name_obj": context.getConstantCode(
-            constant=coroutine_object_body.getFunctionName()
-        ),
-        "coroutine_qualname_obj": getFunctionQualnameObj(
-            coroutine_object_body, context
-        ),
-        "code_identifier": getCodeObjectAccessCode(
-            code_object=coroutine_object_body.getCodeObject(), context=context
-        ),
-        "closure_name": "closure" if closure_variables else "NULL",
-        "closure_count": len(closure_variables),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_coroutine_object_body,
+        result,
+        {
+            "function_identifier": function_identifier,
+            "function_body": function_codes,
+            "heap_declaration": indented(heap_declaration),
+            "has_heap_declaration": 1 if heap_declaration != "" else 0,
+            "function_local_types": indented(local_type_decl),
+            "function_var_inits": indented(function_locals),
+            "function_dispatch": indented(getYieldReturnDispatchCode(context)),
+            "coroutine_maker_identifier": _getCoroutineMakerIdentifier(
+                function_identifier
+            ),
+            "coroutine_creation_args": ", ".join(coroutine_creation_args),
+            "coroutine_exit": generator_exit,
+            "coroutine_module": getModuleAccessCode(context),
+            "coroutine_name_obj": context.getConstantCode(
+                constant=coroutine_object_body.getFunctionName()
+            ),
+            "coroutine_qualname_obj": getFunctionQualnameObj(
+                coroutine_object_body, context
+            ),
+            "code_identifier": getCodeObjectAccessCode(
+                code_object=coroutine_object_body.getCodeObject(), context=context
+            ),
+            "closure_name": "closure" if closure_variables else "NULL",
+            "closure_count": len(closure_variables),
+        },
+    )
+
+    return result
 
 
 def generateMakeCoroutineObjectCode(to_name, expression, emit, context):
@@ -165,16 +196,17 @@ def generateMakeCoroutineObjectCode(to_name, expression, emit, context):
     if closure_name:
         args.append(closure_name)
 
-    emit(
-        template_make_coroutine
-        % {
+    emitTemplate(
+        template_make_coroutine,
+        emit,
+        {
             "to_name": to_name,
             "coroutine_maker_identifier": _getCoroutineMakerIdentifier(
                 coroutine_object_body.getCodeName()
             ),
             "args": ", ".join(str(arg) for arg in args),
             "closure_copy": indented(closure_copy),
-        }
+        },
     )
 
     context.addCleanupTempName(to_name)

--- a/nuitka/code_generation/Emission.py
+++ b/nuitka/code_generation/Emission.py
@@ -12,13 +12,113 @@ use of these will occur.
 import contextlib
 
 
+def getCodeString(code):
+    if type(code) is str:
+        return code
+
+    if hasattr(code, "asCode"):
+        return code.asCode()
+
+    return str(code)
+
+
+def _appendCodeString(result, code):
+    if type(code) is str:
+        result.append(code)
+    elif type(code) is SourceCodeTemplateExpansion:
+        code.appendToCodeStringFlattened(result)
+    elif type(code) is SourceCodeCollector:
+        code.appendToCodeStringFlattened(result)
+    else:
+        result.append(getCodeString(code))
+
+
+def _joinCodeStrings(codes):
+    try:
+        return "".join(codes)
+    except TypeError:
+        result = []
+
+        for code in codes:
+            _appendCodeString(result, code)
+
+        return "".join(result)
+
+
+class SourceCodeTemplateExpansion(object):
+    __slots__ = ("template", "values")
+
+    def __init__(self, template, values):
+        self.template = template
+        self.values = values
+
+    def appendToCodeString(self, result):
+        self.template.emit(result.append, self.values)
+
+    def appendToCodeStringFlattened(self, result):
+        def append(part):
+            _appendCodeString(result, part)
+
+        self.template.emit(append, self.values)
+
+    def asCode(self):
+        result = []
+
+        self.appendToCodeString(result)
+
+        return _joinCodeStrings(result)
+
+
 class SourceCodeCollector(list):
-    __slots__ = ()
+    __slots__ = ("has_template_fragments",)
+
+    def __init__(self):
+        list.__init__(self)
+
+        self.has_template_fragments = False
 
     def __call__(self, code):
         self.append(code)
 
     emit = __call__
+
+    def emitTemplate(self, template, values):
+        self.append(SourceCodeTemplateExpansion(template, values))
+        self.has_template_fragments = True
+
+    def reset(self):
+        del self[:]
+        self.has_template_fragments = False
+
+    def appendToCodeString(self, result):
+        for count, code in enumerate(self):
+            if count:
+                result.append("\n")
+
+            if type(code) is SourceCodeTemplateExpansion:
+                code.appendToCodeString(result)
+            else:
+                result.append(code)
+
+    def appendToCodeStringFlattened(self, result):
+        for count, code in enumerate(self):
+            if count:
+                result.append("\n")
+
+            _appendCodeString(result, code)
+
+    def asCode(self):
+        if not self.has_template_fragments:
+            try:
+                return "\n".join(self)
+            except TypeError:
+                pass
+
+        result = []
+
+        self.appendToCodeString(result)
+
+        return _joinCodeStrings(result)
 
 
 @contextlib.contextmanager

--- a/nuitka/code_generation/FrameCodes.py
+++ b/nuitka/code_generation/FrameCodes.py
@@ -26,6 +26,7 @@ from .templates.CodeTemplatesFrames import (
     template_frame_guard_normal_main_block,
     template_frame_guard_normal_return_handler,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 
 
 def getFrameLocalsStorageSize(type_descriptions):
@@ -201,11 +202,19 @@ def getFrameAttachLocalsCode(context, frame_identifier):
     if frame_variable_codes:
         frame_variable_codes = ",\n    " + frame_variable_codes
 
-    return template_frame_attach_locals % {
-        "frame_identifier": frame_identifier,
-        "type_description": context.getFrameTypeDescriptionDeclaration(),
-        "frame_variable_refs": frame_variable_codes,
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_frame_attach_locals,
+        result,
+        {
+            "frame_identifier": frame_identifier,
+            "type_description": context.getFrameTypeDescriptionDeclaration(),
+            "frame_variable_refs": frame_variable_codes,
+        },
+    )
+
+    return result
 
 
 def getFrameGuardHeavyCode(
@@ -238,7 +247,9 @@ def getFrameGuardHeavyCode(
 
     # Expose the locals dictionary with the frame locals if it exists.
     if frame_node.isStatementsFrameClass():
-        attach_locals_code = getFrameAttachLocalsCode(context, frame_identifier)
+        attach_locals_code = indented(
+            getFrameAttachLocalsCode(context, frame_identifier)
+        )
         module_identifier = getModuleAccessCode(context)
         locals_dict_name = context.variable_storage.getVariableDeclarationTop(
             frame_node.getLocalsScope().getCodeName()
@@ -278,7 +289,9 @@ Nuitka_Frame_ClearLocals(%(frame_identifier)s);
                 "frame_identifier": frame_identifier,
             }
     elif frame_node.isStatementsFrameFunction():
-        attach_locals_code = getFrameAttachLocalsCode(context, frame_identifier)
+        attach_locals_code = indented(
+            getFrameAttachLocalsCode(context, frame_identifier)
+        )
 
         make_frame_code = (
             """MAKE_FUNCTION_FRAME(tstate, %(code_identifier)s, %(module_identifier)s, %(locals_size)s)"""

--- a/nuitka/code_generation/FunctionCodes.py
+++ b/nuitka/code_generation/FunctionCodes.py
@@ -46,6 +46,7 @@ from .templates.CodeTemplatesFunction import (
     template_make_function,
     template_maker_function_body,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 from .TupleCodes import getTupleCreationCode
 from .VariableCodes import (
     decideLocalVariableCodeType,
@@ -118,10 +119,18 @@ def getFunctionMakerDecl(
         type_params_name=type_params_name,
     )
 
-    return template_function_make_declaration % {
-        "function_identifier": function_identifier,
-        "function_creation_args": ", ".join(function_creation_args),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_function_make_declaration,
+        result,
+        {
+            "function_identifier": function_identifier,
+            "function_creation_args": ", ".join(function_creation_args),
+        },
+    )
+
+    return result
 
 
 def getFunctionMakerCode(
@@ -182,27 +191,33 @@ def getFunctionMakerCode(
 
     module_identifier = getModuleAccessCode(context=context)
 
-    result = template_maker_function_body % {
-        "function_name_obj": context.getConstantCode(
-            constant=function_body.getFunctionName()
-        ),
-        "function_qualname_obj": getFunctionQualnameObj(function_body, context),
-        "function_maker_identifier": function_maker_identifier,
-        "function_impl_identifier": function_impl_identifier,
-        "function_creation_args": ", ".join(function_creation_args),
-        "code_identifier": getCodeObjectAccessCode(
-            code_object=function_body.getCodeObject(), context=context
-        ),
-        "function_doc": function_doc,
-        "defaults": "defaults" if defaults_name else "NULL",
-        "kw_defaults": "kw_defaults" if kw_defaults_name else "NULL",
-        "annotations": "annotations" if annotations_name else "NULL",
-        "closure_count": len(closure_variables),
-        "closure_name": "closure" if closure_variables else "NULL",
-        "module_identifier": module_identifier,
-        "constant_return_code": indented(constant_return_code),
-        "type_params": "type_params" if type_params_name else "NULL",
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_maker_function_body,
+        result,
+        {
+            "function_name_obj": context.getConstantCode(
+                constant=function_body.getFunctionName()
+            ),
+            "function_qualname_obj": getFunctionQualnameObj(function_body, context),
+            "function_maker_identifier": function_maker_identifier,
+            "function_impl_identifier": function_impl_identifier,
+            "function_creation_args": ", ".join(function_creation_args),
+            "code_identifier": getCodeObjectAccessCode(
+                code_object=function_body.getCodeObject(), context=context
+            ),
+            "function_doc": function_doc,
+            "defaults": "defaults" if defaults_name else "NULL",
+            "kw_defaults": "kw_defaults" if kw_defaults_name else "NULL",
+            "annotations": "annotations" if annotations_name else "NULL",
+            "closure_count": len(closure_variables),
+            "closure_name": "closure" if closure_variables else "NULL",
+            "module_identifier": module_identifier,
+            "constant_return_code": indented(constant_return_code),
+            "type_params": "type_params" if type_params_name else "NULL",
+        },
+    )
 
     # TODO: Make it optional, only dill plugin really uses that table to
     # transport the C code implementation pointers.
@@ -411,14 +426,15 @@ def getFunctionCreationCode(
         function_identifier=function_identifier
     )
 
-    emit(
-        template_make_function
-        % {
+    emitTemplate(
+        template_make_function,
+        emit,
+        {
             "to_name": to_name,
             "function_maker_identifier": function_maker_identifier,
             "args": ", ".join(str(arg) for arg in args),
             "closure_copy": indented(closure_copy),
-        }
+        },
     )
 
     if context.needsCleanup(defaults_name):
@@ -526,11 +542,17 @@ def getFunctionDirectDecl(function_identifier, closure_variables, file_scope, co
             variable_c_type.getVariableArgDeclarationCode(variable_declaration)
         )
 
-    result = template_function_direct_declaration % {
-        "file_scope": file_scope,
-        "function_identifier": function_identifier,
-        "direct_call_arg_spec": ", ".join(parameter_objects_decl),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_function_direct_declaration,
+        result,
+        {
+            "file_scope": file_scope,
+            "function_identifier": function_identifier,
+            "direct_call_arg_spec": ", ".join(parameter_objects_decl),
+        },
+    )
 
     return result
 
@@ -692,16 +714,14 @@ def _getFunctionCode(
 
     function_doc = context.getConstantCode(constant=function_doc)
 
-    result = ""
+    result = SourceCodeCollector()
 
-    emit = SourceCodeCollector()
+    function_exit = SourceCodeCollector()
 
     getMustNotGetHereCode(
-        reason="Return statement must have exited already.", emit=emit
+        reason="Return statement must have exited already.", emit=function_exit
     )
-
-    function_exit = indented(emit) + "\n\n"
-    del emit
+    function_exit.append("")
 
     if needs_exception_exit:
         (
@@ -709,15 +729,21 @@ def _getFunctionCode(
             _exception_lineno,
         ) = context.variable_storage.getExceptionVariableDescriptions()
 
-        function_exit += template_function_exception_exit % {
-            "function_cleanup": indented(function_cleanup),
-            "exception_state_name": exception_state_name,
-        }
+        emitTemplate(
+            template_function_exception_exit,
+            function_exit,
+            {
+                "function_cleanup": indented(function_cleanup),
+                "exception_state_name": exception_state_name,
+            },
+        )
 
     if context.hasTempName("return_value"):
-        function_exit += template_function_return_exit % {
-            "function_cleanup": indented(function_cleanup)
-        }
+        emitTemplate(
+            template_function_return_exit,
+            function_exit,
+            {"function_cleanup": indented(function_cleanup)},
+        )
 
     if context.isForCreatedFunction():
         parameter_objects_decl = ["struct Nuitka_FunctionObject const *self"]
@@ -740,22 +766,30 @@ def _getFunctionCode(
                 variable_c_type.getVariableArgDeclarationCode(variable_declaration)
             )
 
-        result += function_direct_body_template % {
-            "file_scope": file_scope,
-            "function_identifier": function_identifier,
-            "direct_call_arg_spec": ", ".join(parameter_objects_decl),
-            "function_locals": indented(function_locals),
-            "function_body": indented(function_codes),
-            "function_exit": function_exit,
-        }
+        emitTemplate(
+            function_direct_body_template,
+            result,
+            {
+                "file_scope": file_scope,
+                "function_identifier": function_identifier,
+                "direct_call_arg_spec": ", ".join(parameter_objects_decl),
+                "function_locals": indented(function_locals),
+                "function_body": function_codes,
+                "function_exit": function_exit,
+            },
+        )
     else:
-        result += template_function_body % {
-            "function_identifier": function_identifier,
-            "parameter_objects_decl": ", ".join(parameter_objects_decl),
-            "function_locals": indented(function_locals),
-            "function_body": indented(function_codes),
-            "function_exit": function_exit,
-        }
+        emitTemplate(
+            template_function_body,
+            result,
+            {
+                "function_identifier": function_identifier,
+                "parameter_objects_decl": ", ".join(parameter_objects_decl),
+                "function_locals": indented(function_locals),
+                "function_body": function_codes,
+                "function_exit": function_exit,
+            },
+        )
 
     return result
 

--- a/nuitka/code_generation/FunctionCodes.py
+++ b/nuitka/code_generation/FunctionCodes.py
@@ -37,8 +37,8 @@ from .PythonSourceCodeGeneration import (
     getFunctionMakerIdentifier,
 )
 from .templates.CodeTemplatesFunction import (
-    function_direct_body_template,
     template_function_body,
+    template_function_direct_body,
     template_function_direct_declaration,
     template_function_exception_exit,
     template_function_make_declaration,
@@ -767,7 +767,7 @@ def _getFunctionCode(
             )
 
         emitTemplate(
-            function_direct_body_template,
+            template_function_direct_body,
             result,
             {
                 "file_scope": file_scope,

--- a/nuitka/code_generation/GeneratorCodes.py
+++ b/nuitka/code_generation/GeneratorCodes.py
@@ -26,6 +26,7 @@ from .templates.CodeTemplatesGeneratorFunction import (
     template_make_empty_generator,
     template_make_generator,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 from .YieldCodes import getYieldReturnDispatchCode
 
 
@@ -42,10 +43,20 @@ def getGeneratorObjectDeclCode(function_identifier, closure_variables):
         type_params_name=None,
     )
 
-    return template_generator_context_maker_decl % {
-        "generator_maker_identifier": _getGeneratorMakerIdentifier(function_identifier),
-        "generator_creation_args": ", ".join(generator_creation_args),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_generator_context_maker_decl,
+        result,
+        {
+            "generator_maker_identifier": _getGeneratorMakerIdentifier(
+                function_identifier
+            ),
+            "generator_creation_args": ", ".join(generator_creation_args),
+        },
+    )
+
+    return result
 
 
 def getGeneratorObjectCode(
@@ -85,22 +96,34 @@ def getGeneratorObjectCode(
             _exception_lineno,
         ) = context.variable_storage.getExceptionVariableDescriptions()
 
-        generator_exit = template_generator_exception_exit % {
-            "function_cleanup": indented(function_cleanup),
-            "exception_state_name": exception_state_name,
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_generator_exception_exit,
+            generator_exit,
+            {
+                "function_cleanup": indented(function_cleanup),
+                "exception_state_name": exception_state_name,
+            },
+        )
     else:
-        generator_exit = template_generator_no_exception_exit % {
-            "function_cleanup": indented(function_cleanup)
-        }
+        generator_exit = SourceCodeCollector()
+        emitTemplate(
+            template_generator_no_exception_exit,
+            generator_exit,
+            {"function_cleanup": indented(function_cleanup)},
+        )
 
     if needs_generator_return:
-        generator_exit += template_generator_return_exit % {
-            "return_value": (
-                context.getReturnValueName() if python_version >= 0x300 else None
-            ),
-            "function_cleanup": indented(function_cleanup),
-        }
+        emitTemplate(
+            template_generator_return_exit,
+            generator_exit,
+            {
+                "return_value": (
+                    context.getReturnValueName() if python_version >= 0x300 else None
+                ),
+                "function_cleanup": indented(function_cleanup),
+            },
+        )
 
     function_locals = context.variable_storage.makeCFunctionLevelDeclarations()
 
@@ -126,30 +149,40 @@ struct %(function_identifier)s_locals *generator_heap = \
         type_params_name=None,
     )
 
-    return template_generator_context_body_template % {
-        "function_identifier": function_identifier,
-        "function_body": indented(function_codes),
-        "heap_declaration": indented(heap_declaration),
-        "has_heap_declaration": 1 if heap_declaration != "" else 0,
-        "function_local_types": indented(local_type_decl),
-        "function_var_inits": indented(function_locals),
-        "function_dispatch": indented(getYieldReturnDispatchCode(context)),
-        "generator_maker_identifier": _getGeneratorMakerIdentifier(function_identifier),
-        "generator_creation_args": ", ".join(generator_creation_args),
-        "generator_exit": generator_exit,
-        "generator_module": getModuleAccessCode(context),
-        "generator_name_obj": context.getConstantCode(
-            constant=generator_object_body.getFunctionName()
-        ),
-        "generator_qualname_obj": getFunctionQualnameObj(
-            generator_object_body, context
-        ),
-        "code_identifier": getCodeObjectAccessCode(
-            code_object=generator_object_body.getCodeObject(), context=context
-        ),
-        "closure_name": "closure" if closure_variables else "NULL",
-        "closure_count": len(closure_variables),
-    }
+    result = SourceCodeCollector()
+
+    emitTemplate(
+        template_generator_context_body_template,
+        result,
+        {
+            "function_identifier": function_identifier,
+            "function_body": function_codes,
+            "heap_declaration": indented(heap_declaration),
+            "has_heap_declaration": 1 if heap_declaration != "" else 0,
+            "function_local_types": indented(local_type_decl),
+            "function_var_inits": indented(function_locals),
+            "function_dispatch": indented(getYieldReturnDispatchCode(context)),
+            "generator_maker_identifier": _getGeneratorMakerIdentifier(
+                function_identifier
+            ),
+            "generator_creation_args": ", ".join(generator_creation_args),
+            "generator_exit": generator_exit,
+            "generator_module": getModuleAccessCode(context),
+            "generator_name_obj": context.getConstantCode(
+                constant=generator_object_body.getFunctionName()
+            ),
+            "generator_qualname_obj": getFunctionQualnameObj(
+                generator_object_body, context
+            ),
+            "code_identifier": getCodeObjectAccessCode(
+                code_object=generator_object_body.getCodeObject(), context=context
+            ),
+            "closure_name": "closure" if closure_variables else "NULL",
+            "closure_count": len(closure_variables),
+        },
+    )
+
+    return result
 
 
 def generateMakeGeneratorObjectCode(to_name, expression, emit, context):
@@ -167,9 +200,10 @@ def generateMakeGeneratorObjectCode(to_name, expression, emit, context):
 
     # Special case empty generators.
     if generator_object_body.subnode_body is None:
-        emit(
-            template_make_empty_generator
-            % {
+        emitTemplate(
+            template_make_empty_generator,
+            emit,
+            {
                 "closure_copy": indented(closure_copy),
                 "to_name": to_name,
                 "generator_module": getModuleAccessCode(context),
@@ -184,19 +218,20 @@ def generateMakeGeneratorObjectCode(to_name, expression, emit, context):
                 ),
                 "closure_name": closure_name if closure_name is not None else "NULL",
                 "closure_count": len(closure_variables),
-            }
+            },
         )
     else:
-        emit(
-            template_make_generator
-            % {
+        emitTemplate(
+            template_make_generator,
+            emit,
+            {
                 "generator_maker_identifier": _getGeneratorMakerIdentifier(
                     generator_object_body.getCodeName()
                 ),
                 "to_name": to_name,
                 "args": ", ".join(str(arg) for arg in args),
                 "closure_copy": indented(closure_copy),
-            }
+            },
         )
 
     context.addCleanupTempName(to_name)

--- a/nuitka/code_generation/LoaderCodes.py
+++ b/nuitka/code_generation/LoaderCodes.py
@@ -37,6 +37,7 @@ from nuitka.Tracing import inclusion_logger
 from nuitka.utils.CStrings import encodePythonStringToC, encodePythonUnicodeToC
 from nuitka.utils.Utils import isWin32Windows
 
+from .Emission import SourceCodeCollector
 from .Indentation import indented
 from .templates.CodeTemplatesLoader import (
     template_metapath_loader_body,
@@ -45,6 +46,7 @@ from .templates.CodeTemplatesLoader import (
     template_metapath_loader_excluded_module_entry,
     template_metapath_loader_extension_module_entry,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 
 
 def _getMetaPathLoaderNameCode(module_name, name_index):
@@ -98,37 +100,58 @@ def getModuleMetaPathLoaderEntryCode(module, bytecode_accessor, name_index):
             name="bytecode of module '%s'" % module.getFullName(),
         )
 
-        return template_metapath_loader_bytecode_module_entry % {
-            "module_name": module_c_name,
-            "bytecode": accessor_code[accessor_code.find("[") + 1 : -1],
-            "size": len(code_data),
-            "flags": " | ".join(flags),
-            "file_path": file_path,
-        }
+        result = SourceCodeCollector()
+        emitTemplate(
+            template_metapath_loader_bytecode_module_entry,
+            result,
+            {
+                "module_name": module_c_name,
+                "bytecode": accessor_code[accessor_code.find("[") + 1 : -1],
+                "size": len(code_data),
+                "flags": " | ".join(flags),
+                "file_path": file_path,
+            },
+        )
+
+        return result
     elif module.isPythonExtensionModule():
         flags.append("NUITKA_EXTENSION_MODULE_FLAG")
 
         if module.isExtensionModulePackage():
             flags.append("NUITKA_PACKAGE_FLAG")
 
-        return template_metapath_loader_extension_module_entry % {
-            "module_name": module_c_name,
-            "flags": " | ".join(flags),
-            "file_path": file_path,
-        }
+        result = SourceCodeCollector()
+        emitTemplate(
+            template_metapath_loader_extension_module_entry,
+            result,
+            {
+                "module_name": module_c_name,
+                "flags": " | ".join(flags),
+                "file_path": file_path,
+            },
+        )
+
+        return result
     else:
         if module.isCompiledPythonPackage():
             flags.append("NUITKA_PACKAGE_FLAG")
 
-        return template_metapath_loader_compiled_module_entry % {
-            "module_name": module_c_name,
-            "module_identifier": module.getCodeName(),
-            "flags": " | ".join(flags),
-            "file_path": file_path,
-        }
+        result = SourceCodeCollector()
+        emitTemplate(
+            template_metapath_loader_compiled_module_entry,
+            result,
+            {
+                "module_name": module_c_name,
+                "module_identifier": module.getCodeName(),
+                "flags": " | ".join(flags),
+                "file_path": file_path,
+            },
+        )
+
+        return result
 
 
-def getMetaPathLoaderBodyCode(bytecode_accessor):
+def getMetaPathLoaderBodyCode(bytecode_accessor):  # pylint: disable=too-many-locals
     metapath_loader_inittab = []
     metapath_module_decls = []
 
@@ -211,22 +234,32 @@ PyThreadState *tstate, PyObject *, struct Nuitka_MetaPathBasedLoaderEntry const 
             # but for now we include all rejected modules that have a reason.
             # We might want to filter this better, e.g. only if it starts with "Module ... instructed by user"
             # For now, let's include all explicit 'False' decisions where we have a module name.
-            metapath_loader_inittab.append(
-                template_metapath_loader_excluded_module_entry
-                % {
+            excluded_module_entry = SourceCodeCollector()
+            emitTemplate(
+                template_metapath_loader_excluded_module_entry,
+                excluded_module_entry,
+                {
                     "module_name": module_c_name,
                     "flags": "NUITKA_TRANSLATED_FLAG | NUITKA_EXCLUDED_MODULE_FLAG",
                     "exclusion_reason": reason_c_string,
-                }
+                },
             )
+            metapath_loader_inittab.append(excluded_module_entry)
 
-    return template_metapath_loader_body % {
-        "metapath_module_decls": indented(metapath_module_decls),
-        "metapath_loader_inittab": indented(metapath_loader_inittab),
-        "entry_count": len(metapath_loader_inittab),
-        "bytecode_count": bytecode_accessor.getConstantsCount(),
-        "frozen_modules": indented(frozen_defs),
-    }
+    result = SourceCodeCollector()
+    emitTemplate(
+        template_metapath_loader_body,
+        result,
+        {
+            "metapath_module_decls": indented(metapath_module_decls),
+            "metapath_loader_inittab": indented(metapath_loader_inittab),
+            "entry_count": len(metapath_loader_inittab),
+            "bytecode_count": bytecode_accessor.getConstantsCount(),
+            "frozen_modules": indented(frozen_defs),
+        },
+    )
+
+    return result.asCode()
 
 
 perfect_supported = set()

--- a/nuitka/code_generation/ModuleCodes.py
+++ b/nuitka/code_generation/ModuleCodes.py
@@ -35,6 +35,7 @@ from .templates.CodeTemplatesModules import (
 from .templates.CodeTemplatesVariables import (
     template_module_variable_accessor_function,
 )
+from .templates.TemplateDebugWrapper import emitTemplate
 from .VariableCodes import (
     getModuleVariableAccessorCodeName,
     getModuleVariableReferenceCode,
@@ -89,8 +90,8 @@ def getModuleCode(
     for _identifier, code in sorted(iterItems(context.getDeclarations())):
         function_decl_codes.append(code)
 
-    function_body_codes = "\n\n".join(function_body_codes)
-    function_decl_codes = "\n\n".join(function_decl_codes)
+    function_body_codes = "\n\n".join(indented(code) for code in function_body_codes)
+    function_decl_codes = "\n\n".join(indented(code) for code in function_decl_codes)
 
     _cleanup = finalizeFunctionLocalVariables(context)
 
@@ -100,12 +101,18 @@ def getModuleCode(
     module_identifier = module.getCodeName()
 
     if module_body is not None and module_body.mayRaiseException(BaseException):
-        module_exit = template_module_exception_exit % {
-            "module_identifier": module_identifier,
-            "is_top": 1 if module.isTopModule() else 0,
-        }
+        module_exit = Emission.SourceCodeCollector()
+        emitTemplate(
+            template_module_exception_exit,
+            module_exit,
+            {
+                "module_identifier": module_identifier,
+                "is_top": 1 if module.isTopModule() else 0,
+            },
+        )
     else:
-        module_exit = template_module_no_exception_exit
+        module_exit = Emission.SourceCodeCollector()
+        emitTemplate(template_module_no_exception_exit, module_exit, {})
 
     local_var_inits = context.variable_storage.makeCFunctionLevelDeclarations()
 
@@ -119,11 +126,6 @@ def getModuleCode(
     is_top = module.isTopModule()
 
     module_identifier = module.getCodeName()
-
-    template = template_global_copyright + template_module_body_template
-
-    if is_top == 1 and shallMakeModule():
-        template += template_module_external_entry_point
 
     module_code_objects_decl = getCodeObjectsDeclCode(context)
     module_code_objects_init = getCodeObjectsInitCode(context)
@@ -179,17 +181,20 @@ def getModuleCode(
     for module_variable_name, caching in sorted(
         context.getModuleVariableAccessors().items()
     ):
-        module_variable_accessor_codes.append(
-            template_module_variable_accessor_function
-            % {
+        module_variable_accessor_code = Emission.SourceCodeCollector()
+        emitTemplate(
+            template_module_variable_accessor_function,
+            module_variable_accessor_code,
+            {
                 "accessor_function_name": getModuleVariableAccessorCodeName(
                     module_identifier, module_variable_name
                 ),
                 "var_name": context.getConstantCode(constant=module_variable_name),
                 "module_identifier": module_identifier,
                 "caching": "1" if caching else "0",
-            }
+            },
         )
+        module_variable_accessor_codes.append(module_variable_accessor_code)
 
     (
         constants_count,
@@ -198,7 +203,7 @@ def getModuleCode(
         module_constants_check_object,
     ) = getModuleConstantsDeclAndChecks(context)
 
-    return template % {
+    template_values = {
         "module_name_cstr": encodePythonStringToC(
             module_name.asString().encode("utf8")
         ),
@@ -233,6 +238,16 @@ def getModuleCode(
             '#include "%s"' % include for include in context.getModuleIncludes()
         ),
     }
+
+    result = Emission.SourceCodeCollector()
+    result(template_global_copyright % template_values)
+
+    emitTemplate(template_module_body_template, result, template_values)
+
+    if is_top == 1 and shallMakeModule():
+        emitTemplate(template_module_external_entry_point, result, template_values)
+
+    return result.asCode()
 
 
 def generateModuleAttributeFileCode(to_name, expression, emit, context):

--- a/nuitka/code_generation/c_types/CTypeNuitkaInts.py
+++ b/nuitka/code_generation/c_types/CTypeNuitkaInts.py
@@ -7,6 +7,7 @@ from nuitka.code_generation.templates.CodeTemplatesVariables import (
     template_release_object_clear,
     template_release_object_unclear,
 )
+from nuitka.code_generation.templates.TemplateDebugWrapper import emitTemplate
 
 from ..ErrorCodes import getTakeReferenceCode
 from .CTypeBases import CTypeBase
@@ -117,7 +118,7 @@ class CTypeNuitkaIntOrLongStruct(CTypeBase):
         else:
             template = template_release_object_clear
 
-        emit(template % {"identifier": "%s.python_value" % value_name})
+        emitTemplate(template, emit, {"identifier": "%s.python_value" % value_name})
 
         emit("}")
 

--- a/nuitka/code_generation/c_types/CTypePyObjectPointers.py
+++ b/nuitka/code_generation/c_types/CTypePyObjectPointers.py
@@ -36,6 +36,7 @@ from nuitka.code_generation.templates.CodeTemplatesVariables import (
     template_write_shared_unclear_ref0,
     template_write_shared_unclear_ref1,
 )
+from nuitka.code_generation.templates.TemplateDebugWrapper import emitTemplate
 from nuitka.Constants import getConstantValueGuide, isMutable
 
 from .CTypeBases import CTypeBase
@@ -81,7 +82,7 @@ class CPythonPyObjectPtrBase(CTypeBase):
             if ref_count:
                 context.removeCleanupTempName(tmp_name)
 
-        emit(template % {"identifier": value_name, "tmp_name": tmp_name})
+        emitTemplate(template, emit, {"identifier": value_name, "tmp_name": tmp_name})
 
     @classmethod
     def emitAssignmentCodeToNuitkaIntOrLong(
@@ -118,7 +119,7 @@ class CPythonPyObjectPtrBase(CTypeBase):
         else:
             template = template_release_object_clear
 
-        emit(template % {"identifier": value_name})
+        emitTemplate(template, emit, {"identifier": value_name})
 
     @classmethod
     def emitAssignInplaceNegatedValueCode(cls, to_name, needs_check, emit, context):
@@ -352,13 +353,14 @@ class CTypePyObjectPtr(CPythonPyObjectPtrBase):
         cls, to_name, value_name, needs_check, tolerant, emit, context
     ):
         if not needs_check:
-            emit(template_del_local_known % {"identifier": value_name})
+            emitTemplate(template_del_local_known, emit, {"identifier": value_name})
         elif tolerant:
-            emit(template_del_local_tolerant % {"identifier": value_name})
+            emitTemplate(template_del_local_tolerant, emit, {"identifier": value_name})
         else:
-            emit(
-                template_del_local_intolerant
-                % {"identifier": value_name, "result": to_name}
+            emitTemplate(
+                template_del_local_intolerant,
+                emit,
+                {"identifier": value_name, "result": to_name},
             )
 
     @classmethod
@@ -413,7 +415,7 @@ class CTypePyObjectPtr(CPythonPyObjectPtrBase):
         else:
             template = template_release_object_clear
 
-        emit(template % {"identifier": value_name})
+        emitTemplate(template, emit, {"identifier": value_name})
 
     @classmethod
     def getTakeReferenceCode(cls, value_name, emit):
@@ -496,7 +498,7 @@ class CTypeCellObject(CTypeBase):
                 else:
                     template = template_write_shared_unclear_ref1
 
-        emit(template % {"identifier": value_name, "tmp_name": tmp_name})
+        emitTemplate(template, emit, {"identifier": value_name, "tmp_name": tmp_name})
 
     @classmethod
     def emitValueAccessCode(cls, value_name, emit, context):
@@ -528,13 +530,14 @@ class CTypeCellObject(CTypeBase):
         cls, to_name, value_name, needs_check, tolerant, emit, context
     ):
         if not needs_check:
-            emit(template_del_shared_known % {"identifier": value_name})
+            emitTemplate(template_del_shared_known, emit, {"identifier": value_name})
         elif tolerant:
-            emit(template_del_shared_tolerant % {"identifier": value_name})
+            emitTemplate(template_del_shared_tolerant, emit, {"identifier": value_name})
         else:
-            emit(
-                template_del_shared_intolerant
-                % {"identifier": value_name, "result": to_name}
+            emitTemplate(
+                template_del_shared_intolerant,
+                emit,
+                {"identifier": value_name, "result": to_name},
             )
 
     @classmethod
@@ -544,7 +547,7 @@ class CTypeCellObject(CTypeBase):
         else:
             template = template_release_object_clear
 
-        emit(template % {"identifier": value_name})
+        emitTemplate(template, emit, {"identifier": value_name})
 
     @classmethod
     def emitReInitCode(cls, value_name, emit):
@@ -599,7 +602,7 @@ class CTypePyCellObject(CTypeCellObject):
             else:
                 template = template_write_py_cell_unclear_ref1
 
-        emit(template % {"identifier": value_name, "tmp_name": tmp_name})
+        emitTemplate(template, emit, {"identifier": value_name, "tmp_name": tmp_name})
 
     @classmethod
     def emitValueAccessCode(cls, value_name, emit, context):
@@ -621,13 +624,16 @@ class CTypePyCellObject(CTypeCellObject):
         cls, to_name, value_name, needs_check, tolerant, emit, context
     ):
         if not needs_check:
-            emit(template_del_py_cell_known % {"identifier": value_name})
+            emitTemplate(template_del_py_cell_known, emit, {"identifier": value_name})
         elif tolerant:
-            emit(template_del_py_cell_tolerant % {"identifier": value_name})
+            emitTemplate(
+                template_del_py_cell_tolerant, emit, {"identifier": value_name}
+            )
         else:
-            emit(
-                template_del_py_cell_intolerant
-                % {"identifier": value_name, "result": to_name}
+            emitTemplate(
+                template_del_py_cell_intolerant,
+                emit,
+                {"identifier": value_name, "result": to_name},
             )
 
     @classmethod

--- a/nuitka/code_generation/templates/CodeTemplatesFunction.py
+++ b/nuitka/code_generation/templates/CodeTemplatesFunction.py
@@ -81,7 +81,7 @@ function_return_exit:
    assert(had_error || !HAS_ERROR_OCCURRED(tstate));
    return tmp_return_value;"""
 
-function_direct_body_template = """\
+template_function_direct_body = """\
 %(file_scope)s PyObject *impl_%(function_identifier)s(PyThreadState *tstate, %(direct_call_arg_spec)s) {
 #ifndef __NUITKA_NO_ASSERT__
     NUITKA_MAY_BE_UNUSED bool had_error = HAS_ERROR_OCCURRED(tstate);

--- a/nuitka/code_generation/templates/CodeTemplatesGenerated.py
+++ b/nuitka/code_generation/templates/CodeTemplatesGenerated.py
@@ -264,7 +264,7 @@ def _emit_006_template_constants_reading(emit, values):
     )
     emit(values["nuitka_version_level"])
     emit(
-        '"));\n\nPyObject *containing_directory = getContainingDirectoryObject(false);\n#if _NUITKA_STANDALONE_MODE\n#if !_NUITKA_ONEFILE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n\n#if _NUITKA_MACOS_BUNDLE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n#endif\n\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 4, containing_directory);\n\n#if _NUITKA_STANDALONE_MODE\nPyObject *is_standalone_mode = Py_True;\n#else\nPyObject *is_standalone_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 5, is_standalone_mode);\n#ifdef _NUITKA_ONEFILE_MODE\nPyObject *is_onefile_mode = Py_True;\n#else\nPyObject *is_onefile_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 6, is_onefile_mode);\n\n#if _NUITKA_MACOS_BUNDLE_MODE\nPyObject *is_macos_bundle_mode = Py_True;\n#else\nPyObject *is_macos_bundle_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 7, is_macos_bundle_mode);\n\n#if _NUITKA_NO_ASSERTS == 1\nPyObject *is_no_asserts = Py_True;\n#else\nPyObject *is_no_asserts = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 8, is_no_asserts);\n\n#if _NUITKA_NO_DOCSTRINGS == 1\nPyObject *is_no_docstrings = Py_True;\n#else\nPyObject *is_no_docstrings = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 9, is_no_docstrings);\n\n#if _NUITKA_NO_ANNOTATIONS == 1\nPyObject *is_no_annotations = Py_True;\n#else\nPyObject *is_no_annotations = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 10, is_no_annotations);\n\n#if _NUITKA_MODULE_MODE\nPyObject *is_module_mode = Py_True;\n#else\nPyObject *is_module_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 11, is_module_mode);\n\n#if _NUITKA_MODULE_MODE\nPyObject *main_name = real_module_name;\nPy_INCREF(real_module_name);\n#else\nPyObject *main_name = Nuitka_String_FromString("__main__");\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\nPyObject *original_argv0 = getOriginalArgv0Object();\n#else\nPyObject *original_argv0 = Py_None;\n# endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, original_argv0);\n\n#if _NUITKA_MODULE_MODE\nPyObject *extension_filename = getDllFilenameObject();\n#else\nPyObject *extension_filename = Py_None;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 14, extension_filename);\n\n// Prevent users from creating the Nuitka version type object.\nNuitka_VersionInfoType.tp_init = NULL;\nNuitka_VersionInfoType.tp_new = NULL;\n\n// Register included meta data.\nsetDistributionsMetadata(tstate, '
+        '"));\n\nPyObject *containing_directory = getContainingDirectoryObject(false);\n#if _NUITKA_STANDALONE_MODE\n#if !_NUITKA_ONEFILE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n\n#if _NUITKA_MACOS_BUNDLE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n#endif\n\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 4, containing_directory);\n\n#if _NUITKA_STANDALONE_MODE\nPyObject *is_standalone_mode = Py_True;\n#else\nPyObject *is_standalone_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 5, is_standalone_mode);\n#ifdef _NUITKA_ONEFILE_MODE\nPyObject *is_onefile_mode = Py_True;\n#else\nPyObject *is_onefile_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 6, is_onefile_mode);\n\n#if _NUITKA_MACOS_BUNDLE_MODE\nPyObject *is_macos_bundle_mode = Py_True;\n#else\nPyObject *is_macos_bundle_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 7, is_macos_bundle_mode);\n\n#if _NUITKA_NO_ASSERTS == 1\nPyObject *is_no_asserts = Py_True;\n#else\nPyObject *is_no_asserts = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 8, is_no_asserts);\n\n#if _NUITKA_NO_DOCSTRINGS == 1\nPyObject *is_no_docstrings = Py_True;\n#else\nPyObject *is_no_docstrings = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 9, is_no_docstrings);\n\n#if _NUITKA_NO_ANNOTATIONS == 1\nPyObject *is_no_annotations = Py_True;\n#else\nPyObject *is_no_annotations = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 10, is_no_annotations);\n\n#if _NUITKA_MODULE_MODE\nPyObject *is_module_mode = Py_True;\n#else\nPyObject *is_module_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 11, is_module_mode);\n\n#if _NUITKA_MODULE_MODE\nPyObject *main_name = real_module_name;\nPy_INCREF(real_module_name);\n#else\nPyObject *main_name = Nuitka_String_FromString("__main__");\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\nPyObject *original_argv0 = getOriginalArgv0Object();\n#else\nPyObject *original_argv0 = Py_None;\n# endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, original_argv0);\n\n#if _NUITKA_MODULE_MODE\nPyObject *extension_filename = getDllFilenameObject();\n#else\nPyObject *extension_filename = Py_None;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 14, extension_filename);\n\n\nNuitka_VersionInfoType.tp_init = NULL;\nNuitka_VersionInfoType.tp_new = NULL;\n\n\nsetDistributionsMetadata(tstate, '
     )
     emit(values["metadata_values"])
     emit(
@@ -936,7 +936,41 @@ def _emit_026_template_function_return_exit_readable(emit, values):
     )
 
 
-def _emit_027_template_generator_context_maker_decl(emit, values):
+def _emit_027_template_function_direct_body(emit, values):
+    emit(values["file_scope"])
+    emit(" PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["direct_call_arg_spec"])
+    emit(
+        ") {\n#ifndef __NUITKA_NO_ASSERT__\nNUITKA_MAY_BE_UNUSED bool had_error = HAS_ERROR_OCCURRED(tstate);\nassert(!had_error); \n#endif\n\n\n"
+    )
+    emit(values["function_locals"])
+    emit("\n\n\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["function_exit"])
+    emit("\n}\n")
+
+
+def _emit_027_template_function_direct_body_readable(emit, values):
+    emit(values["file_scope"])
+    emit(" PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["direct_call_arg_spec"])
+    emit(
+        ") {\n#ifndef __NUITKA_NO_ASSERT__\n    NUITKA_MAY_BE_UNUSED bool had_error = HAS_ERROR_OCCURRED(tstate);\n    assert(!had_error); // Do not enter inlined functions with error set.\n#endif\n\n    // Local variable declarations.\n"
+    )
+    emit(values["function_locals"])
+    emit("\n\n    // Actual function body.\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["function_exit"])
+    emit("\n}\n")
+
+
+def _emit_028_template_generator_context_maker_decl(emit, values):
     emit("static PyObject *")
     emit(values["generator_maker_identifier"])
     emit("(")
@@ -944,7 +978,7 @@ def _emit_027_template_generator_context_maker_decl(emit, values):
     emit(");\n")
 
 
-def _emit_027_template_generator_context_maker_decl_readable(emit, values):
+def _emit_028_template_generator_context_maker_decl_readable(emit, values):
     emit("static PyObject *")
     emit(values["generator_maker_identifier"])
     emit("(")
@@ -952,7 +986,7 @@ def _emit_027_template_generator_context_maker_decl_readable(emit, values):
     emit(");\n")
 
 
-def _emit_028_template_generator_context_body_template(emit, values):
+def _emit_029_template_generator_context_body_template(emit, values):
     emit("\n#if ")
     emit(values["has_heap_declaration"])
     emit("\nstruct ")
@@ -1000,7 +1034,7 @@ def _emit_028_template_generator_context_body_template(emit, values):
     emit("_locals)\n#else\n0\n#endif\n);\n}\n")
 
 
-def _emit_028_template_generator_context_body_template_readable(emit, values):
+def _emit_029_template_generator_context_body_template_readable(emit, values):
     emit("\n#if ")
     emit(values["has_heap_declaration"])
     emit("\nstruct ")
@@ -1048,7 +1082,7 @@ def _emit_028_template_generator_context_body_template_readable(emit, values):
     emit("_locals)\n#else\n        0\n#endif\n    );\n}\n")
 
 
-def _emit_029_template_make_generator(emit, values):
+def _emit_030_template_make_generator(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
@@ -1059,7 +1093,7 @@ def _emit_029_template_make_generator(emit, values):
     emit(");\n")
 
 
-def _emit_029_template_make_generator_readable(emit, values):
+def _emit_030_template_make_generator_readable(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
@@ -1070,7 +1104,7 @@ def _emit_029_template_make_generator_readable(emit, values):
     emit(");\n")
 
 
-def _emit_030_template_make_empty_generator(emit, values):
+def _emit_031_template_make_empty_generator(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
@@ -1089,7 +1123,7 @@ def _emit_030_template_make_empty_generator(emit, values):
     emit("\n);\n")
 
 
-def _emit_030_template_make_empty_generator_readable(emit, values):
+def _emit_031_template_make_empty_generator_readable(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
@@ -1108,7 +1142,7 @@ def _emit_030_template_make_empty_generator_readable(emit, values):
     emit("\n);\n")
 
 
-def _emit_031_template_generator_exception_exit(emit, values):
+def _emit_032_template_generator_exception_exit(emit, values):
     emit(values["function_cleanup"])
     emit("\nreturn NULL;\n\nfunction_exception_exit:\n")
     emit(values["function_cleanup"])
@@ -1119,7 +1153,7 @@ def _emit_031_template_generator_exception_exit(emit, values):
     emit(");\n\nreturn NULL;\n")
 
 
-def _emit_031_template_generator_exception_exit_readable(emit, values):
+def _emit_032_template_generator_exception_exit_readable(emit, values):
     emit(values["function_cleanup"])
     emit("\n    return NULL;\n\n    function_exception_exit:\n")
     emit(values["function_cleanup"])
@@ -1130,19 +1164,19 @@ def _emit_031_template_generator_exception_exit_readable(emit, values):
     emit(");\n\n    return NULL;\n")
 
 
-def _emit_032_template_generator_no_exception_exit(emit, values):
+def _emit_033_template_generator_no_exception_exit(emit, values):
     emit("\n")
     emit(values["function_cleanup"])
     emit("\nreturn NULL;\n")
 
 
-def _emit_032_template_generator_no_exception_exit_readable(emit, values):
+def _emit_033_template_generator_no_exception_exit_readable(emit, values):
     emit("    // Return statement need not be present.\n")
     emit(values["function_cleanup"])
     emit("\n    return NULL;\n")
 
 
-def _emit_033_template_generator_return_exit(emit, values):
+def _emit_034_template_generator_return_exit(emit, values):
     emit(
         'NUITKA_CANNOT_GET_HERE("Generator must have exited already.");\nreturn NULL;\n\nfunction_return_exit:\n#if PYTHON_VERSION >= 0x300\ngenerator->m_returned = '
     )
@@ -1152,7 +1186,7 @@ def _emit_033_template_generator_return_exit(emit, values):
     emit("\nreturn NULL;\n")
 
 
-def _emit_033_template_generator_return_exit_readable(emit, values):
+def _emit_034_template_generator_return_exit_readable(emit, values):
     emit(
         '    NUITKA_CANNOT_GET_HERE("Generator must have exited already.");\n    return NULL;\n\n    function_return_exit:\n#if PYTHON_VERSION >= 0x300\n    generator->m_returned = '
     )
@@ -1162,7 +1196,7 @@ def _emit_033_template_generator_return_exit_readable(emit, values):
     emit("\n    return NULL;\n")
 
 
-def _emit_034_template_loop_break_next(emit, values):
+def _emit_035_template_loop_break_next(emit, values):
     emit("if (")
     emit(values["to_name"])
     emit(" == NULL) {\nif (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
@@ -1182,7 +1216,7 @@ def _emit_034_template_loop_break_next(emit, values):
     emit(";\n}\n}\n")
 
 
-def _emit_034_template_loop_break_next_readable(emit, values):
+def _emit_035_template_loop_break_next_readable(emit, values):
     emit("if (")
     emit(values["to_name"])
     emit(" == NULL) {\n    if (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
@@ -1202,7 +1236,7 @@ def _emit_034_template_loop_break_next_readable(emit, values):
     emit(";\n    }\n}\n")
 
 
-def _emit_035_template_metapath_loader_body(emit, values):
+def _emit_036_template_metapath_loader_body(emit, values):
     emit(
         '\n\n\n#include "nuitka/prelude.h"\n\n\n#if PY_MICRO_VERSION < 16\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + PY_MICRO_VERSION)\n#else\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + 15)\n#endif\n\n#include "nuitka/constants_blob.h"\n\n#include "nuitka/tracing.h"\n#include "nuitka/unfreezing.h"\n\n\n#ifndef __cplusplus\n#include <stdbool.h>\n#endif\n\n#if '
     )
@@ -1234,7 +1268,7 @@ def _emit_035_template_metapath_loader_body(emit, values):
     )
 
 
-def _emit_035_template_metapath_loader_body_readable(emit, values):
+def _emit_036_template_metapath_loader_body_readable(emit, values):
     emit(
         '\n/* Code to register embedded modules for meta path based loading if any. */\n\n#include "nuitka/prelude.h"\n\n/* Use a hex version of our own to compare for versions. We do not care about pre-releases */\n#if PY_MICRO_VERSION < 16\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + PY_MICRO_VERSION)\n#else\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + 15)\n#endif\n\n#include "nuitka/constants_blob.h"\n\n#include "nuitka/tracing.h"\n#include "nuitka/unfreezing.h"\n\n/* Type bool, spell-checker: ignore stdbool */\n#ifndef __cplusplus\n#include <stdbool.h>\n#endif\n\n#if '
     )
@@ -1266,18 +1300,13 @@ def _emit_035_template_metapath_loader_body_readable(emit, values):
     )
 
 
-def _emit_036_template_global_copyright(emit, values):
-    emit(values["module_identifier"])
-    emit("'\n* created by Nuitka version ")
-    emit(values["version"])
-    emit("\n*\n* This code is in part copyright ")
-    emit(values["year"])
-    emit(
-        ' Kay Hayen.\n*\n* Licensed under the GNU Affero General Public License, Version 3 (the "License");\n* you may not use this file except in compliance with the License.\n*\n* You may obtain a copy of the License in "LICENSE.txt" and the runtime\n* exception granted in "LICENSE-RUNTIME.txt" from Nuitka source code. For\n* deploying the generated code it is intended to not restrict distributing\n* created binaries.\n*\n* Unless required by applicable law or agreed to in writing, software\n* distributed under the License is distributed on an "AS IS" BASIS,\n* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n* See the License for the specific language governing permissions and\n* limitations under the License.\n*/\n'
-    )
+def _emit_037_template_global_copyright(emit, values):
+    emit("\n")
+    emit("\n\n")
+    emit("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n")
 
 
-def _emit_036_template_global_copyright_readable(emit, values):
+def _emit_037_template_global_copyright_readable(emit, values):
     emit("/* Generated code for Python module '")
     emit(values["module_identifier"])
     emit("'\n * created by Nuitka version ")
@@ -1289,16 +1318,13 @@ def _emit_036_template_global_copyright_readable(emit, values):
     )
 
 
-def _emit_037_template_module_body_template(emit, values):
+def _emit_038_template_module_body_template(emit, values):
     emit(
         '\n#include "nuitka/prelude.h"\n\n#include "nuitka/unfreezing.h"\n\n#include "__helpers.h"\n\n'
     )
     emit(values["module_includes"])
     emit("\n\n")
-    emit(values["module_identifier"])
-    emit(
-        '" is a Python object pointer of module type.\n*\n* Note: For full compatibility with CPython, every module variable access\n* needs to go through it except for cases where the module cannot possibly\n* have changed in the mean time.\n*/\n\nPyObject *module_'
-    )
+    emit("\n\n\n\n\n\n\nPyObject *module_")
     emit(values["module_identifier"])
     emit(";\nPyDictObject *moduledict_")
     emit(values["module_identifier"])
@@ -1378,7 +1404,7 @@ def _emit_037_template_module_body_template(emit, values):
         '(PyThreadState *tstate, PyObject *module, struct Nuitka_MetaPathBasedLoaderEntry const *loader_entry) {\n\nPGO_onModuleEntered("'
     )
     emit(values["module_identifier"])
-    emit('");\n\n// Store the module for future use.\nmodule_')
+    emit('");\n\n\nmodule_')
     emit(values["module_identifier"])
     emit(" = module;\n\nmoduledict_")
     emit(values["module_identifier"])
@@ -1399,7 +1425,7 @@ def _emit_037_template_module_body_template(emit, values):
     emit(' >= 0\n#ifdef _NUITKA_TRACE\nPRINT_STRING("')
     emit(values["module_identifier"])
     emit(
-        ': Calling updateMetaPathBasedLoaderModuleRoot().\\n");\n#endif\nupdateMetaPathBasedLoaderModuleRoot(module_full_name);\n#endif\n\n\n#if PYTHON_VERSION >= 0x300\npatchInspectModule(tstate);\n#endif\n\n#endif\n\n/* The constants only used by this module are created now. */\nNUITKA_PRINT_TRACE("'
+        ': Calling updateMetaPathBasedLoaderModuleRoot().\\n");\n#endif\nupdateMetaPathBasedLoaderModuleRoot(module_full_name);\n#endif\n\n\n#if PYTHON_VERSION >= 0x300\npatchInspectModule(tstate);\n#endif\n\n#endif\n\n\nNUITKA_PRINT_TRACE("'
     )
     emit(values["module_identifier"])
     emit(
@@ -1409,9 +1435,8 @@ def _emit_037_template_module_body_template(emit, values):
     emit("\nPyObject *pre_load = IMPORT_EMBEDDED_MODULE(tstate, ")
     emit(values["module_name_cstr"])
     emit(' "-preLoad");\nif (pre_load == NULL) {\nreturn NULL;\n}\n#endif\n\n')
-    emit(values["module_identifier"])
     emit(
-        '\\n");\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n{\nchar const *module_name_c;\nif (loader_entry != NULL) {\nmodule_name_c = loader_entry->name;\n} else {\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_'
+        "\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n{\nchar const *module_name_c;\nif (loader_entry != NULL) {\nmodule_name_c = loader_entry->name;\n} else {\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_"
     )
     emit(values["module_identifier"])
     emit(
@@ -1515,7 +1540,7 @@ def _emit_037_template_module_body_template(emit, values):
     emit("\n")
 
 
-def _emit_037_template_module_body_template_readable(emit, values):
+def _emit_038_template_module_body_template_readable(emit, values):
     emit(
         '\n#include "nuitka/prelude.h"\n\n#include "nuitka/unfreezing.h"\n\n#include "__helpers.h"\n\n'
     )
@@ -1765,7 +1790,7 @@ def _emit_037_template_module_body_template_readable(emit, values):
     emit("\n")
 
 
-def _emit_038_template_module_external_entry_point(emit, values):
+def _emit_039_template_module_external_entry_point(emit, values):
     emit(
         '\n\n\n#if defined(__GNUC__)\n\n#if PYTHON_VERSION < 0x300\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyMODINIT_FUNC\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC __attribute__((visibility("default")))\n#endif\n\n#else\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyObject *\n#else\n\n#ifdef __cplusplus\n#define NUITKA_MODULE_INIT_FUNCTION extern "C" __attribute__((visibility("default"))) PyObject *\n#else\n#define NUITKA_MODULE_INIT_FUNCTION __attribute__((visibility("default"))) PyObject *\n#endif\n\n#endif\n#endif\n\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC\n#endif\n\nstatic PyObject *orig_dunder_file_value;\n\n#if PYTHON_VERSION >= 0x300\nstatic setattrofunc orig_PyModule_Type_tp_setattro;\n\n\nstatic int Nuitka_TopLevelModule_tp_setattro(PyObject *module, PyObject *name, PyObject *value) {\nPyModule_Type.tp_setattro = orig_PyModule_Type_tp_setattro;\n\nif (orig_dunder_file_value != NULL) {\nUPDATE_STRING_DICT0(\nmoduledict_'
     )
@@ -1837,7 +1862,7 @@ def _emit_038_template_module_external_entry_point(emit, values):
     emit("_phase2(module);\n#endif\n}\n")
 
 
-def _emit_038_template_module_external_entry_point_readable(emit, values):
+def _emit_039_template_module_external_entry_point_readable(emit, values):
     emit(
         '\n\n/* Visibility definitions to make the DLL entry point exported */\n#if defined(__GNUC__)\n\n#if PYTHON_VERSION < 0x300\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyMODINIT_FUNC\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC __attribute__((visibility("default")))\n#endif\n\n#else\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyObject *\n#else\n\n#ifdef __cplusplus\n#define NUITKA_MODULE_INIT_FUNCTION extern "C" __attribute__((visibility("default"))) PyObject *\n#else\n#define NUITKA_MODULE_INIT_FUNCTION __attribute__((visibility("default"))) PyObject *\n#endif\n\n#endif\n#endif\n\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC\n#endif\n\nstatic PyObject *orig_dunder_file_value;\n\n#if PYTHON_VERSION >= 0x300\nstatic setattrofunc orig_PyModule_Type_tp_setattro;\n\n/* This is used one time only. */\nstatic int Nuitka_TopLevelModule_tp_setattro(PyObject *module, PyObject *name, PyObject *value) {\n    PyModule_Type.tp_setattro = orig_PyModule_Type_tp_setattro;\n\n    if (orig_dunder_file_value != NULL) {\n        UPDATE_STRING_DICT0(\n            moduledict_'
     )
@@ -1913,7 +1938,7 @@ def _emit_038_template_module_external_entry_point_readable(emit, values):
     emit("_phase2(module);\n#endif\n}\n")
 
 
-def _emit_039_template_module_exception_exit(emit, values):
+def _emit_040_template_module_exception_exit(emit, values):
     emit("module_exception_exit:\n\n#if _NUITKA_MODULE_MODE && ")
     emit(str(values["is_top"]))
     emit("\n{\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
@@ -1927,7 +1952,7 @@ def _emit_039_template_module_exception_exit(emit, values):
     )
 
 
-def _emit_039_template_module_exception_exit_readable(emit, values):
+def _emit_040_template_module_exception_exit_readable(emit, values):
     emit("    module_exception_exit:\n\n#if _NUITKA_MODULE_MODE && ")
     emit(str(values["is_top"]))
     emit("\n    {\n        PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
@@ -1941,27 +1966,27 @@ def _emit_039_template_module_exception_exit_readable(emit, values):
     )
 
 
-def _emit_040_template_module_no_exception_exit(emit, values):
+def _emit_041_template_module_no_exception_exit(emit, values):
     emit("}")
 
 
-def _emit_040_template_module_no_exception_exit_readable(emit, values):
+def _emit_041_template_module_no_exception_exit_readable(emit, values):
     emit("}")
 
 
-def _emit_041_template_helper_impl_decl(emit, values):
+def _emit_042_template_helper_impl_decl(emit, values):
     emit(
         '\n\n\n#include "nuitka/prelude.h"\n\nextern PyObject *callPythonFunction(PyObject *func, PyObject *const *args, int count);\n\n'
     )
 
 
-def _emit_041_template_helper_impl_decl_readable(emit, values):
+def _emit_042_template_helper_impl_decl_readable(emit, values):
     emit(
         '// This file contains helper functions that are automatically created from\n// templates.\n\n#include "nuitka/prelude.h"\n\nextern PyObject *callPythonFunction(PyObject *func, PyObject *const *args, int count);\n\n'
     )
 
 
-def _emit_042_template_header_guard(emit, values):
+def _emit_043_template_header_guard(emit, values):
     emit("#ifndef ")
     emit(values["header_guard_name"])
     emit("\n#define ")
@@ -1971,7 +1996,7 @@ def _emit_042_template_header_guard(emit, values):
     emit("\n#endif\n")
 
 
-def _emit_042_template_header_guard_readable(emit, values):
+def _emit_043_template_header_guard_readable(emit, values):
     emit("#ifndef ")
     emit(values["header_guard_name"])
     emit("\n#define ")
@@ -1981,7 +2006,7 @@ def _emit_042_template_header_guard_readable(emit, values):
     emit("\n#endif\n")
 
 
-def _emit_043_template_write_local_unclear_ref0(emit, values):
+def _emit_044_template_write_local_unclear_ref0(emit, values):
     emit("{\nPyObject *old = ")
     emit(values["identifier"])
     emit(";\n")
@@ -1991,7 +2016,7 @@ def _emit_043_template_write_local_unclear_ref0(emit, values):
     emit(";\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_043_template_write_local_unclear_ref0_readable(emit, values):
+def _emit_044_template_write_local_unclear_ref0_readable(emit, values):
     emit("{\n    PyObject *old = ")
     emit(values["identifier"])
     emit(";\n    ")
@@ -2001,7 +2026,7 @@ def _emit_043_template_write_local_unclear_ref0_readable(emit, values):
     emit(";\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_044_template_write_local_unclear_ref1(emit, values):
+def _emit_045_template_write_local_unclear_ref1(emit, values):
     emit("{\nPyObject *old = ")
     emit(values["identifier"])
     emit(";\n")
@@ -2013,7 +2038,7 @@ def _emit_044_template_write_local_unclear_ref1(emit, values):
     emit(");\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_044_template_write_local_unclear_ref1_readable(emit, values):
+def _emit_045_template_write_local_unclear_ref1_readable(emit, values):
     emit("{\n    PyObject *old = ")
     emit(values["identifier"])
     emit(";\n    ")
@@ -2025,7 +2050,7 @@ def _emit_044_template_write_local_unclear_ref1_readable(emit, values):
     emit(");\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_045_template_write_local_empty_ref0(emit, values):
+def _emit_046_template_write_local_empty_ref0(emit, values):
     emit("assert(")
     emit(values["identifier"])
     emit(" == NULL);\n")
@@ -2035,7 +2060,7 @@ def _emit_045_template_write_local_empty_ref0(emit, values):
     emit(";")
 
 
-def _emit_045_template_write_local_empty_ref0_readable(emit, values):
+def _emit_046_template_write_local_empty_ref0_readable(emit, values):
     emit("assert(")
     emit(values["identifier"])
     emit(" == NULL);\n")
@@ -2045,7 +2070,7 @@ def _emit_045_template_write_local_empty_ref0_readable(emit, values):
     emit(";")
 
 
-def _emit_046_template_write_local_empty_ref1(emit, values):
+def _emit_047_template_write_local_empty_ref1(emit, values):
     emit("assert(")
     emit(values["identifier"])
     emit(" == NULL);\nPy_INCREF(")
@@ -2057,7 +2082,7 @@ def _emit_046_template_write_local_empty_ref1(emit, values):
     emit(";")
 
 
-def _emit_046_template_write_local_empty_ref1_readable(emit, values):
+def _emit_047_template_write_local_empty_ref1_readable(emit, values):
     emit("assert(")
     emit(values["identifier"])
     emit(" == NULL);\nPy_INCREF(")
@@ -2069,7 +2094,7 @@ def _emit_046_template_write_local_empty_ref1_readable(emit, values):
     emit(";")
 
 
-def _emit_047_template_write_local_clear_ref0(emit, values):
+def _emit_048_template_write_local_clear_ref0(emit, values):
     emit("{\nPyObject *old = ")
     emit(values["identifier"])
     emit(";\nassert(old != NULL);\n")
@@ -2079,7 +2104,7 @@ def _emit_047_template_write_local_clear_ref0(emit, values):
     emit(";\nPy_DECREF(old);\n}\n")
 
 
-def _emit_047_template_write_local_clear_ref0_readable(emit, values):
+def _emit_048_template_write_local_clear_ref0_readable(emit, values):
     emit("{\n    PyObject *old = ")
     emit(values["identifier"])
     emit(";\n    assert(old != NULL);\n    ")
@@ -2089,21 +2114,21 @@ def _emit_047_template_write_local_clear_ref0_readable(emit, values):
     emit(";\n    Py_DECREF(old);\n}\n")
 
 
-def _emit_048_template_write_local_inplace(emit, values):
+def _emit_049_template_write_local_inplace(emit, values):
     emit(values["identifier"])
     emit(" = ")
     emit(values["tmp_name"])
     emit(";\n")
 
 
-def _emit_048_template_write_local_inplace_readable(emit, values):
+def _emit_049_template_write_local_inplace_readable(emit, values):
     emit(values["identifier"])
     emit(" = ")
     emit(values["tmp_name"])
     emit(";\n")
 
 
-def _emit_049_template_write_shared_inplace(emit, values):
+def _emit_050_template_write_shared_inplace(emit, values):
     emit("Nuitka_Cell_SET(")
     emit(values["identifier"])
     emit(", ")
@@ -2111,7 +2136,7 @@ def _emit_049_template_write_shared_inplace(emit, values):
     emit(");\n")
 
 
-def _emit_049_template_write_shared_inplace_readable(emit, values):
+def _emit_050_template_write_shared_inplace_readable(emit, values):
     emit("Nuitka_Cell_SET(")
     emit(values["identifier"])
     emit(", ")
@@ -2119,7 +2144,7 @@ def _emit_049_template_write_shared_inplace_readable(emit, values):
     emit(");\n")
 
 
-def _emit_050_template_write_local_clear_ref1(emit, values):
+def _emit_051_template_write_local_clear_ref1(emit, values):
     emit("{\nPyObject *old = ")
     emit(values["identifier"])
     emit(";\nassert(old != NULL);\n")
@@ -2131,7 +2156,7 @@ def _emit_050_template_write_local_clear_ref1(emit, values):
     emit(");\nPy_DECREF(old);\n}\n")
 
 
-def _emit_050_template_write_local_clear_ref1_readable(emit, values):
+def _emit_051_template_write_local_clear_ref1_readable(emit, values):
     emit("{\n    PyObject *old = ")
     emit(values["identifier"])
     emit(";\n    assert(old != NULL);\n    ")
@@ -2143,7 +2168,7 @@ def _emit_050_template_write_local_clear_ref1_readable(emit, values):
     emit(");\n    Py_DECREF(old);\n}\n")
 
 
-def _emit_051_template_write_shared_unclear_ref0(emit, values):
+def _emit_052_template_write_shared_unclear_ref0(emit, values):
     emit("{\nPyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\nNuitka_Cell_SET(")
@@ -2153,7 +2178,7 @@ def _emit_051_template_write_shared_unclear_ref0(emit, values):
     emit(");\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_051_template_write_shared_unclear_ref0_readable(emit, values):
+def _emit_052_template_write_shared_unclear_ref0_readable(emit, values):
     emit("{\n    PyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n    Nuitka_Cell_SET(")
@@ -2163,7 +2188,7 @@ def _emit_051_template_write_shared_unclear_ref0_readable(emit, values):
     emit(");\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_052_template_write_shared_unclear_ref1(emit, values):
+def _emit_053_template_write_shared_unclear_ref1(emit, values):
     emit("{\nPyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\nNuitka_Cell_SET(")
@@ -2175,7 +2200,7 @@ def _emit_052_template_write_shared_unclear_ref1(emit, values):
     emit(");\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_052_template_write_shared_unclear_ref1_readable(emit, values):
+def _emit_053_template_write_shared_unclear_ref1_readable(emit, values):
     emit("{\n    PyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n    Nuitka_Cell_SET(")
@@ -2187,7 +2212,7 @@ def _emit_052_template_write_shared_unclear_ref1_readable(emit, values):
     emit(");\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_053_template_write_shared_clear_ref0(emit, values):
+def _emit_054_template_write_shared_clear_ref0(emit, values):
     emit("assert(Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(") == NULL);\nNuitka_Cell_SET(")
@@ -2197,7 +2222,7 @@ def _emit_053_template_write_shared_clear_ref0(emit, values):
     emit(");\n")
 
 
-def _emit_053_template_write_shared_clear_ref0_readable(emit, values):
+def _emit_054_template_write_shared_clear_ref0_readable(emit, values):
     emit("assert(Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(") == NULL);\nNuitka_Cell_SET(")
@@ -2207,7 +2232,7 @@ def _emit_053_template_write_shared_clear_ref0_readable(emit, values):
     emit(");\n")
 
 
-def _emit_054_template_write_shared_clear_ref1(emit, values):
+def _emit_055_template_write_shared_clear_ref1(emit, values):
     emit("assert(Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(") == NULL);\nPy_INCREF(")
@@ -2219,7 +2244,7 @@ def _emit_054_template_write_shared_clear_ref1(emit, values):
     emit(");\n")
 
 
-def _emit_054_template_write_shared_clear_ref1_readable(emit, values):
+def _emit_055_template_write_shared_clear_ref1_readable(emit, values):
     emit("assert(Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(") == NULL);\nPy_INCREF(")
@@ -2231,7 +2256,7 @@ def _emit_054_template_write_shared_clear_ref1_readable(emit, values):
     emit(");\n")
 
 
-def _emit_055_template_del_local_tolerant(emit, values):
+def _emit_056_template_del_local_tolerant(emit, values):
     emit("Py_XDECREF(")
     emit(values["identifier"])
     emit(");\n")
@@ -2239,7 +2264,7 @@ def _emit_055_template_del_local_tolerant(emit, values):
     emit(" = NULL;\n")
 
 
-def _emit_055_template_del_local_tolerant_readable(emit, values):
+def _emit_056_template_del_local_tolerant_readable(emit, values):
     emit("Py_XDECREF(")
     emit(values["identifier"])
     emit(");\n")
@@ -2247,7 +2272,7 @@ def _emit_055_template_del_local_tolerant_readable(emit, values):
     emit(" = NULL;\n")
 
 
-def _emit_056_template_del_shared_tolerant(emit, values):
+def _emit_057_template_del_shared_tolerant(emit, values):
     emit("{\nPyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\nNuitka_Cell_SET(")
@@ -2255,7 +2280,7 @@ def _emit_056_template_del_shared_tolerant(emit, values):
     emit(", NULL);\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_056_template_del_shared_tolerant_readable(emit, values):
+def _emit_057_template_del_shared_tolerant_readable(emit, values):
     emit("{\n    PyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n    Nuitka_Cell_SET(")
@@ -2263,7 +2288,7 @@ def _emit_056_template_del_shared_tolerant_readable(emit, values):
     emit(", NULL);\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_057_template_del_local_intolerant(emit, values):
+def _emit_058_template_del_local_intolerant(emit, values):
     emit(values["result"])
     emit(" = ")
     emit(values["identifier"])
@@ -2276,7 +2301,7 @@ def _emit_057_template_del_local_intolerant(emit, values):
     emit(" = NULL;\n}\n")
 
 
-def _emit_057_template_del_local_intolerant_readable(emit, values):
+def _emit_058_template_del_local_intolerant_readable(emit, values):
     emit(values["result"])
     emit(" = ")
     emit(values["identifier"])
@@ -2289,7 +2314,7 @@ def _emit_057_template_del_local_intolerant_readable(emit, values):
     emit(" = NULL;\n}\n")
 
 
-def _emit_058_template_del_shared_intolerant(emit, values):
+def _emit_059_template_del_shared_intolerant(emit, values):
     emit("{\nPyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\nNuitka_Cell_SET(")
@@ -2299,7 +2324,7 @@ def _emit_058_template_del_shared_intolerant(emit, values):
     emit(" = old != NULL;\n}\n")
 
 
-def _emit_058_template_del_shared_intolerant_readable(emit, values):
+def _emit_059_template_del_shared_intolerant_readable(emit, values):
     emit("{\n    PyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n    Nuitka_Cell_SET(")
@@ -2309,7 +2334,7 @@ def _emit_058_template_del_shared_intolerant_readable(emit, values):
     emit(" = old != NULL;\n}\n")
 
 
-def _emit_059_template_del_local_known(emit, values):
+def _emit_060_template_del_local_known(emit, values):
     emit("CHECK_OBJECT(")
     emit(values["identifier"])
     emit(");\nPy_DECREF(")
@@ -2319,7 +2344,7 @@ def _emit_059_template_del_local_known(emit, values):
     emit(" = NULL;\n")
 
 
-def _emit_059_template_del_local_known_readable(emit, values):
+def _emit_060_template_del_local_known_readable(emit, values):
     emit("CHECK_OBJECT(")
     emit(values["identifier"])
     emit(");\nPy_DECREF(")
@@ -2329,7 +2354,7 @@ def _emit_059_template_del_local_known_readable(emit, values):
     emit(" = NULL;\n")
 
 
-def _emit_060_template_del_shared_known(emit, values):
+def _emit_061_template_del_shared_known(emit, values):
     emit("{\nPyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\nNuitka_Cell_SET(")
@@ -2337,7 +2362,7 @@ def _emit_060_template_del_shared_known(emit, values):
     emit(", NULL);\n\nCHECK_OBJECT(old);\nPy_DECREF(old);\n}\n")
 
 
-def _emit_060_template_del_shared_known_readable(emit, values):
+def _emit_061_template_del_shared_known_readable(emit, values):
     emit("{\n    PyObject *old = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n    Nuitka_Cell_SET(")
@@ -2345,19 +2370,19 @@ def _emit_060_template_del_shared_known_readable(emit, values):
     emit(", NULL);\n\n    CHECK_OBJECT(old);\n    Py_DECREF(old);\n}\n")
 
 
-def _emit_061_template_release_object_unclear(emit, values):
+def _emit_062_template_release_object_unclear(emit, values):
     emit("Py_XDECREF(")
     emit(values["identifier"])
     emit(");")
 
 
-def _emit_061_template_release_object_unclear_readable(emit, values):
+def _emit_062_template_release_object_unclear_readable(emit, values):
     emit("Py_XDECREF(")
     emit(values["identifier"])
     emit(");")
 
 
-def _emit_062_template_release_object_clear(emit, values):
+def _emit_063_template_release_object_clear(emit, values):
     emit("CHECK_OBJECT(")
     emit(values["identifier"])
     emit(");\nPy_DECREF(")
@@ -2365,7 +2390,7 @@ def _emit_062_template_release_object_clear(emit, values):
     emit(");")
 
 
-def _emit_062_template_release_object_clear_readable(emit, values):
+def _emit_063_template_release_object_clear_readable(emit, values):
     emit("CHECK_OBJECT(")
     emit(values["identifier"])
     emit(");\nPy_DECREF(")
@@ -2373,21 +2398,21 @@ def _emit_062_template_release_object_clear_readable(emit, values):
     emit(");")
 
 
-def _emit_063_template_read_shared_known(emit, values):
+def _emit_064_template_read_shared_known(emit, values):
     emit(values["tmp_name"])
     emit(" = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n")
 
 
-def _emit_063_template_read_shared_known_readable(emit, values):
+def _emit_064_template_read_shared_known_readable(emit, values):
     emit(values["tmp_name"])
     emit(" = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n")
 
 
-def _emit_064_template_read_mvar_unclear(emit, values):
+def _emit_065_template_read_mvar_unclear(emit, values):
     emit(values["tmp_name"])
     emit(" = LOOKUP_MODULE_VALUE(moduledict_")
     emit(values["module_identifier"])
@@ -2396,7 +2421,7 @@ def _emit_064_template_read_mvar_unclear(emit, values):
     emit(");\n")
 
 
-def _emit_064_template_read_mvar_unclear_readable(emit, values):
+def _emit_065_template_read_mvar_unclear_readable(emit, values):
     emit(values["tmp_name"])
     emit(" = LOOKUP_MODULE_VALUE(moduledict_")
     emit(values["module_identifier"])
@@ -2405,7 +2430,7 @@ def _emit_064_template_read_mvar_unclear_readable(emit, values):
     emit(");\n")
 
 
-def _emit_065_template_read_locals_dict_with_fallback(emit, values):
+def _emit_066_template_read_locals_dict_with_fallback(emit, values):
     emit(values["to_name"])
     emit(" = ")
     emit(values["dict_get_item"])
@@ -2420,7 +2445,7 @@ def _emit_065_template_read_locals_dict_with_fallback(emit, values):
     emit("\n}\n")
 
 
-def _emit_065_template_read_locals_dict_with_fallback_readable(emit, values):
+def _emit_066_template_read_locals_dict_with_fallback_readable(emit, values):
     emit(values["to_name"])
     emit(" = ")
     emit(values["dict_get_item"])
@@ -2435,7 +2460,7 @@ def _emit_065_template_read_locals_dict_with_fallback_readable(emit, values):
     emit("\n}\n")
 
 
-def _emit_066_template_read_locals_dict_without_fallback(emit, values):
+def _emit_067_template_read_locals_dict_without_fallback(emit, values):
     emit(values["to_name"])
     emit(" = DICT_GET_ITEM0(tstate, ")
     emit(values["locals_dict"])
@@ -2444,7 +2469,7 @@ def _emit_066_template_read_locals_dict_without_fallback(emit, values):
     emit(");\n")
 
 
-def _emit_066_template_read_locals_dict_without_fallback_readable(emit, values):
+def _emit_067_template_read_locals_dict_without_fallback_readable(emit, values):
     emit(values["to_name"])
     emit(" = DICT_GET_ITEM0(tstate, ")
     emit(values["locals_dict"])
@@ -2453,7 +2478,7 @@ def _emit_066_template_read_locals_dict_without_fallback_readable(emit, values):
     emit(");\n")
 
 
-def _emit_067_template_read_locals_mapping_with_fallback_no_ref(emit, values):
+def _emit_068_template_read_locals_mapping_with_fallback_no_ref(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2472,7 +2497,7 @@ def _emit_067_template_read_locals_mapping_with_fallback_no_ref(emit, values):
     emit(";\n}\n}\n")
 
 
-def _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable(emit, values):
+def _emit_068_template_read_locals_mapping_with_fallback_no_ref_readable(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2491,7 +2516,7 @@ def _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable(emit, v
     emit(";\n    }\n}\n")
 
 
-def _emit_068_template_read_locals_mapping_with_fallback_ref(emit, values):
+def _emit_069_template_read_locals_mapping_with_fallback_ref(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2508,7 +2533,7 @@ def _emit_068_template_read_locals_mapping_with_fallback_ref(emit, values):
     emit(";\n}\n}\n")
 
 
-def _emit_068_template_read_locals_mapping_with_fallback_ref_readable(emit, values):
+def _emit_069_template_read_locals_mapping_with_fallback_ref_readable(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2525,7 +2550,7 @@ def _emit_068_template_read_locals_mapping_with_fallback_ref_readable(emit, valu
     emit(";\n    }\n}\n")
 
 
-def _emit_069_template_read_locals_mapping_without_fallback(emit, values):
+def _emit_070_template_read_locals_mapping_without_fallback(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2534,7 +2559,7 @@ def _emit_069_template_read_locals_mapping_without_fallback(emit, values):
     emit(");\n")
 
 
-def _emit_069_template_read_locals_mapping_without_fallback_readable(emit, values):
+def _emit_070_template_read_locals_mapping_without_fallback_readable(emit, values):
     emit(values["to_name"])
     emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
@@ -2543,7 +2568,7 @@ def _emit_069_template_read_locals_mapping_without_fallback_readable(emit, value
     emit(");\n")
 
 
-def _emit_070_template_del_global_unclear(emit, values):
+def _emit_071_template_del_global_unclear(emit, values):
     emit(values["result"])
     emit(" = DICT_REMOVE_ITEM((PyObject *)moduledict_")
     emit(values["module_identifier"])
@@ -2554,7 +2579,7 @@ def _emit_070_template_del_global_unclear(emit, values):
     emit(" == false) CLEAR_ERROR_OCCURRED(tstate);\n")
 
 
-def _emit_070_template_del_global_unclear_readable(emit, values):
+def _emit_071_template_del_global_unclear_readable(emit, values):
     emit(values["result"])
     emit(" = DICT_REMOVE_ITEM((PyObject *)moduledict_")
     emit(values["module_identifier"])
@@ -2565,7 +2590,7 @@ def _emit_070_template_del_global_unclear_readable(emit, values):
     emit(" == false) CLEAR_ERROR_OCCURRED(tstate);\n")
 
 
-def _emit_071_template_del_global_known(emit, values):
+def _emit_072_template_del_global_known(emit, values):
     emit("if (DICT_REMOVE_ITEM((PyObject *)moduledict_")
     emit(values["module_identifier"])
     emit(", ")
@@ -2573,7 +2598,7 @@ def _emit_071_template_del_global_known(emit, values):
     emit(") == false) {\nCLEAR_ERROR_OCCURRED(tstate);\n}\n")
 
 
-def _emit_071_template_del_global_known_readable(emit, values):
+def _emit_072_template_del_global_known_readable(emit, values):
     emit("if (DICT_REMOVE_ITEM((PyObject *)moduledict_")
     emit(values["module_identifier"])
     emit(", ")
@@ -2581,7 +2606,7 @@ def _emit_071_template_del_global_known_readable(emit, values):
     emit(") == false) {\n    CLEAR_ERROR_OCCURRED(tstate);\n}\n")
 
 
-def _emit_072_template_update_locals_dict_value(emit, values):
+def _emit_073_template_update_locals_dict_value(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\nPyObject *value;\n")
@@ -2597,7 +2622,7 @@ def _emit_072_template_update_locals_dict_value(emit, values):
     emit(") == false) {\nCLEAR_ERROR_OCCURRED(tstate);\n}\n}\n")
 
 
-def _emit_072_template_update_locals_dict_value_readable(emit, values):
+def _emit_073_template_update_locals_dict_value_readable(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\n    PyObject *value;\n")
@@ -2613,7 +2638,7 @@ def _emit_072_template_update_locals_dict_value_readable(emit, values):
     emit(") == false) {\n        CLEAR_ERROR_OCCURRED(tstate);\n    }\n}\n")
 
 
-def _emit_073_template_set_locals_dict_value(emit, values):
+def _emit_074_template_set_locals_dict_value(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\nPyObject *value;\n")
@@ -2625,7 +2650,7 @@ def _emit_073_template_set_locals_dict_value(emit, values):
     emit(",\nvalue\n);\n\nassert(res == 0);\n}\n")
 
 
-def _emit_073_template_set_locals_dict_value_readable(emit, values):
+def _emit_074_template_set_locals_dict_value_readable(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\n    PyObject *value;\n")
@@ -2637,7 +2662,7 @@ def _emit_073_template_set_locals_dict_value_readable(emit, values):
     emit(",\n        value\n    );\n\n    assert(res == 0);\n}\n")
 
 
-def _emit_074_template_update_locals_mapping_value(emit, values):
+def _emit_075_template_update_locals_mapping_value(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\nPyObject *value;\n")
@@ -2665,7 +2690,7 @@ def _emit_074_template_update_locals_mapping_value(emit, values):
     emit(" = true;\n}\n}\n")
 
 
-def _emit_074_template_update_locals_mapping_value_readable(emit, values):
+def _emit_075_template_update_locals_mapping_value_readable(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\n    PyObject *value;\n")
@@ -2695,7 +2720,7 @@ def _emit_074_template_update_locals_mapping_value_readable(emit, values):
     emit(" = true;\n    }\n}\n")
 
 
-def _emit_075_template_set_locals_mapping_value(emit, values):
+def _emit_076_template_set_locals_mapping_value(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\nPyObject *value;\n")
@@ -2711,7 +2736,7 @@ def _emit_075_template_set_locals_mapping_value(emit, values):
     emit(" = true;\n}\n")
 
 
-def _emit_075_template_set_locals_mapping_value_readable(emit, values):
+def _emit_076_template_set_locals_mapping_value_readable(emit, values):
     emit("if (")
     emit(values["test_code"])
     emit(") {\n    PyObject *value;\n")
@@ -2727,7 +2752,7 @@ def _emit_075_template_set_locals_mapping_value_readable(emit, values):
     emit(" = true;\n}\n")
 
 
-def _emit_076_template_module_variable_accessor_function(emit, values):
+def _emit_077_template_module_variable_accessor_function(emit, values):
     emit("static PyObject *")
     emit(values["accessor_function_name"])
     emit("(PyThreadState *tstate) {\n#if ")
@@ -2781,7 +2806,7 @@ def _emit_076_template_module_variable_accessor_function(emit, values):
     emit(");\n}\n\nreturn result;\n}\n")
 
 
-def _emit_076_template_module_variable_accessor_function_readable(emit, values):
+def _emit_077_template_module_variable_accessor_function_readable(emit, values):
     emit("static PyObject *")
     emit(values["accessor_function_name"])
     emit("(PyThreadState *tstate) {\n#if ")
@@ -2837,7 +2862,7 @@ def _emit_076_template_module_variable_accessor_function_readable(emit, values):
     emit(");\n    }\n\n    return result;\n}\n")
 
 
-def _emit_077_template_write_py_cell_inplace(emit, values):
+def _emit_078_template_write_py_cell_inplace(emit, values):
     emit("PyCell_SET((PyObject *)")
     emit(values["identifier"])
     emit(", ")
@@ -2845,7 +2870,7 @@ def _emit_077_template_write_py_cell_inplace(emit, values):
     emit(");\n")
 
 
-def _emit_077_template_write_py_cell_inplace_readable(emit, values):
+def _emit_078_template_write_py_cell_inplace_readable(emit, values):
     emit("PyCell_SET((PyObject *)")
     emit(values["identifier"])
     emit(", ")
@@ -2853,7 +2878,7 @@ def _emit_077_template_write_py_cell_inplace_readable(emit, values):
     emit(");\n")
 
 
-def _emit_078_template_write_py_cell_unclear_ref0(emit, values):
+def _emit_079_template_write_py_cell_unclear_ref0(emit, values):
     emit("{\nPyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\nPyCell_SET((PyObject *)")
@@ -2863,7 +2888,7 @@ def _emit_078_template_write_py_cell_unclear_ref0(emit, values):
     emit(");\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_078_template_write_py_cell_unclear_ref0_readable(emit, values):
+def _emit_079_template_write_py_cell_unclear_ref0_readable(emit, values):
     emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\n    PyCell_SET((PyObject *)")
@@ -2873,7 +2898,7 @@ def _emit_078_template_write_py_cell_unclear_ref0_readable(emit, values):
     emit(");\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_079_template_write_py_cell_unclear_ref1(emit, values):
+def _emit_080_template_write_py_cell_unclear_ref1(emit, values):
     emit("{\nPyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\nPyCell_SET((PyObject *)")
@@ -2885,7 +2910,7 @@ def _emit_079_template_write_py_cell_unclear_ref1(emit, values):
     emit(");\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_079_template_write_py_cell_unclear_ref1_readable(emit, values):
+def _emit_080_template_write_py_cell_unclear_ref1_readable(emit, values):
     emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\n    PyCell_SET((PyObject *)")
@@ -2897,7 +2922,7 @@ def _emit_079_template_write_py_cell_unclear_ref1_readable(emit, values):
     emit(");\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_080_template_del_py_cell_tolerant(emit, values):
+def _emit_081_template_del_py_cell_tolerant(emit, values):
     emit("{\nPyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\nPyCell_SET((PyObject *)")
@@ -2905,7 +2930,7 @@ def _emit_080_template_del_py_cell_tolerant(emit, values):
     emit(", NULL);\nPy_XDECREF(old);\n}\n")
 
 
-def _emit_080_template_del_py_cell_tolerant_readable(emit, values):
+def _emit_081_template_del_py_cell_tolerant_readable(emit, values):
     emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\n    PyCell_SET((PyObject *)")
@@ -2913,7 +2938,7 @@ def _emit_080_template_del_py_cell_tolerant_readable(emit, values):
     emit(", NULL);\n    Py_XDECREF(old);\n}\n")
 
 
-def _emit_081_template_del_py_cell_intolerant(emit, values):
+def _emit_082_template_del_py_cell_intolerant(emit, values):
     emit("{\nPyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\nPyCell_SET((PyObject *)")
@@ -2923,7 +2948,7 @@ def _emit_081_template_del_py_cell_intolerant(emit, values):
     emit(" = old != NULL;\n}\n")
 
 
-def _emit_081_template_del_py_cell_intolerant_readable(emit, values):
+def _emit_082_template_del_py_cell_intolerant_readable(emit, values):
     emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\n    PyCell_SET((PyObject *)")
@@ -2933,7 +2958,7 @@ def _emit_081_template_del_py_cell_intolerant_readable(emit, values):
     emit(" = old != NULL;\n}\n")
 
 
-def _emit_082_template_del_py_cell_known(emit, values):
+def _emit_083_template_del_py_cell_known(emit, values):
     emit("{\nPyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\nPyCell_SET((PyObject *)")
@@ -2941,7 +2966,7 @@ def _emit_082_template_del_py_cell_known(emit, values):
     emit(", NULL);\n\nCHECK_OBJECT(old);\nPy_DECREF(old);\n}\n")
 
 
-def _emit_082_template_del_py_cell_known_readable(emit, values):
+def _emit_083_template_del_py_cell_known_readable(emit, values):
     emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
     emit(values["identifier"])
     emit(");\n    PyCell_SET((PyObject *)")
@@ -3165,6 +3190,19 @@ template_infos = {
         _emit_024_template_function_body,
         _emit_024_template_function_body_readable,
     ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_direct_body": (
+        "812f0cfdb03205d9a3f6c1d2e47cccdbf034f20f52a48b38abc151fa629b74e1",
+        (
+            "direct_call_arg_spec",
+            "file_scope",
+            "function_body",
+            "function_exit",
+            "function_identifier",
+            "function_locals",
+        ),
+        _emit_027_template_function_direct_body,
+        _emit_027_template_function_direct_body_readable,
+    ),
     "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_direct_declaration": (
         "5fd5c08bee3a373a51d5e622b3f64fe6b2065ef75e0d37382a73eb3c944dac02",
         ("direct_call_arg_spec", "file_scope", "function_identifier"),
@@ -3237,32 +3275,32 @@ template_infos = {
             "has_heap_declaration",
             "heap_declaration",
         ),
-        _emit_028_template_generator_context_body_template,
-        _emit_028_template_generator_context_body_template_readable,
+        _emit_029_template_generator_context_body_template,
+        _emit_029_template_generator_context_body_template_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_context_maker_decl": (
         "4841f0b6421846e27390df65257fe96abf7e40d49834810445261474ca913234",
         ("generator_creation_args", "generator_maker_identifier"),
-        _emit_027_template_generator_context_maker_decl,
-        _emit_027_template_generator_context_maker_decl_readable,
+        _emit_028_template_generator_context_maker_decl,
+        _emit_028_template_generator_context_maker_decl_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_exception_exit": (
         "430ad39a236f3d3c0e4c34d54d8a77b3e62dd83968284b2adfe52cd12a2f9b91",
         ("exception_state_name", "function_cleanup"),
-        _emit_031_template_generator_exception_exit,
-        _emit_031_template_generator_exception_exit_readable,
+        _emit_032_template_generator_exception_exit,
+        _emit_032_template_generator_exception_exit_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_no_exception_exit": (
         "87995cc27186872b078370fc4dfba2b182d6a19360233f080640b3061ce0c4ed",
         ("function_cleanup",),
-        _emit_032_template_generator_no_exception_exit,
-        _emit_032_template_generator_no_exception_exit_readable,
+        _emit_033_template_generator_no_exception_exit,
+        _emit_033_template_generator_no_exception_exit_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_return_exit": (
         "f06ad373e40a6038b3e2569fc28ca1ab262ef37815156fd2e0c6fbe6f3589b60",
         ("function_cleanup", "return_value"),
-        _emit_033_template_generator_return_exit,
-        _emit_033_template_generator_return_exit_readable,
+        _emit_034_template_generator_return_exit,
+        _emit_034_template_generator_return_exit_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_empty_generator": (
         "b99cf335642cd23e7ce6dd8de5d28c547e4dce566169ba9a137990b9c53fc676",
@@ -3276,14 +3314,14 @@ template_infos = {
             "generator_qualname_obj",
             "to_name",
         ),
-        _emit_030_template_make_empty_generator,
-        _emit_030_template_make_empty_generator_readable,
+        _emit_031_template_make_empty_generator,
+        _emit_031_template_make_empty_generator_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_generator": (
         "ef18f2f53fae77d87d02568d173349aab047ab21aeba825b26ab6473ff665c7e",
         ("args", "closure_copy", "generator_maker_identifier", "to_name"),
-        _emit_029_template_make_generator,
-        _emit_029_template_make_generator_readable,
+        _emit_030_template_make_generator,
+        _emit_030_template_make_generator_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesIterators.template_loop_break_next": (
         "92add9ba69be2a694b88e75c06b386542d271d43c9a21dd11bd2f47516b8eb20",
@@ -3297,8 +3335,8 @@ template_infos = {
             "to_name",
             "var_description_code",
         ),
-        _emit_034_template_loop_break_next,
-        _emit_034_template_loop_break_next_readable,
+        _emit_035_template_loop_break_next,
+        _emit_035_template_loop_break_next_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesLoader.template_metapath_loader_body": (
         "1f90f9fd9849405949fd86dc4397208da06b0b8f3239f4c751e05ffa6af3e7ce",
@@ -3309,26 +3347,26 @@ template_infos = {
             "metapath_loader_inittab",
             "metapath_module_decls",
         ),
-        _emit_035_template_metapath_loader_body,
-        _emit_035_template_metapath_loader_body_readable,
+        _emit_036_template_metapath_loader_body,
+        _emit_036_template_metapath_loader_body_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_global_copyright": (
         "16bd6ceb6d060356654eb1bf718a9e1b04d44ad1a3ed96d41f30c0346de14001",
         ("module_identifier", "version", "year"),
-        _emit_036_template_global_copyright,
-        _emit_036_template_global_copyright_readable,
+        _emit_037_template_global_copyright,
+        _emit_037_template_global_copyright_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_header_guard": (
         "1fffdd3b3c781d73b532acd2667d4c3701bf8da886bed3bc5be2a948e01f3008",
         ("header_body", "header_guard_name"),
-        _emit_042_template_header_guard,
-        _emit_042_template_header_guard_readable,
+        _emit_043_template_header_guard,
+        _emit_043_template_header_guard_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_helper_impl_decl": (
         "b4dbfc627b20fb92231456a7edb1a3a689ede4ddcb1b01b879911ab239a2fd3a",
         (),
-        _emit_041_template_helper_impl_decl,
-        _emit_041_template_helper_impl_decl_readable,
+        _emit_042_template_helper_impl_decl,
+        _emit_042_template_helper_impl_decl_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_module_body_template": (
         "929231ce442e0b271649c7b370813a1d7e7296b0aeb68d585e28fc4ae0943f9e",
@@ -3360,14 +3398,14 @@ template_infos = {
             "temps_decl",
             "use_direct_constant_blobs",
         ),
-        _emit_037_template_module_body_template,
-        _emit_037_template_module_body_template_readable,
+        _emit_038_template_module_body_template,
+        _emit_038_template_module_body_template_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_module_exception_exit": (
         "7545624bdd6f885197f6c6962c271d2169176b2619f7cbab5175f2558524d452",
         ("is_top", "module_identifier"),
-        _emit_039_template_module_exception_exit,
-        _emit_039_template_module_exception_exit_readable,
+        _emit_040_template_module_exception_exit,
+        _emit_040_template_module_exception_exit_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_module_external_entry_point": (
         "e6ccf0cd90836dcc9581272fc6769743f2d933010dcaa9c40fe2faed75d0c68e",
@@ -3377,98 +3415,98 @@ template_infos = {
             "module_identifier",
             "module_name_cstr",
         ),
-        _emit_038_template_module_external_entry_point,
-        _emit_038_template_module_external_entry_point_readable,
+        _emit_039_template_module_external_entry_point,
+        _emit_039_template_module_external_entry_point_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesModules.template_module_no_exception_exit": (
         "d10b36aa74a59bcf4a88185837f658afaf3646eff2bb16c3928d0e9335e945d2",
         (),
-        _emit_040_template_module_no_exception_exit,
-        _emit_040_template_module_no_exception_exit_readable,
+        _emit_041_template_module_no_exception_exit,
+        _emit_041_template_module_no_exception_exit_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_known": (
         "d52dabfbda2d73a75b60f8517c134170b673ebc5625dab0e4b117113f1aaa277",
         ("module_identifier", "var_name"),
-        _emit_071_template_del_global_known,
-        _emit_071_template_del_global_known_readable,
+        _emit_072_template_del_global_known,
+        _emit_072_template_del_global_known_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_unclear": (
         "e19f5a72a151a717a270dc98327195283acfd7b8e7d64ceaf4f9b69202a0ac4d",
         ("module_identifier", "result", "var_name"),
-        _emit_070_template_del_global_unclear,
-        _emit_070_template_del_global_unclear_readable,
+        _emit_071_template_del_global_unclear,
+        _emit_071_template_del_global_unclear_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_intolerant": (
         "fc2bcef2d97262102249aad6861201353e36b8cbd127c98a74d4532d99e040c6",
         ("identifier", "result"),
-        _emit_057_template_del_local_intolerant,
-        _emit_057_template_del_local_intolerant_readable,
+        _emit_058_template_del_local_intolerant,
+        _emit_058_template_del_local_intolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_known": (
         "ae5576a4e417926a6b8eaa943c8c79acfa65a057eb58f9997b1481e891bda0b0",
         ("identifier",),
-        _emit_059_template_del_local_known,
-        _emit_059_template_del_local_known_readable,
+        _emit_060_template_del_local_known,
+        _emit_060_template_del_local_known_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_tolerant": (
         "7c519e95013bbe50865ee8bdf7e1927a9b98f8d10e67604acd13b76b12462295",
         ("identifier",),
-        _emit_055_template_del_local_tolerant,
-        _emit_055_template_del_local_tolerant_readable,
+        _emit_056_template_del_local_tolerant,
+        _emit_056_template_del_local_tolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_intolerant": (
         "26d8c64439200a202fd0963d8b602913897455bfec7faf97303e84d1a2172d68",
         ("identifier", "result"),
-        _emit_081_template_del_py_cell_intolerant,
-        _emit_081_template_del_py_cell_intolerant_readable,
+        _emit_082_template_del_py_cell_intolerant,
+        _emit_082_template_del_py_cell_intolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_known": (
         "9b803de889dc98ab0a644cbe18256966ecd44342a12f8f76446175bf9ef5bc52",
         ("identifier",),
-        _emit_082_template_del_py_cell_known,
-        _emit_082_template_del_py_cell_known_readable,
+        _emit_083_template_del_py_cell_known,
+        _emit_083_template_del_py_cell_known_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_tolerant": (
         "70b2303a20bfc14342ed69a42e0c0d204f02fe207056d5aa6bc6cc2375450eb9",
         ("identifier",),
-        _emit_080_template_del_py_cell_tolerant,
-        _emit_080_template_del_py_cell_tolerant_readable,
+        _emit_081_template_del_py_cell_tolerant,
+        _emit_081_template_del_py_cell_tolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_intolerant": (
         "ddf1157ea0de7012d54093e6cffdee00f8dd5050b6d63162d17b66c166d3ae54",
         ("identifier", "result"),
-        _emit_058_template_del_shared_intolerant,
-        _emit_058_template_del_shared_intolerant_readable,
+        _emit_059_template_del_shared_intolerant,
+        _emit_059_template_del_shared_intolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_known": (
         "417c1768ca66c155bd9c48d2ada3bf6aebdeedd6da4643b5620fdc39f5fce0f4",
         ("identifier",),
-        _emit_060_template_del_shared_known,
-        _emit_060_template_del_shared_known_readable,
+        _emit_061_template_del_shared_known,
+        _emit_061_template_del_shared_known_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_tolerant": (
         "2e0d1aa2d273ac3be4aa858f4ad5d60ca15295a09fc0107cd151d16766143abf",
         ("identifier",),
-        _emit_056_template_del_shared_tolerant,
-        _emit_056_template_del_shared_tolerant_readable,
+        _emit_057_template_del_shared_tolerant,
+        _emit_057_template_del_shared_tolerant_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_module_variable_accessor_function": (
         "e6d5affebd0b8808d0fd3537203650ed25009ab4f65d6b0bce4d95c25b982dd6",
         ("accessor_function_name", "caching", "module_identifier", "var_name"),
-        _emit_076_template_module_variable_accessor_function,
-        _emit_076_template_module_variable_accessor_function_readable,
+        _emit_077_template_module_variable_accessor_function,
+        _emit_077_template_module_variable_accessor_function_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_with_fallback": (
         "26ee6849e18e5334d362a7e2411510fa02896be7b9fff97bfdc47b46f3d06f36",
         ("dict_get_item", "fallback", "locals_dict", "to_name", "var_name"),
-        _emit_065_template_read_locals_dict_with_fallback,
-        _emit_065_template_read_locals_dict_with_fallback_readable,
+        _emit_066_template_read_locals_dict_with_fallback,
+        _emit_066_template_read_locals_dict_with_fallback_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_without_fallback": (
         "5f07e5195932f38611856adaddbc68ff3452e5ffa81a93a035aff354250c6842",
         ("locals_dict", "to_name", "var_name"),
-        _emit_066_template_read_locals_dict_without_fallback,
-        _emit_066_template_read_locals_dict_without_fallback_readable,
+        _emit_067_template_read_locals_dict_without_fallback,
+        _emit_067_template_read_locals_dict_without_fallback_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_no_ref": (
         "4d673ff262ce29766823cbfef3c60f8e264e8d6210d36dfbf42631163a77f3be",
@@ -3480,8 +3518,8 @@ template_infos = {
             "to_name",
             "var_name",
         ),
-        _emit_067_template_read_locals_mapping_with_fallback_no_ref,
-        _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable,
+        _emit_068_template_read_locals_mapping_with_fallback_no_ref,
+        _emit_068_template_read_locals_mapping_with_fallback_no_ref_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_ref": (
         "bea3d667173723884aeb8e387b9bd2882b365b49ef26d2507a0a4a3d13079ce1",
@@ -3493,152 +3531,152 @@ template_infos = {
             "to_name",
             "var_name",
         ),
-        _emit_068_template_read_locals_mapping_with_fallback_ref,
-        _emit_068_template_read_locals_mapping_with_fallback_ref_readable,
+        _emit_069_template_read_locals_mapping_with_fallback_ref,
+        _emit_069_template_read_locals_mapping_with_fallback_ref_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_without_fallback": (
         "a1e8dceb6a326ffbf9e3492637406666a6cf25770e66df8db00e82b80c93a2ff",
         ("locals_dict", "to_name", "var_name"),
-        _emit_069_template_read_locals_mapping_without_fallback,
-        _emit_069_template_read_locals_mapping_without_fallback_readable,
+        _emit_070_template_read_locals_mapping_without_fallback,
+        _emit_070_template_read_locals_mapping_without_fallback_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_mvar_unclear": (
         "edfa07c85fa85055bf44003e44de9dc22aab0bcad78ceec5c8282846d8a79c76",
         ("module_identifier", "tmp_name", "var_name"),
-        _emit_064_template_read_mvar_unclear,
-        _emit_064_template_read_mvar_unclear_readable,
+        _emit_065_template_read_mvar_unclear,
+        _emit_065_template_read_mvar_unclear_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_shared_known": (
         "fd308f64b50e21c8f68921086401e41b3c0a4dd16d84644d2a05dd085547f69e",
         ("identifier", "tmp_name"),
-        _emit_063_template_read_shared_known,
-        _emit_063_template_read_shared_known_readable,
+        _emit_064_template_read_shared_known,
+        _emit_064_template_read_shared_known_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_clear": (
         "6cc31fe6f8c8c5bc622389deb2a50a23baa6e33861249043997def820b8cc5ca",
         ("identifier",),
-        _emit_062_template_release_object_clear,
-        _emit_062_template_release_object_clear_readable,
+        _emit_063_template_release_object_clear,
+        _emit_063_template_release_object_clear_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_unclear": (
         "4673b63d7274ed62ee911fab568304a54ba15172fac5807feb319f40980413ac",
         ("identifier",),
-        _emit_061_template_release_object_unclear,
-        _emit_061_template_release_object_unclear_readable,
+        _emit_062_template_release_object_unclear,
+        _emit_062_template_release_object_unclear_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_dict_value": (
         "e12be7b1c99f8ce52bca406a677a0e2b4c3f91a34d0166674077b6c9009234e9",
         ("access_code", "dict_name", "test_code", "var_name"),
-        _emit_073_template_set_locals_dict_value,
-        _emit_073_template_set_locals_dict_value_readable,
+        _emit_074_template_set_locals_dict_value,
+        _emit_074_template_set_locals_dict_value_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_mapping_value": (
         "65e3faa0b16044876f203e0e27b89c01d61bc2fffa0f34a1e331289db87abf4f",
         ("access_code", "mapping_name", "test_code", "tmp_name", "var_name"),
-        _emit_075_template_set_locals_mapping_value,
-        _emit_075_template_set_locals_mapping_value_readable,
+        _emit_076_template_set_locals_mapping_value,
+        _emit_076_template_set_locals_mapping_value_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_dict_value": (
         "d138fbf7934aea407c19732e68a8d428f3be62e9f8d009a804a22829ca8bac6f",
         ("access_code", "dict_name", "test_code", "var_name"),
-        _emit_072_template_update_locals_dict_value,
-        _emit_072_template_update_locals_dict_value_readable,
+        _emit_073_template_update_locals_dict_value,
+        _emit_073_template_update_locals_dict_value_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_mapping_value": (
         "2763851919448fde41dbd1a23d1a1f6d865d3219a3241c873c062c6cc11412c6",
         ("access_code", "mapping_name", "test_code", "tmp_name", "var_name"),
-        _emit_074_template_update_locals_mapping_value,
-        _emit_074_template_update_locals_mapping_value_readable,
+        _emit_075_template_update_locals_mapping_value,
+        _emit_075_template_update_locals_mapping_value_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref0": (
         "a79a193ae3f6f03bb44483feb56bce2461277064436ecc4e62bba12d99d87a44",
         ("identifier", "tmp_name"),
-        _emit_047_template_write_local_clear_ref0,
-        _emit_047_template_write_local_clear_ref0_readable,
+        _emit_048_template_write_local_clear_ref0,
+        _emit_048_template_write_local_clear_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref1": (
         "7187806a4d01c37782eb5b370cc23b688465b881a0cc5c86ae928978dbb9073a",
         ("identifier", "tmp_name"),
-        _emit_050_template_write_local_clear_ref1,
-        _emit_050_template_write_local_clear_ref1_readable,
+        _emit_051_template_write_local_clear_ref1,
+        _emit_051_template_write_local_clear_ref1_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref0": (
         "0f28bb1b6eb41e78703952a33bb5bb3c49601bc22dd1ea52f8efd9c36a752360",
         ("identifier", "tmp_name"),
-        _emit_045_template_write_local_empty_ref0,
-        _emit_045_template_write_local_empty_ref0_readable,
+        _emit_046_template_write_local_empty_ref0,
+        _emit_046_template_write_local_empty_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref1": (
         "6231a9e663b590213380cd3e0f8e9f56655c7d89f437ff4c9ce6f256d73b593e",
         ("identifier", "tmp_name"),
-        _emit_046_template_write_local_empty_ref1,
-        _emit_046_template_write_local_empty_ref1_readable,
+        _emit_047_template_write_local_empty_ref1,
+        _emit_047_template_write_local_empty_ref1_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_inplace": (
         "6b24114fbcb93f554d4781e910348485bc78f481a014561090ada2455a5ec3fd",
         ("identifier", "tmp_name"),
-        _emit_048_template_write_local_inplace,
-        _emit_048_template_write_local_inplace_readable,
+        _emit_049_template_write_local_inplace,
+        _emit_049_template_write_local_inplace_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref0": (
         "68600ea7a983e8b1aa261d952eac01d16b755a50fc9471a38420ee6b46f8e044",
         ("identifier", "tmp_name"),
-        _emit_043_template_write_local_unclear_ref0,
-        _emit_043_template_write_local_unclear_ref0_readable,
+        _emit_044_template_write_local_unclear_ref0,
+        _emit_044_template_write_local_unclear_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref1": (
         "0f9acd29e95ee650e8a1fd1da3f93b7a203824f3fd4653f35187c8c926651eab",
         ("identifier", "tmp_name"),
-        _emit_044_template_write_local_unclear_ref1,
-        _emit_044_template_write_local_unclear_ref1_readable,
+        _emit_045_template_write_local_unclear_ref1,
+        _emit_045_template_write_local_unclear_ref1_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_inplace": (
         "fc77fd03121d1e92e3fe96f671c15ac7b2ae79a48aca3c7ad54244cfe03b19a3",
         ("identifier", "tmp_name"),
-        _emit_077_template_write_py_cell_inplace,
-        _emit_077_template_write_py_cell_inplace_readable,
+        _emit_078_template_write_py_cell_inplace,
+        _emit_078_template_write_py_cell_inplace_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref0": (
         "4c6ebda925fecb94e4ddb776400505503e564fe6826f0a7406553b25b00e9fa4",
         ("identifier", "tmp_name"),
-        _emit_078_template_write_py_cell_unclear_ref0,
-        _emit_078_template_write_py_cell_unclear_ref0_readable,
+        _emit_079_template_write_py_cell_unclear_ref0,
+        _emit_079_template_write_py_cell_unclear_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref1": (
         "585df5b46aee34892618de24cd09ace82adc3896f5933ac50b774eea56f55b59",
         ("identifier", "tmp_name"),
-        _emit_079_template_write_py_cell_unclear_ref1,
-        _emit_079_template_write_py_cell_unclear_ref1_readable,
+        _emit_080_template_write_py_cell_unclear_ref1,
+        _emit_080_template_write_py_cell_unclear_ref1_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref0": (
         "9ef33805b0a960ae8d02ed8ec5e301511cf817db9fac344f022d35500b084bfb",
         ("identifier", "tmp_name"),
-        _emit_053_template_write_shared_clear_ref0,
-        _emit_053_template_write_shared_clear_ref0_readable,
+        _emit_054_template_write_shared_clear_ref0,
+        _emit_054_template_write_shared_clear_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref1": (
         "9e6b8b16a7e64f00f1e7a4af6351c029804798364c40cf4832e5db20bf6de789",
         ("identifier", "tmp_name"),
-        _emit_054_template_write_shared_clear_ref1,
-        _emit_054_template_write_shared_clear_ref1_readable,
+        _emit_055_template_write_shared_clear_ref1,
+        _emit_055_template_write_shared_clear_ref1_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_inplace": (
         "e8d516dfe1e92289de7d98e57e5ca7276fedb034c40fc670225c3af9c2850215",
         ("identifier", "tmp_name"),
-        _emit_049_template_write_shared_inplace,
-        _emit_049_template_write_shared_inplace_readable,
+        _emit_050_template_write_shared_inplace,
+        _emit_050_template_write_shared_inplace_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref0": (
         "fdc9447573fc677fc96af34112a885dda897ee604699ff2e7d86f9c195f25002",
         ("identifier", "tmp_name"),
-        _emit_051_template_write_shared_unclear_ref0,
-        _emit_051_template_write_shared_unclear_ref0_readable,
+        _emit_052_template_write_shared_unclear_ref0,
+        _emit_052_template_write_shared_unclear_ref0_readable,
     ),
     "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref1": (
         "4b91c4cfef66190226abf7510f5c24ae23b23c9bbf410048b91e9632c3494349",
         ("identifier", "tmp_name"),
-        _emit_052_template_write_shared_unclear_ref1,
-        _emit_052_template_write_shared_unclear_ref1_readable,
+        _emit_053_template_write_shared_unclear_ref1,
+        _emit_053_template_write_shared_unclear_ref1_readable,
     ),
 }
 
@@ -3805,6 +3843,14 @@ template_variables = {
     "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_body": (
         ("function_identifier", "s"),
         ("parameter_objects_decl", "s"),
+        ("function_locals", "s"),
+        ("function_body", "s"),
+        ("function_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_direct_body": (
+        ("file_scope", "s"),
+        ("function_identifier", "s"),
+        ("direct_call_arg_spec", "s"),
         ("function_locals", "s"),
         ("function_body", "s"),
         ("function_exit", "s"),

--- a/nuitka/code_generation/templates/CodeTemplatesGenerated.py
+++ b/nuitka/code_generation/templates/CodeTemplatesGenerated.py
@@ -1,0 +1,4301 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+# We are not avoiding these in generated code at all
+# pylint: disable=I0021,line-too-long,too-many-instance-attributes,too-many-lines
+# pylint: disable=I0021,too-many-arguments,too-many-return-statements,too-many-statements
+
+
+"""Prepared code generation templates
+
+WARNING, this code is GENERATED. Modify the template CodeTemplates*.py instead!
+
+spell-checker: ignore __prepare__ append args autograph capitalize casefold center chars
+spell-checker: ignore clear copy count decode default delete dist distribution_name encode
+spell-checker: ignore encoding end endswith errors exit_code expandtabs
+spell-checker: ignore experimental_attributes experimental_autograph_options
+spell-checker: ignore experimental_compile experimental_follow_type_hints
+spell-checker: ignore experimental_implements experimental_relax_shapes extend fillchar
+spell-checker: ignore find format format_map formatmap fromkeys func get group handle
+spell-checker: ignore has_key haskey index input_signature insert isalnum isalpha isascii
+spell-checker: ignore isdecimal isdigit isidentifier islower isnumeric isprintable isspace
+spell-checker: ignore istitle isupper item items iterable iteritems iterkeys itervalues
+spell-checker: ignore jit_compile join keepends key keys kwargs ljust lower lstrip
+spell-checker: ignore maketrans maxsplit mode name new old p package
+spell-checker: ignore package_or_requirement pairs partition path pop popitem prefix
+spell-checker: ignore prepare reduce_retracing remove replace resource resource_name
+spell-checker: ignore reverse rfind rindex rjust rpartition rsplit rstrip s sep setdefault
+spell-checker: ignore sort split splitlines start startswith stop strip sub suffix
+spell-checker: ignore swapcase table tabsize title translate update upper use_errno
+spell-checker: ignore use_last_error value values viewitems viewkeys viewvalues width
+spell-checker: ignore winmode zfill
+"""
+
+# pylint: disable=unused-argument
+
+
+def _emit_000_template_asyncgen_object_maker_template(emit, values):
+    emit("static PyObject *")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["asyncgen_creation_args"])
+    emit(");\n")
+
+
+def _emit_000_template_asyncgen_object_maker_template_readable(emit, values):
+    emit("static PyObject *")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["asyncgen_creation_args"])
+    emit(");\n")
+
+
+def _emit_001_template_asyncgen_object_body(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_AsyncgenObject *asyncgen, PyObject *yield_return_value) {\nCHECK_OBJECT(asyncgen);\nassert(Nuitka_Asyncgen_Check((PyObject *)asyncgen));\nCHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n\n")
+    emit(values["function_dispatch"])
+    emit("\n\n\n")
+    emit(values["function_var_inits"])
+    emit("\n\n\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["asyncgen_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["asyncgen_creation_args"])
+    emit(") {\nreturn Nuitka_Asyncgen_New(\n")
+    emit(values["function_identifier"])
+    emit("_context,\n")
+    emit(values["asyncgen_module"])
+    emit(",\n")
+    emit(values["asyncgen_name_obj"])
+    emit(",\n")
+    emit(values["asyncgen_qualname_obj"])
+    emit(",\n")
+    emit(values["code_identifier"])
+    emit(",\n")
+    emit(values["closure_name"])
+    emit(",\n")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nsizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n0\n#endif\n);\n}\n")
+
+
+def _emit_001_template_asyncgen_object_body_readable(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_AsyncgenObject *asyncgen, PyObject *yield_return_value) {\n    CHECK_OBJECT(asyncgen);\n    assert(Nuitka_Asyncgen_Check((PyObject *)asyncgen));\n    CHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n    // Heap access.\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n    // Dispatch to yield based on return label index:\n")
+    emit(values["function_dispatch"])
+    emit("\n\n    // Local variable initialization\n")
+    emit(values["function_var_inits"])
+    emit("\n\n    // Actual asyncgen body.\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["asyncgen_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["asyncgen_creation_args"])
+    emit(") {\n    return Nuitka_Asyncgen_New(\n        ")
+    emit(values["function_identifier"])
+    emit("_context,\n        ")
+    emit(values["asyncgen_module"])
+    emit(",\n        ")
+    emit(values["asyncgen_name_obj"])
+    emit(",\n        ")
+    emit(values["asyncgen_qualname_obj"])
+    emit(",\n        ")
+    emit(values["code_identifier"])
+    emit(",\n        ")
+    emit(values["closure_name"])
+    emit(",\n        ")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\n        sizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n        0\n#endif\n    );\n}\n")
+
+
+def _emit_002_template_make_asyncgen(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit("= ")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_002_template_make_asyncgen_readable(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit(" = ")
+    emit(values["asyncgen_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_003_template_asyncgen_exception_exit(emit, values):
+    emit(
+        'NUITKA_CANNOT_GET_HERE("return must be present");\n\nfunction_exception_exit:\n'
+    )
+    emit(values["function_cleanup"])
+    emit("\nCHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\nRESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\nreturn NULL;\n")
+
+
+def _emit_003_template_asyncgen_exception_exit_readable(emit, values):
+    emit(
+        '    NUITKA_CANNOT_GET_HERE("return must be present");\n\n    function_exception_exit:\n'
+    )
+    emit(values["function_cleanup"])
+    emit("\n    CHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\n    RESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n    return NULL;\n")
+
+
+def _emit_004_template_asyncgen_no_exception_exit(emit, values):
+    emit('NUITKA_CANNOT_GET_HERE("return must be present");\n\n')
+    emit(values["function_cleanup"])
+    emit("\nreturn NULL;\n")
+
+
+def _emit_004_template_asyncgen_no_exception_exit_readable(emit, values):
+    emit('    NUITKA_CANNOT_GET_HERE("return must be present");\n\n')
+    emit(values["function_cleanup"])
+    emit("\n    return NULL;\n")
+
+
+def _emit_005_template_asyncgen_return_exit(emit, values):
+    emit("function_return_exit:;\n\nreturn NULL;\n")
+
+
+def _emit_005_template_asyncgen_return_exit_readable(emit, values):
+    emit("    function_return_exit:;\n\n    return NULL;\n")
+
+
+def _emit_006_template_constants_reading(emit, values):
+    emit(
+        '\n#include "nuitka/prelude.h"\n#include <structseq.h>\n\n#include "build_definitions.h"\n#include "nuitka/constants_blob.h"\n\n\nPyObject *global_constants['
+    )
+    emit(str(values["global_constants_count"]))
+    emit(
+        "] = {0};\n\n\n\n\nPyObject *Nuitka_sentinel_value = NULL;\n\nPyObject *Nuitka_dunder_compiled_value = NULL;\n\n\n#if _NUITKA_STANDALONE_MODE\nextern PyObject *getStandaloneSysExecutablePath(PyObject *basename);\n\nNUITKA_MAY_BE_UNUSED static PyObject *STRIP_DIRNAME(PyObject *path) {\n#if PYTHON_VERSION < 0x300\nchar const *path_cstr = PyString_AS_STRING(path);\n\n#ifdef _WIN32\nchar const *last_sep = strrchr(path_cstr, '\\\\');\n#else\nchar const *last_sep = strrchr(path_cstr, '/');\n#endif\nif (unlikely(last_sep == NULL)) {\nPy_INCREF(path);\nreturn path;\n}\n\nreturn PyString_FromStringAndSize(path_cstr, last_sep - path_cstr);\n#else\n#ifdef _WIN32\nPy_ssize_t dot_index = PyUnicode_Find(path, const_str_backslash, 0, PyUnicode_GetLength(path), -1);\n#else\nPy_ssize_t dot_index = PyUnicode_Find(path, const_str_slash, 0, PyUnicode_GetLength(path), -1);\n#endif\nif (likely(dot_index != -1)) {\nreturn PyUnicode_Substring(path, 0, dot_index);\n} else {\nPy_INCREF(path);\nreturn path;\n}\n#endif\n}\n#endif\n\nextern void setDistributionsMetadata(PyThreadState *tstate, PyObject *metadata_items);\n\n\nPyObject *Py_SysVersionInfo = NULL;\n\nNUITKA_DECLARE_CONSTANT_BLOB(\n"
+    )
+    emit(values["global_constants_blob_symbol_name"])
+    emit(",\n")
+    emit(values["global_constants_blob_symbol_name"])
+    emit(
+        ',\nconst\n);\n\n#if _NUITKA_MODULE_MODE\nstatic void _createGlobalConstants(PyThreadState *tstate, PyObject *real_module_name) {\n#else\nstatic void _createGlobalConstants(PyThreadState *tstate) {\n#endif\n\nPy_SysVersionInfo = Nuitka_SysGetObject("version_info");\n\n\n#if '
+    )
+    emit(str(values["use_direct_constant_blobs"]))
+    emit("\nLOAD_DIRECT_CONSTANTS_BLOB(tstate, &global_constants[0], ")
+    emit(values["global_constants_blob_symbol_name"])
+    emit(
+        ');\n#else\nloadConstantsBlob(tstate, &global_constants[0], "");\n#endif\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\n\n\nNuitka_SysSetObject(\n"executable",\n#if !_NUITKA_STANDALONE_MODE\n'
+    )
+    emit(values["sys_executable"])
+    emit("\n#else\ngetStandaloneSysExecutablePath(")
+    emit(values["sys_executable"])
+    emit(
+        ')\n#endif\n);\n\n#if !_NUITKA_STANDALONE_MODE\n\nNuitka_SysSetObject(\n"prefix",\n'
+    )
+    emit(values["sys_prefix"])
+    emit('\n);\n\n\nNuitka_SysSetObject(\n"exec_prefix",\n')
+    emit(values["sys_exec_prefix"])
+    emit(
+        '\n);\n\n\n#if PYTHON_VERSION >= 0x300\n\nNuitka_SysSetObject(\n"base_prefix",\n'
+    )
+    emit(values["sys_base_prefix"])
+    emit('\n);\n\n\nNuitka_SysSetObject(\n"base_exec_prefix",\n')
+    emit(values["sys_base_exec_prefix"])
+    emit(
+        '\n);\n\n#endif\n#endif\n#endif\n\nstatic PyTypeObject Nuitka_VersionInfoType;\n\n\n\nstatic PyStructSequence_Field Nuitka_VersionInfoFields[] = {\n{(char *)"major", (char *)"Major release number"},\n{(char *)"minor", (char *)"Minor release number"},\n{(char *)"micro", (char *)"Micro release number"},\n{(char *)"releaselevel", (char *)"\'alpha\', \'beta\', \'candidate\', or \'release\'"},\n{(char *)"containing_dir", (char *)"directory of the containing binary"},\n{(char *)"standalone", (char *)"boolean indicating standalone mode usage"},\n{(char *)"onefile", (char *)"boolean indicating onefile mode usage"},\n{(char *)"macos_bundle_mode", (char *)"boolean indicating macOS app bundle mode usage"},\n{(char *)"no_asserts", (char *)"boolean indicating --python-flag=no_asserts usage"},\n{(char *)"no_docstrings", (char *)"boolean indicating --python-flag=no_docstrings usage"},\n{(char *)"no_annotations", (char *)"boolean indicating --python-flag=no_annotations usage"},\n{(char *)"module", (char *)"boolean indicating --module usage"},\n{(char *)"main", (char *)"name of main module at runtime"},\n{(char *)"original_argv0", (char *)"original argv[0] as received by the onefile binary, None otherwise"},\n{(char *)"extension_filename", (char *)"loaded extension filename in module/package mode, None otherwise"},\n{0}\n};\n\nstatic PyStructSequence_Desc Nuitka_VersionInfoDesc = {\n(char *)"__nuitka_version__",                                       \n(char *)"__compiled__\\\\n\\\\nVersion information as a named tuple.",  \nNuitka_VersionInfoFields,                                           \nsizeof(Nuitka_VersionInfoFields) / sizeof(PyStructSequence_Field)-1 \n};\n\nPyStructSequence_InitType(&Nuitka_VersionInfoType, &Nuitka_VersionInfoDesc);\n\nNuitka_dunder_compiled_value = PyStructSequence_New(&Nuitka_VersionInfoType);\nassert(Nuitka_dunder_compiled_value != NULL);\n\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 0, Nuitka_PyInt_FromLong('
+    )
+    emit(values["nuitka_version_major"])
+    emit(
+        "));\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 1, Nuitka_PyInt_FromLong("
+    )
+    emit(values["nuitka_version_minor"])
+    emit(
+        "));\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 2, Nuitka_PyInt_FromLong("
+    )
+    emit(values["nuitka_version_micro"])
+    emit(
+        '));\n\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 3, Nuitka_String_FromString("'
+    )
+    emit(values["nuitka_version_level"])
+    emit(
+        '"));\n\nPyObject *containing_directory = getContainingDirectoryObject(false);\n#if _NUITKA_STANDALONE_MODE\n#if !_NUITKA_ONEFILE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n\n#if _NUITKA_MACOS_BUNDLE_MODE\ncontaining_directory = STRIP_DIRNAME(containing_directory);\ncontaining_directory = STRIP_DIRNAME(containing_directory);\n#endif\n#endif\n\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 4, containing_directory);\n\n#if _NUITKA_STANDALONE_MODE\nPyObject *is_standalone_mode = Py_True;\n#else\nPyObject *is_standalone_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 5, is_standalone_mode);\n#ifdef _NUITKA_ONEFILE_MODE\nPyObject *is_onefile_mode = Py_True;\n#else\nPyObject *is_onefile_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 6, is_onefile_mode);\n\n#if _NUITKA_MACOS_BUNDLE_MODE\nPyObject *is_macos_bundle_mode = Py_True;\n#else\nPyObject *is_macos_bundle_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 7, is_macos_bundle_mode);\n\n#if _NUITKA_NO_ASSERTS == 1\nPyObject *is_no_asserts = Py_True;\n#else\nPyObject *is_no_asserts = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 8, is_no_asserts);\n\n#if _NUITKA_NO_DOCSTRINGS == 1\nPyObject *is_no_docstrings = Py_True;\n#else\nPyObject *is_no_docstrings = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 9, is_no_docstrings);\n\n#if _NUITKA_NO_ANNOTATIONS == 1\nPyObject *is_no_annotations = Py_True;\n#else\nPyObject *is_no_annotations = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 10, is_no_annotations);\n\n#if _NUITKA_MODULE_MODE\nPyObject *is_module_mode = Py_True;\n#else\nPyObject *is_module_mode = Py_False;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 11, is_module_mode);\n\n#if _NUITKA_MODULE_MODE\nPyObject *main_name = real_module_name;\nPy_INCREF(real_module_name);\n#else\nPyObject *main_name = Nuitka_String_FromString("__main__");\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\nPyObject *original_argv0 = getOriginalArgv0Object();\n#else\nPyObject *original_argv0 = Py_None;\n# endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, original_argv0);\n\n#if _NUITKA_MODULE_MODE\nPyObject *extension_filename = getDllFilenameObject();\n#else\nPyObject *extension_filename = Py_None;\n#endif\nPyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 14, extension_filename);\n\n// Prevent users from creating the Nuitka version type object.\nNuitka_VersionInfoType.tp_init = NULL;\nNuitka_VersionInfoType.tp_new = NULL;\n\n// Register included meta data.\nsetDistributionsMetadata(tstate, '
+    )
+    emit(values["metadata_values"])
+    emit(
+        ');\n}\n\n\n\n\n#ifndef __NUITKA_NO_ASSERT__\nvoid checkGlobalConstants(void) {\n\n\n}\n#endif\n\n#if _NUITKA_MODULE_MODE\nvoid createGlobalConstants(PyThreadState *tstate, PyObject *real_module_name) {\n#else\nvoid createGlobalConstants(PyThreadState *tstate) {\n#endif\nif (Nuitka_sentinel_value == NULL) {\n#if PYTHON_VERSION < 0x300\nNuitka_sentinel_value = PyCObject_FromVoidPtr(NULL, NULL);\n#else\n\nNuitka_sentinel_value = PyCapsule_New((void *)27, "sentinel", NULL);\n#endif\nassert(Nuitka_sentinel_value);\n\nPy_SET_REFCNT_IMMORTAL(Nuitka_sentinel_value);\n\n#if _NUITKA_MODULE_MODE\n_createGlobalConstants(tstate, real_module_name);\n#else\n_createGlobalConstants(tstate);\n#endif\n}\n}\n'
+    )
+
+
+def _emit_006_template_constants_reading_readable(emit, values):
+    emit(
+        '\n#include "nuitka/prelude.h"\n#include <structseq.h>\n\n#include "build_definitions.h"\n#include "nuitka/constants_blob.h"\n\n// Global constants storage\nPyObject *global_constants['
+    )
+    emit(str(values["global_constants_count"]))
+    emit(
+        "] = {0};\n\n// Sentinel PyObject to be used for all our call iterator endings. It will\n// become a PyCObject pointing to NULL. It's address is unique, and that's\n// enough for us to use it as sentinel value.\nPyObject *Nuitka_sentinel_value = NULL;\n\nPyObject *Nuitka_dunder_compiled_value = NULL;\n\n\n#if _NUITKA_STANDALONE_MODE\nextern PyObject *getStandaloneSysExecutablePath(PyObject *basename);\n\nNUITKA_MAY_BE_UNUSED static PyObject *STRIP_DIRNAME(PyObject *path) {\n#if PYTHON_VERSION < 0x300\n    char const *path_cstr = PyString_AS_STRING(path);\n\n#ifdef _WIN32\n    char const *last_sep = strrchr(path_cstr, '\\\\');\n#else\n    char const *last_sep = strrchr(path_cstr, '/');\n#endif\n    if (unlikely(last_sep == NULL)) {\n        Py_INCREF(path);\n        return path;\n    }\n\n    return PyString_FromStringAndSize(path_cstr, last_sep - path_cstr);\n#else\n#ifdef _WIN32\n    Py_ssize_t dot_index = PyUnicode_Find(path, const_str_backslash, 0, PyUnicode_GetLength(path), -1);\n#else\n    Py_ssize_t dot_index = PyUnicode_Find(path, const_str_slash, 0, PyUnicode_GetLength(path), -1);\n#endif\n    if (likely(dot_index != -1)) {\n        return PyUnicode_Substring(path, 0, dot_index);\n    } else {\n        Py_INCREF(path);\n        return path;\n    }\n#endif\n}\n#endif\n\nextern void setDistributionsMetadata(PyThreadState *tstate, PyObject *metadata_items);\n\n// We provide the sys.version info shortcut as a global value here for ease of use.\nPyObject *Py_SysVersionInfo = NULL;\n\nNUITKA_DECLARE_CONSTANT_BLOB(\n    "
+    )
+    emit(values["global_constants_blob_symbol_name"])
+    emit(",\n    ")
+    emit(values["global_constants_blob_symbol_name"])
+    emit(
+        ',\n    const\n);\n\n#if _NUITKA_MODULE_MODE\nstatic void _createGlobalConstants(PyThreadState *tstate, PyObject *real_module_name) {\n#else\nstatic void _createGlobalConstants(PyThreadState *tstate) {\n#endif\n    // We provide the sys.version info shortcut as a global value here for ease of use.\n    Py_SysVersionInfo = Nuitka_SysGetObject("version_info");\n\n    // The empty name means global.\n#if '
+    )
+    emit(str(values["use_direct_constant_blobs"]))
+    emit("\n    LOAD_DIRECT_CONSTANTS_BLOB(tstate, &global_constants[0], ")
+    emit(values["global_constants_blob_symbol_name"])
+    emit(
+        ');\n#else\n    loadConstantsBlob(tstate, &global_constants[0], "");\n#endif\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\n    /* Set the "sys.executable" path to the original CPython executable or point to inside the\n       distribution for standalone. */\n    Nuitka_SysSetObject(\n        "executable",\n#if !_NUITKA_STANDALONE_MODE\n        '
+    )
+    emit(values["sys_executable"])
+    emit("\n#else\n        getStandaloneSysExecutablePath(")
+    emit(values["sys_executable"])
+    emit(
+        ')\n#endif\n    );\n\n#if !_NUITKA_STANDALONE_MODE\n    /* Set the "sys.prefix" path to the original one. */\n    Nuitka_SysSetObject(\n        "prefix",\n        '
+    )
+    emit(values["sys_prefix"])
+    emit(
+        '\n    );\n\n    /* Set the "sys.prefix" path to the original one. */\n    Nuitka_SysSetObject(\n        "exec_prefix",\n        '
+    )
+    emit(values["sys_exec_prefix"])
+    emit(
+        '\n    );\n\n\n#if PYTHON_VERSION >= 0x300\n    /* Set the "sys.base_prefix" path to the original one. */\n    Nuitka_SysSetObject(\n        "base_prefix",\n        '
+    )
+    emit(values["sys_base_prefix"])
+    emit(
+        '\n    );\n\n    /* Set the "sys.exec_base_prefix" path to the original one. */\n    Nuitka_SysSetObject(\n        "base_exec_prefix",\n        '
+    )
+    emit(values["sys_base_exec_prefix"])
+    emit(
+        '\n    );\n\n#endif\n#endif\n#endif\n\n    static PyTypeObject Nuitka_VersionInfoType;\n\n    // Same fields as "sys.version_info" except no serial number\n    // spell-checker: ignore releaselevel\n    static PyStructSequence_Field Nuitka_VersionInfoFields[] = {\n        {(char *)"major", (char *)"Major release number"},\n        {(char *)"minor", (char *)"Minor release number"},\n        {(char *)"micro", (char *)"Micro release number"},\n        {(char *)"releaselevel", (char *)"\'alpha\', \'beta\', \'candidate\', or \'release\'"},\n        {(char *)"containing_dir", (char *)"directory of the containing binary"},\n        {(char *)"standalone", (char *)"boolean indicating standalone mode usage"},\n        {(char *)"onefile", (char *)"boolean indicating onefile mode usage"},\n        {(char *)"macos_bundle_mode", (char *)"boolean indicating macOS app bundle mode usage"},\n        {(char *)"no_asserts", (char *)"boolean indicating --python-flag=no_asserts usage"},\n        {(char *)"no_docstrings", (char *)"boolean indicating --python-flag=no_docstrings usage"},\n        {(char *)"no_annotations", (char *)"boolean indicating --python-flag=no_annotations usage"},\n        {(char *)"module", (char *)"boolean indicating --module usage"},\n        {(char *)"main", (char *)"name of main module at runtime"},\n        {(char *)"original_argv0", (char *)"original argv[0] as received by the onefile binary, None otherwise"},\n        {(char *)"extension_filename", (char *)"loaded extension filename in module/package mode, None otherwise"},\n        {0}\n    };\n\n    static PyStructSequence_Desc Nuitka_VersionInfoDesc = {\n        (char *)"__nuitka_version__",                                       /* name */\n        (char *)"__compiled__\\\\n\\\\nVersion information as a named tuple.",  /* doc */\n        Nuitka_VersionInfoFields,                                           /* fields */\n        sizeof(Nuitka_VersionInfoFields) / sizeof(PyStructSequence_Field)-1 /* count */\n    };\n\n    PyStructSequence_InitType(&Nuitka_VersionInfoType, &Nuitka_VersionInfoDesc);\n\n    Nuitka_dunder_compiled_value = PyStructSequence_New(&Nuitka_VersionInfoType);\n    assert(Nuitka_dunder_compiled_value != NULL);\n\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 0, Nuitka_PyInt_FromLong('
+    )
+    emit(values["nuitka_version_major"])
+    emit(
+        "));\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 1, Nuitka_PyInt_FromLong("
+    )
+    emit(values["nuitka_version_minor"])
+    emit(
+        "));\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 2, Nuitka_PyInt_FromLong("
+    )
+    emit(values["nuitka_version_micro"])
+    emit(
+        '));\n\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 3, Nuitka_String_FromString("'
+    )
+    emit(values["nuitka_version_level"])
+    emit(
+        '"));\n\n    PyObject *containing_directory = getContainingDirectoryObject(false);\n#if _NUITKA_STANDALONE_MODE\n#if !_NUITKA_ONEFILE_MODE\n    containing_directory = STRIP_DIRNAME(containing_directory);\n#endif\n\n#if _NUITKA_MACOS_BUNDLE_MODE\n    containing_directory = STRIP_DIRNAME(containing_directory);\n    containing_directory = STRIP_DIRNAME(containing_directory);\n#endif\n#endif\n\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 4, containing_directory);\n\n#if _NUITKA_STANDALONE_MODE\n    PyObject *is_standalone_mode = Py_True;\n#else\n    PyObject *is_standalone_mode = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 5, is_standalone_mode);\n#ifdef _NUITKA_ONEFILE_MODE\n    PyObject *is_onefile_mode = Py_True;\n#else\n    PyObject *is_onefile_mode = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 6, is_onefile_mode);\n\n#if _NUITKA_MACOS_BUNDLE_MODE\n    PyObject *is_macos_bundle_mode = Py_True;\n#else\n    PyObject *is_macos_bundle_mode = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 7, is_macos_bundle_mode);\n\n#if _NUITKA_NO_ASSERTS == 1\n    PyObject *is_no_asserts = Py_True;\n#else\n    PyObject *is_no_asserts = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 8, is_no_asserts);\n\n#if _NUITKA_NO_DOCSTRINGS == 1\n    PyObject *is_no_docstrings = Py_True;\n#else\n    PyObject *is_no_docstrings = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 9, is_no_docstrings);\n\n#if _NUITKA_NO_ANNOTATIONS == 1\n    PyObject *is_no_annotations = Py_True;\n#else\n    PyObject *is_no_annotations = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 10, is_no_annotations);\n\n#if _NUITKA_MODULE_MODE\n    PyObject *is_module_mode = Py_True;\n#else\n    PyObject *is_module_mode = Py_False;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 11, is_module_mode);\n\n#if _NUITKA_MODULE_MODE\n    PyObject *main_name = real_module_name;\n    Py_INCREF(real_module_name);\n#else\n    PyObject *main_name = Nuitka_String_FromString("__main__");\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 12, main_name);\n\n#if _NUITKA_EXE_MODE || _NUITKA_DLL_MODE\n    PyObject *original_argv0 = getOriginalArgv0Object();\n#else\n    PyObject *original_argv0 = Py_None;\n# endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 13, original_argv0);\n\n#if _NUITKA_MODULE_MODE\n    PyObject *extension_filename = getDllFilenameObject();\n#else\n    PyObject *extension_filename = Py_None;\n#endif\n    PyStructSequence_SET_ITEM(Nuitka_dunder_compiled_value, 14, extension_filename);\n\n    // Prevent users from creating the Nuitka version type object.\n    Nuitka_VersionInfoType.tp_init = NULL;\n    Nuitka_VersionInfoType.tp_new = NULL;\n\n    // Register included meta data.\n    setDistributionsMetadata(tstate, '
+    )
+    emit(values["metadata_values"])
+    emit(
+        ');\n}\n\n// In debug mode we can check that the constants were not tampered with in any\n// given moment. We typically do it at program exit, but we can add extra calls\n// for sanity.\n#ifndef __NUITKA_NO_ASSERT__\nvoid checkGlobalConstants(void) {\n// TODO: Ask constant code to check values.\n\n}\n#endif\n\n#if _NUITKA_MODULE_MODE\nvoid createGlobalConstants(PyThreadState *tstate, PyObject *real_module_name) {\n#else\nvoid createGlobalConstants(PyThreadState *tstate) {\n#endif\n    if (Nuitka_sentinel_value == NULL) {\n#if PYTHON_VERSION < 0x300\n        Nuitka_sentinel_value = PyCObject_FromVoidPtr(NULL, NULL);\n#else\n        // The NULL value is not allowed for a capsule, so use something else.\n        Nuitka_sentinel_value = PyCapsule_New((void *)27, "sentinel", NULL);\n#endif\n        assert(Nuitka_sentinel_value);\n\n        Py_SET_REFCNT_IMMORTAL(Nuitka_sentinel_value);\n\n#if _NUITKA_MODULE_MODE\n        _createGlobalConstants(tstate, real_module_name);\n#else\n        _createGlobalConstants(tstate);\n#endif\n    }\n}\n'
+    )
+
+
+def _emit_007_template_coroutine_object_maker(emit, values):
+    emit("static PyObject *")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["coroutine_creation_args"])
+    emit(");\n")
+
+
+def _emit_007_template_coroutine_object_maker_readable(emit, values):
+    emit("static PyObject *")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["coroutine_creation_args"])
+    emit(");\n")
+
+
+def _emit_008_template_coroutine_object_body(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_CoroutineObject *coroutine, PyObject *yield_return_value) {\nCHECK_OBJECT(coroutine);\nassert(Nuitka_Coroutine_Check((PyObject *)coroutine));\nCHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n\n")
+    emit(values["function_dispatch"])
+    emit("\n\n\n")
+    emit(values["function_var_inits"])
+    emit("\n\n\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["coroutine_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["coroutine_creation_args"])
+    emit(") {\nreturn Nuitka_Coroutine_New(\ntstate,\n")
+    emit(values["function_identifier"])
+    emit("_context,\n")
+    emit(values["coroutine_module"])
+    emit(",\n")
+    emit(values["coroutine_name_obj"])
+    emit(",\n")
+    emit(values["coroutine_qualname_obj"])
+    emit(",\n")
+    emit(values["code_identifier"])
+    emit(",\n")
+    emit(values["closure_name"])
+    emit(",\n")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nsizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n0\n#endif\n);\n}\n")
+
+
+def _emit_008_template_coroutine_object_body_readable(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_CoroutineObject *coroutine, PyObject *yield_return_value) {\n    CHECK_OBJECT(coroutine);\n    assert(Nuitka_Coroutine_Check((PyObject *)coroutine));\n    CHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n    // Heap access.\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n    // Dispatch to yield based on return label index:\n")
+    emit(values["function_dispatch"])
+    emit("\n\n    // Local variable initialization\n")
+    emit(values["function_var_inits"])
+    emit("\n\n    // Actual coroutine body.\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["coroutine_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["coroutine_creation_args"])
+    emit(") {\n    return Nuitka_Coroutine_New(\n        tstate,\n        ")
+    emit(values["function_identifier"])
+    emit("_context,\n        ")
+    emit(values["coroutine_module"])
+    emit(",\n        ")
+    emit(values["coroutine_name_obj"])
+    emit(",\n        ")
+    emit(values["coroutine_qualname_obj"])
+    emit(",\n        ")
+    emit(values["code_identifier"])
+    emit(",\n        ")
+    emit(values["closure_name"])
+    emit(",\n        ")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\n        sizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n        0\n#endif\n    );\n}\n")
+
+
+def _emit_009_template_make_coroutine(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit("= ")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_009_template_make_coroutine_readable(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit(" = ")
+    emit(values["coroutine_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_010_template_coroutine_exception_exit(emit, values):
+    emit(
+        'NUITKA_CANNOT_GET_HERE("Return statement must be present");\n\nfunction_exception_exit:\n'
+    )
+    emit(values["function_cleanup"])
+    emit("\nCHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\nRESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\nreturn NULL;\n")
+
+
+def _emit_010_template_coroutine_exception_exit_readable(emit, values):
+    emit(
+        '    NUITKA_CANNOT_GET_HERE("Return statement must be present");\n\n    function_exception_exit:\n'
+    )
+    emit(values["function_cleanup"])
+    emit("\n    CHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\n    RESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n    return NULL;\n")
+
+
+def _emit_011_template_coroutine_no_exception_exit(emit, values):
+    emit('NUITKA_CANNOT_GET_HERE("Return statement must be present");\n\n')
+    emit(values["function_cleanup"])
+    emit("\nreturn NULL;\n")
+
+
+def _emit_011_template_coroutine_no_exception_exit_readable(emit, values):
+    emit('    NUITKA_CANNOT_GET_HERE("Return statement must be present");\n\n')
+    emit(values["function_cleanup"])
+    emit("\n    return NULL;\n")
+
+
+def _emit_012_template_coroutine_return_exit(emit, values):
+    emit("function_return_exit:;\n\ncoroutine->m_returned = ")
+    emit(values["return_value"])
+    emit(";\n\nreturn NULL;\n")
+
+
+def _emit_012_template_coroutine_return_exit_readable(emit, values):
+    emit("    function_return_exit:;\n\n    coroutine->m_returned = ")
+    emit(values["return_value"])
+    emit(";\n\n    return NULL;\n")
+
+
+def _emit_013_template_publish_exception_to_handler(emit, values):
+    emit("{\nPyTracebackObject *exception_tb = GET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(");\nif (exception_tb == NULL) {\nexception_tb = ")
+    emit(values["tb_making"])
+    emit(";\nSET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(", exception_tb);\n} else if (")
+    emit(values["keeper_lineno"])
+    emit("!= 0) {\nexception_tb = ADD_TRACEBACK(exception_tb, ")
+    emit(values["frame_identifier"])
+    emit(", ")
+    emit(values["keeper_lineno"])
+    emit(");\nSET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(", exception_tb);\n}\n}\n")
+
+
+def _emit_013_template_publish_exception_to_handler_readable(emit, values):
+    emit("{\n    PyTracebackObject *exception_tb = GET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(");\n    if (exception_tb == NULL) {\n        exception_tb = ")
+    emit(values["tb_making"])
+    emit(";\n        SET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(", exception_tb);\n    } else if (")
+    emit(values["keeper_lineno"])
+    emit(" != 0) {\n        exception_tb = ADD_TRACEBACK(exception_tb, ")
+    emit(values["frame_identifier"])
+    emit(", ")
+    emit(values["keeper_lineno"])
+    emit(");\n        SET_EXCEPTION_STATE_TRACEBACK(&")
+    emit(values["keeper_exception_state_name"])
+    emit(", exception_tb);\n    }\n}\n")
+
+
+def _emit_014_template_error_catch_fetched_exception(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(") {\nassert(HAS_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit("));\n\n")
+    emit(values["release_temps"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}")
+
+
+def _emit_014_template_error_catch_fetched_exception_readable(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(") {\n    assert(HAS_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit("));\n\n")
+    emit(values["release_temps"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\n    goto ")
+    emit(values["exception_exit"])
+    emit(";\n}")
+
+
+def _emit_015_template_error_catch_exception(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(
+        ") {\nassert(HAS_ERROR_OCCURRED(tstate));\n\nFETCH_ERROR_OCCURRED_STATE(tstate, &"
+    )
+    emit(values["exception_state_name"])
+    emit(");\n")
+    emit(values["release_temps"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}")
+
+
+def _emit_015_template_error_catch_exception_readable(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(
+        ") {\n    assert(HAS_ERROR_OCCURRED(tstate));\n\n    FETCH_ERROR_OCCURRED_STATE(tstate, &"
+    )
+    emit(values["exception_state_name"])
+    emit(");\n")
+    emit(values["release_temps"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\n    goto ")
+    emit(values["exception_exit"])
+    emit(";\n}")
+
+
+def _emit_016_template_error_format_string_exception(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(") {\n")
+    emit(values["release_temps"])
+    emit("\n")
+    emit(values["set_exception"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n")
+
+
+def _emit_016_template_error_format_string_exception_readable(emit, values):
+    emit("if (")
+    emit(values["condition"])
+    emit(") {\n")
+    emit(values["release_temps"])
+    emit("\n")
+    emit(values["set_exception"])
+    emit("\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\n    goto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n")
+
+
+def _emit_017_template_error_format_name_error_exception(emit, values):
+    emit("if (unlikely(")
+    emit(values["condition"])
+    emit(")) {\n")
+    emit(values["release_temps"])
+    emit("\n")
+    emit(values["raise_name_error_helper"])
+    emit("(tstate, &")
+    emit(values["exception_state_name"])
+    emit(", ")
+    emit(values["variable_name"])
+    emit(");\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n")
+
+
+def _emit_017_template_error_format_name_error_exception_readable(emit, values):
+    emit("if (unlikely(")
+    emit(values["condition"])
+    emit(")) {\n")
+    emit(values["release_temps"])
+    emit("\n")
+    emit(values["raise_name_error_helper"])
+    emit("(tstate, &")
+    emit(values["exception_state_name"])
+    emit(", ")
+    emit(values["variable_name"])
+    emit(");\n\n")
+    emit(values["line_number_code"])
+    emit("\n")
+    emit(values["var_description_code"])
+    emit("\n    goto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n")
+
+
+def _emit_018_template_frame_attach_locals(emit, values):
+    emit("Nuitka_Frame_AttachLocals(\n")
+    emit(values["frame_identifier"])
+    emit(",\n")
+    emit(values["type_description"])
+    emit(values["frame_variable_refs"])
+    emit("\n);\n")
+
+
+def _emit_018_template_frame_attach_locals_readable(emit, values):
+    emit("Nuitka_Frame_AttachLocals(\n    ")
+    emit(values["frame_identifier"])
+    emit(",\n    ")
+    emit(values["type_description"])
+    emit(values["frame_variable_refs"])
+    emit("\n);\n")
+
+
+def _emit_019_template_frame_guard_generator_return_handler(emit, values):
+    emit(values["frame_return_exit"])
+    emit(
+        ":;\n\n#if PYTHON_VERSION >= 0x300\n#if PYTHON_VERSION < 0x3b0\nPy_CLEAR(EXC_TYPE_F("
+    )
+    emit(values["context_identifier"])
+    emit("));\n#endif\nPy_CLEAR(EXC_VALUE_F(")
+    emit(values["context_identifier"])
+    emit("));\n#if PYTHON_VERSION < 0x3b0\nPy_CLEAR(EXC_TRACEBACK_F(")
+    emit(values["context_identifier"])
+    emit("));\n#endif\n#endif\n\ngoto ")
+    emit(values["return_exit"])
+    emit(";\n")
+
+
+def _emit_019_template_frame_guard_generator_return_handler_readable(emit, values):
+    emit(values["frame_return_exit"])
+    emit(
+        ":;\n\n#if PYTHON_VERSION >= 0x300\n#if PYTHON_VERSION < 0x3b0\nPy_CLEAR(EXC_TYPE_F("
+    )
+    emit(values["context_identifier"])
+    emit("));\n#endif\nPy_CLEAR(EXC_VALUE_F(")
+    emit(values["context_identifier"])
+    emit("));\n#if PYTHON_VERSION < 0x3b0\nPy_CLEAR(EXC_TRACEBACK_F(")
+    emit(values["context_identifier"])
+    emit("));\n#endif\n#endif\n\ngoto ")
+    emit(values["return_exit"])
+    emit(";\n")
+
+
+def _emit_020_template_function_make_declaration(emit, values):
+    emit("static PyObject *MAKE_FUNCTION_")
+    emit(values["function_identifier"])
+    emit("(")
+    emit(values["function_creation_args"])
+    emit(");\n")
+
+
+def _emit_020_template_function_make_declaration_readable(emit, values):
+    emit("static PyObject *MAKE_FUNCTION_")
+    emit(values["function_identifier"])
+    emit("(")
+    emit(values["function_creation_args"])
+    emit(");\n")
+
+
+def _emit_021_template_function_direct_declaration(emit, values):
+    emit(values["file_scope"])
+    emit("PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["direct_call_arg_spec"])
+    emit(");\n")
+
+
+def _emit_021_template_function_direct_declaration_readable(emit, values):
+    emit(values["file_scope"])
+    emit(" PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["direct_call_arg_spec"])
+    emit(");\n")
+
+
+def _emit_022_template_maker_function_body(emit, values):
+    emit("\nstatic PyObject *")
+    emit(values["function_maker_identifier"])
+    emit("(")
+    emit(values["function_creation_args"])
+    emit(") {\nstruct Nuitka_FunctionObject *result = Nuitka_Function_New(\n")
+    emit(values["function_impl_identifier"])
+    emit(",\n")
+    emit(values["function_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x300\n")
+    emit(values["function_qualname_obj"])
+    emit(",\n#endif\n")
+    emit(values["code_identifier"])
+    emit(",\n")
+    emit(values["defaults"])
+    emit(",\n#if PYTHON_VERSION >= 0x300\n")
+    emit(values["kw_defaults"])
+    emit(",\n")
+    emit(values["annotations"])
+    emit(",\n#endif\n")
+    emit(values["module_identifier"])
+    emit(",\n")
+    emit(values["function_doc"])
+    emit(",\n")
+    emit(values["closure_name"])
+    emit(",\n")
+    emit(str(values["closure_count"]))
+    emit("\n#if PYTHON_VERSION >= 0x300\n, ")
+    emit(values["type_params"])
+    emit("\n#endif\n);\n")
+    emit(values["constant_return_code"])
+    emit("\n\nreturn (PyObject *)result;\n}\n")
+
+
+def _emit_022_template_maker_function_body_readable(emit, values):
+    emit("\nstatic PyObject *")
+    emit(values["function_maker_identifier"])
+    emit("(")
+    emit(values["function_creation_args"])
+    emit(
+        ") {\n    struct Nuitka_FunctionObject *result = Nuitka_Function_New(\n        "
+    )
+    emit(values["function_impl_identifier"])
+    emit(",\n        ")
+    emit(values["function_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x300\n        ")
+    emit(values["function_qualname_obj"])
+    emit(",\n#endif\n        ")
+    emit(values["code_identifier"])
+    emit(",\n        ")
+    emit(values["defaults"])
+    emit(",\n#if PYTHON_VERSION >= 0x300\n        ")
+    emit(values["kw_defaults"])
+    emit(",\n        ")
+    emit(values["annotations"])
+    emit(",\n#endif\n        ")
+    emit(values["module_identifier"])
+    emit(",\n        ")
+    emit(values["function_doc"])
+    emit(",\n        ")
+    emit(values["closure_name"])
+    emit(",\n        ")
+    emit(str(values["closure_count"]))
+    emit("\n#if PYTHON_VERSION >= 0x300\n        , ")
+    emit(values["type_params"])
+    emit("\n#endif\n    );\n")
+    emit(values["constant_return_code"])
+    emit("\n\n    return (PyObject *)result;\n}\n")
+
+
+def _emit_023_template_make_function(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit("= ")
+    emit(values["function_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_023_template_make_function_readable(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit(" = ")
+    emit(values["function_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_024_template_function_body(emit, values):
+    emit("static PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["parameter_objects_decl"])
+    emit(
+        ") {\n\n#ifndef __NUITKA_NO_ASSERT__\nNUITKA_MAY_BE_UNUSED bool had_error = HAS_ERROR_OCCURRED(tstate);\n#endif\n\n\n"
+    )
+    emit(values["function_locals"])
+    emit("\n\n\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["function_exit"])
+    emit("\n}\n")
+
+
+def _emit_024_template_function_body_readable(emit, values):
+    emit("static PyObject *impl_")
+    emit(values["function_identifier"])
+    emit("(PyThreadState *tstate, ")
+    emit(values["parameter_objects_decl"])
+    emit(
+        ") {\n    // Preserve error status for checks\n#ifndef __NUITKA_NO_ASSERT__\n    NUITKA_MAY_BE_UNUSED bool had_error = HAS_ERROR_OCCURRED(tstate);\n#endif\n\n    // Local variable declarations.\n"
+    )
+    emit(values["function_locals"])
+    emit("\n\n    // Actual function body.\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["function_exit"])
+    emit("\n}\n")
+
+
+def _emit_025_template_function_exception_exit(emit, values):
+    emit("function_exception_exit:\n")
+    emit(values["function_cleanup"])
+    emit("\nCHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\nRESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n\nreturn NULL;\n")
+
+
+def _emit_025_template_function_exception_exit_readable(emit, values):
+    emit("function_exception_exit:\n")
+    emit(values["function_cleanup"])
+    emit("\n    CHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\n    RESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n\n    return NULL;\n")
+
+
+def _emit_026_template_function_return_exit(emit, values):
+    emit("\nfunction_return_exit:\n\n")
+    emit(values["function_cleanup"])
+    emit(
+        "\n\n\n\nCHECK_OBJECT(tmp_return_value);\nassert(had_error || !HAS_ERROR_OCCURRED(tstate));\nreturn tmp_return_value;"
+    )
+
+
+def _emit_026_template_function_return_exit_readable(emit, values):
+    emit("\nfunction_return_exit:\n   // Function cleanup code if any.\n")
+    emit(values["function_cleanup"])
+    emit(
+        "\n\n   // Actual function exit with return value, making sure we did not make\n   // the error status worse despite non-NULL return.\n   CHECK_OBJECT(tmp_return_value);\n   assert(had_error || !HAS_ERROR_OCCURRED(tstate));\n   return tmp_return_value;"
+    )
+
+
+def _emit_027_template_generator_context_maker_decl(emit, values):
+    emit("static PyObject *")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["generator_creation_args"])
+    emit(");\n")
+
+
+def _emit_027_template_generator_context_maker_decl_readable(emit, values):
+    emit("static PyObject *")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["generator_creation_args"])
+    emit(");\n")
+
+
+def _emit_028_template_generator_context_body_template(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_GeneratorObject *generator, PyObject *yield_return_value) {\nCHECK_OBJECT(generator);\nassert(Nuitka_Generator_Check((PyObject *)generator));\nCHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n\n")
+    emit(values["function_dispatch"])
+    emit("\n\n\n")
+    emit(values["function_var_inits"])
+    emit("\n\n\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["generator_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["generator_creation_args"])
+    emit(") {\nreturn Nuitka_Generator_New(\n")
+    emit(values["function_identifier"])
+    emit("_context,\n")
+    emit(values["generator_module"])
+    emit(",\n")
+    emit(values["generator_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x350\n")
+    emit(values["generator_qualname_obj"])
+    emit(",\n#endif\n")
+    emit(values["code_identifier"])
+    emit(",\n")
+    emit(values["closure_name"])
+    emit(",\n")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nsizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n0\n#endif\n);\n}\n")
+
+
+def _emit_028_template_generator_context_body_template_readable(emit, values):
+    emit("\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\nstruct ")
+    emit(values["function_identifier"])
+    emit("_locals {\n")
+    emit(values["function_local_types"])
+    emit("\n};\n#endif\n\nstatic PyObject *")
+    emit(values["function_identifier"])
+    emit(
+        "_context(PyThreadState *tstate, struct Nuitka_GeneratorObject *generator, PyObject *yield_return_value) {\n    CHECK_OBJECT(generator);\n    assert(Nuitka_Generator_Check((PyObject *)generator));\n    CHECK_OBJECT_X(yield_return_value);\n\n#if "
+    )
+    emit(values["has_heap_declaration"])
+    emit("\n    // Heap access.\n")
+    emit(values["heap_declaration"])
+    emit("\n#endif\n\n    // Dispatch to yield based on return label index:\n")
+    emit(values["function_dispatch"])
+    emit("\n\n    // Local variable initialization\n")
+    emit(values["function_var_inits"])
+    emit("\n\n    // Actual generator function body.\n")
+    emit(values["function_body"])
+    emit("\n\n")
+    emit(values["generator_exit"])
+    emit("\n}\n\nstatic PyObject *")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["generator_creation_args"])
+    emit(") {\n    return Nuitka_Generator_New(\n        ")
+    emit(values["function_identifier"])
+    emit("_context,\n        ")
+    emit(values["generator_module"])
+    emit(",\n        ")
+    emit(values["generator_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x350\n        ")
+    emit(values["generator_qualname_obj"])
+    emit(",\n#endif\n        ")
+    emit(values["code_identifier"])
+    emit(",\n        ")
+    emit(values["closure_name"])
+    emit(",\n        ")
+    emit(str(values["closure_count"]))
+    emit(",\n#if ")
+    emit(values["has_heap_declaration"])
+    emit("\n        sizeof(struct ")
+    emit(values["function_identifier"])
+    emit("_locals)\n#else\n        0\n#endif\n    );\n}\n")
+
+
+def _emit_029_template_make_generator(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit("= ")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_029_template_make_generator_readable(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit(" = ")
+    emit(values["generator_maker_identifier"])
+    emit("(")
+    emit(values["args"])
+    emit(");\n")
+
+
+def _emit_030_template_make_empty_generator(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit("= Nuitka_Generator_NewEmpty(\n")
+    emit(values["generator_module"])
+    emit(",\n")
+    emit(values["generator_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x350\n")
+    emit(values["generator_qualname_obj"])
+    emit(",\n#endif\n")
+    emit(values["code_identifier"])
+    emit(",\n")
+    emit(values["closure_name"])
+    emit(",\n")
+    emit(str(values["closure_count"]))
+    emit("\n);\n")
+
+
+def _emit_030_template_make_empty_generator_readable(emit, values):
+    emit(values["closure_copy"])
+    emit("\n")
+    emit(values["to_name"])
+    emit(" = Nuitka_Generator_NewEmpty(\n    ")
+    emit(values["generator_module"])
+    emit(",\n    ")
+    emit(values["generator_name_obj"])
+    emit(",\n#if PYTHON_VERSION >= 0x350\n    ")
+    emit(values["generator_qualname_obj"])
+    emit(",\n#endif\n    ")
+    emit(values["code_identifier"])
+    emit(",\n    ")
+    emit(values["closure_name"])
+    emit(",\n    ")
+    emit(str(values["closure_count"]))
+    emit("\n);\n")
+
+
+def _emit_031_template_generator_exception_exit(emit, values):
+    emit(values["function_cleanup"])
+    emit("\nreturn NULL;\n\nfunction_exception_exit:\n")
+    emit(values["function_cleanup"])
+    emit("\nCHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\nRESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n\nreturn NULL;\n")
+
+
+def _emit_031_template_generator_exception_exit_readable(emit, values):
+    emit(values["function_cleanup"])
+    emit("\n    return NULL;\n\n    function_exception_exit:\n")
+    emit(values["function_cleanup"])
+    emit("\n    CHECK_EXCEPTION_STATE(&")
+    emit(values["exception_state_name"])
+    emit(");\n    RESTORE_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n\n    return NULL;\n")
+
+
+def _emit_032_template_generator_no_exception_exit(emit, values):
+    emit("\n")
+    emit(values["function_cleanup"])
+    emit("\nreturn NULL;\n")
+
+
+def _emit_032_template_generator_no_exception_exit_readable(emit, values):
+    emit("    // Return statement need not be present.\n")
+    emit(values["function_cleanup"])
+    emit("\n    return NULL;\n")
+
+
+def _emit_033_template_generator_return_exit(emit, values):
+    emit(
+        'NUITKA_CANNOT_GET_HERE("Generator must have exited already.");\nreturn NULL;\n\nfunction_return_exit:\n#if PYTHON_VERSION >= 0x300\ngenerator->m_returned = '
+    )
+    emit(values["return_value"])
+    emit(";\n#endif\n\n")
+    emit(values["function_cleanup"])
+    emit("\nreturn NULL;\n")
+
+
+def _emit_033_template_generator_return_exit_readable(emit, values):
+    emit(
+        '    NUITKA_CANNOT_GET_HERE("Generator must have exited already.");\n    return NULL;\n\n    function_return_exit:\n#if PYTHON_VERSION >= 0x300\n    generator->m_returned = '
+    )
+    emit(values["return_value"])
+    emit(";\n#endif\n\n")
+    emit(values["function_cleanup"])
+    emit("\n    return NULL;\n")
+
+
+def _emit_034_template_loop_break_next(emit, values):
+    emit("if (")
+    emit(values["to_name"])
+    emit("== NULL) {\nif (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
+    emit(values["break_indicator_code"])
+    emit("\ngoto ")
+    emit(values["break_target"])
+    emit(";\n} else {\n")
+    emit(values["release_temps"])
+    emit("\nFETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n")
+    emit(values["var_description_code"])
+    emit("\n")
+    emit(values["line_number_code"])
+    emit("\ngoto ")
+    emit(values["exception_target"])
+    emit(";\n}\n}\n")
+
+
+def _emit_034_template_loop_break_next_readable(emit, values):
+    emit("if (")
+    emit(values["to_name"])
+    emit(" == NULL) {\n    if (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
+    emit(values["break_indicator_code"])
+    emit("\n        goto ")
+    emit(values["break_target"])
+    emit(";\n    } else {\n")
+    emit(values["release_temps"])
+    emit("\n        FETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n")
+    emit(values["var_description_code"])
+    emit("\n")
+    emit(values["line_number_code"])
+    emit("\n        goto ")
+    emit(values["exception_target"])
+    emit(";\n    }\n}\n")
+
+
+def _emit_035_template_metapath_loader_body(emit, values):
+    emit(
+        '\n\n\n#include "nuitka/prelude.h"\n\n\n#if PY_MICRO_VERSION < 16\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + PY_MICRO_VERSION)\n#else\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + 15)\n#endif\n\n#include "nuitka/constants_blob.h"\n\n#include "nuitka/tracing.h"\n#include "nuitka/unfreezing.h"\n\n\n#ifndef __cplusplus\n#include <stdbool.h>\n#endif\n\n#if '
+    )
+    emit(str(values["bytecode_count"]))
+    emit("> 0\nstatic unsigned char *bytecode_data[")
+    emit(str(values["bytecode_count"]))
+    emit(
+        "];\n#else\nstatic unsigned char **bytecode_data = NULL;\n#endif\n\n\n#ifdef __cplusplus\n#define NUITKA_CAST_INIT_REASON(x) reinterpret_cast<module_init_func>((void*)(x))\n#else\n#define NUITKA_CAST_INIT_REASON(x) (module_init_func)(x)\n#endif\n\n\n\n\n\n"
+    )
+    emit(values["metapath_module_decls"])
+    emit("\n\nstatic struct Nuitka_MetaPathBasedLoaderEntry meta_path_loader_entries[")
+    emit(str(values["entry_count"]))
+    emit("] = {\n")
+    emit(values["metapath_loader_inittab"])
+    emit(
+        '\n};\n\nstatic void _loadBytesCodesBlob(PyThreadState *tstate) {\nstatic bool init_done = false;\n\nif (init_done == false) {\n\nloadConstantsBlob(tstate, bytecode_data, ".bytecode");\n\ninit_done = true;\n}\n}\n\nvoid setupMetaPathBasedLoader(PyThreadState *tstate) {\nstatic bool init_done = false;\nif (init_done == false) {\n_loadBytesCodesBlob(tstate);\nregisterMetaPathBasedLoader(meta_path_loader_entries, bytecode_data, '
+    )
+    emit(str(values["entry_count"]))
+    emit(
+        ");\n\ninit_done = true;\n}\n}\n\n\n\n\n\n\n\n\n\n\nstruct frozen_desc {\nchar const *name;\nint index;\nint size;\n};\n\nstatic struct frozen_desc _frozen_modules[] = {\n"
+    )
+    emit(values["frozen_modules"])
+    emit(
+        '\n{NULL, 0, 0}\n};\n\n\nvoid copyFrozenModulesTo(struct _frozen *destination) {\nNUITKA_PRINT_TIMING("copyFrozenModulesTo(): Calling _loadBytesCodesBlob.");\n_loadBytesCodesBlob(NULL);\n\nNUITKA_PRINT_TIMING("copyFrozenModulesTo(): Updating frozen module table sizes.");\n\nstruct frozen_desc *current = _frozen_modules;\n\nfor (;;) {\ndestination->name = (char *)current->name;\ndestination->code = bytecode_data[current->index];\ndestination->size = current->size;\n#if PYTHON_VERSION >= 0x3b0\ndestination->is_package = current->size < 0;\ndestination->size = Py_ABS(destination->size);\n#if PYTHON_VERSION < 0x3d0\ndestination->get_code = NULL;\n#endif\n#endif\nif (destination->name == NULL) break;\n\ncurrent += 1;\ndestination += 1;\n};\n}\n\n#if _NUITKA_MODULE_MODE\n\n#ifndef NUITKA_LOADER_COMPARE_NAME\n#define NUITKA_LOADER_COMPARE_NAME(name, index, entry) strcmp(name, (entry)->name)\n#endif\n\nstruct Nuitka_MetaPathBasedLoaderEntry const *getLoaderEntry(char const *name) {\nfor (int i = 0; i < '
+    )
+    emit(str(values["entry_count"]))
+    emit(
+        "; i++) {\nif (NUITKA_LOADER_COMPARE_NAME(name, i, &meta_path_loader_entries[i]) == 0) {\nreturn &meta_path_loader_entries[i];\n}\n}\n\nassert(false);\nreturn NULL;\n}\n#endif\n\n"
+    )
+
+
+def _emit_035_template_metapath_loader_body_readable(emit, values):
+    emit(
+        '\n/* Code to register embedded modules for meta path based loading if any. */\n\n#include "nuitka/prelude.h"\n\n/* Use a hex version of our own to compare for versions. We do not care about pre-releases */\n#if PY_MICRO_VERSION < 16\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + PY_MICRO_VERSION)\n#else\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + 15)\n#endif\n\n#include "nuitka/constants_blob.h"\n\n#include "nuitka/tracing.h"\n#include "nuitka/unfreezing.h"\n\n/* Type bool, spell-checker: ignore stdbool */\n#ifndef __cplusplus\n#include <stdbool.h>\n#endif\n\n#if '
+    )
+    emit(str(values["bytecode_count"]))
+    emit(" > 0\nstatic unsigned char *bytecode_data[")
+    emit(str(values["bytecode_count"]))
+    emit(
+        "];\n#else\nstatic unsigned char **bytecode_data = NULL;\n#endif\n\n/* Helper for portable cast, to use string literals as module_init_func */\n#ifdef __cplusplus\n#define NUITKA_CAST_INIT_REASON(x) reinterpret_cast<module_init_func>((void*)(x))\n#else\n#define NUITKA_CAST_INIT_REASON(x) (module_init_func)(x)\n#endif\n\n/* Table for lookup to find compiled or bytecode modules included in this\n * binary or module, or put along this binary as extension modules. We do\n * our own loading for each of these.\n */\n"
+    )
+    emit(values["metapath_module_decls"])
+    emit("\n\nstatic struct Nuitka_MetaPathBasedLoaderEntry meta_path_loader_entries[")
+    emit(str(values["entry_count"]))
+    emit("] = {\n")
+    emit(values["metapath_loader_inittab"])
+    emit(
+        '\n};\n\nstatic void _loadBytesCodesBlob(PyThreadState *tstate) {\n    static bool init_done = false;\n\n    if (init_done == false) {\n        // Note needed for mere data.\n        loadConstantsBlob(tstate, bytecode_data, ".bytecode");\n\n        init_done = true;\n    }\n}\n\nvoid setupMetaPathBasedLoader(PyThreadState *tstate) {\n    static bool init_done = false;\n    if (init_done == false) {\n        _loadBytesCodesBlob(tstate);\n        registerMetaPathBasedLoader(meta_path_loader_entries, bytecode_data, '
+    )
+    emit(str(values["entry_count"]))
+    emit(
+        ');\n\n        init_done = true;\n    }\n}\n\n// This provides the frozen (compiled bytecode) files that are included if\n// any.\n\n// These modules should be loaded as bytecode. They may e.g. have to be loadable\n// during "Py_Initialize" already, or for irrelevance, they are only included\n// in this un-optimized form. These are not compiled by Nuitka, and therefore\n// are not accelerated at all, merely bundled with the binary or module, so\n// that CPython library can start out finding them.\n\nstruct frozen_desc {\n    char const *name;\n    int index;\n    int size;\n};\n\nstatic struct frozen_desc _frozen_modules[] = {\n'
+    )
+    emit(values["frozen_modules"])
+    emit(
+        '\n    {NULL, 0, 0}\n};\n\n\nvoid copyFrozenModulesTo(struct _frozen *destination) {\n    NUITKA_PRINT_TIMING("copyFrozenModulesTo(): Calling _loadBytesCodesBlob.");\n    _loadBytesCodesBlob(NULL);\n\n    NUITKA_PRINT_TIMING("copyFrozenModulesTo(): Updating frozen module table sizes.");\n\n    struct frozen_desc *current = _frozen_modules;\n\n    for (;;) {\n        destination->name = (char *)current->name;\n        destination->code = bytecode_data[current->index];\n        destination->size = current->size;\n#if PYTHON_VERSION >= 0x3b0\n        destination->is_package = current->size < 0;\n        destination->size = Py_ABS(destination->size);\n#if PYTHON_VERSION < 0x3d0\n        destination->get_code = NULL;\n#endif\n#endif\n        if (destination->name == NULL) break;\n\n        current += 1;\n        destination += 1;\n    };\n}\n\n#if _NUITKA_MODULE_MODE\n\n#ifndef NUITKA_LOADER_COMPARE_NAME\n#define NUITKA_LOADER_COMPARE_NAME(name, index, entry) strcmp(name, (entry)->name)\n#endif\n\nstruct Nuitka_MetaPathBasedLoaderEntry const *getLoaderEntry(char const *name) {\n    for (int i = 0; i < '
+    )
+    emit(str(values["entry_count"]))
+    emit(
+        "; i++) {\n        if (NUITKA_LOADER_COMPARE_NAME(name, i, &meta_path_loader_entries[i]) == 0) {\n            return &meta_path_loader_entries[i];\n        }\n    }\n\n    assert(false);\n    return NULL;\n}\n#endif\n\n"
+    )
+
+
+def _emit_036_template_global_copyright(emit, values):
+    emit(values["module_identifier"])
+    emit("'\n* created by Nuitka version ")
+    emit(values["version"])
+    emit("\n*\n* This code is in part copyright ")
+    emit(values["year"])
+    emit(
+        'Kay Hayen.\n*\n* Licensed under the GNU Affero General Public License, Version 3 (the "License");\n* you may not use this file except in compliance with the License.\n*\n* You may obtain a copy of the License in "LICENSE.txt" and the runtime\n* exception granted in "LICENSE-RUNTIME.txt" from Nuitka source code. For\n* deploying the generated code it is intended to not restrict distributing\n* created binaries.\n*\n* Unless required by applicable law or agreed to in writing, software\n* distributed under the License is distributed on an "AS IS" BASIS,\n* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n* See the License for the specific language governing permissions and\n* limitations under the License.\n*/\n'
+    )
+
+
+def _emit_036_template_global_copyright_readable(emit, values):
+    emit("/* Generated code for Python module '")
+    emit(values["module_identifier"])
+    emit("'\n * created by Nuitka version ")
+    emit(values["version"])
+    emit("\n *\n * This code is in part copyright ")
+    emit(values["year"])
+    emit(
+        ' Kay Hayen.\n *\n * Licensed under the GNU Affero General Public License, Version 3 (the "License");\n * you may not use this file except in compliance with the License.\n *\n * You may obtain a copy of the License in "LICENSE.txt" and the runtime\n * exception granted in "LICENSE-RUNTIME.txt" from Nuitka source code. For\n * deploying the generated code it is intended to not restrict distributing\n * created binaries.\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */\n'
+    )
+
+
+def _emit_037_template_module_body_template(emit, values):
+    emit(
+        '\n#include "nuitka/prelude.h"\n\n#include "nuitka/unfreezing.h"\n\n#include "__helpers.h"\n\n'
+    )
+    emit(values["module_includes"])
+    emit("\n\n")
+    emit(values["module_identifier"])
+    emit(
+        '" is a Python object pointer of module type.\n*\n* Note: For full compatibility with CPython, every module variable access\n* needs to go through it except for cases where the module cannot possibly\n* have changed in the mean time.\n*/\n\nPyObject *module_'
+    )
+    emit(values["module_identifier"])
+    emit(";\nPyDictObject *moduledict_")
+    emit(values["module_identifier"])
+    emit(";\n\n\nstatic struct ModuleConstants {\n")
+    emit(values["module_constants_decl"])
+    emit(
+        "\n} mod_consts;\n#ifndef __NUITKA_NO_ASSERT__\nstatic Py_hash_t mod_consts_hash["
+    )
+    emit(str(values["constants_count"]))
+    emit(
+        "];\n#endif\n\nstatic PyObject *module_filename_obj = NULL;\n\n\nstatic bool constants_created = false;\n\nNUITKA_DECLARE_CONSTANT_BLOB(\n"
+    )
+    emit(values["module_const_blob_symbol_name"])
+    emit(",\n")
+    emit(values["module_const_blob_symbol_name"])
+    emit(
+        ",\nconst\n);\n\n\nstatic void createModuleConstants(PyThreadState *tstate) {\nif (constants_created == false) {\n#if "
+    )
+    emit(str(values["use_direct_constant_blobs"]))
+    emit("\nLOAD_DIRECT_CONSTANTS_BLOB(tstate, (PyObject **)&mod_consts, ")
+    emit(values["module_const_blob_symbol_name"])
+    emit(");\n#else\nloadConstantsBlob(tstate, &mod_consts, UN_TRANSLATE(")
+    emit(values["module_const_blob_name"])
+    emit("));\n#endif\nconstants_created = true;\n\n#ifndef __NUITKA_NO_ASSERT__\n")
+    emit(values["module_constants_check_hash"])
+    emit("\n#endif\n}\n}\n\n\n#if ")
+    emit(values["is_dunder_main"])
+    emit(
+        "\nvoid createMainModuleConstants(PyThreadState *tstate) {\ncreateModuleConstants(tstate);\n}\n#endif\n\n\n#ifndef __NUITKA_NO_ASSERT__\nvoid checkModuleConstants_"
+    )
+    emit(values["module_identifier"])
+    emit("(PyThreadState *tstate) {\n\nif (constants_created == false) return;\n\n")
+    emit(values["module_constants_check_object"])
+    emit("\n}\n#endif\n\n\n#if ")
+    emit(str(values["module_variable_accessors_count"]))
+    emit(
+        "\n#if PYTHON_VERSION >= 0x3c0\nNUITKA_MAY_BE_UNUSED static uint32_t _Nuitka_PyDictKeys_GetVersionForCurrentState(PyInterpreterState *interp, PyDictKeysObject *dk)\n{\nif (dk->dk_version != 0) {\nreturn dk->dk_version;\n}\nuint32_t result = Nuitka_PyInterpreterState_GetDictState(interp)->next_keys_version++;\ndk->dk_version = result;\nreturn result;\n}\n#elif PYTHON_VERSION >= 0x3b0\nstatic uint32_t _Nuitka_next_dict_keys_version = 2;\n\nNUITKA_MAY_BE_UNUSED static uint32_t _Nuitka_PyDictKeys_GetVersionForCurrentState(PyDictKeysObject *dk)\n{\nif (dk->dk_version != 0) {\nreturn dk->dk_version;\n}\nuint32_t result = _Nuitka_next_dict_keys_version++;\ndk->dk_version = result;\nreturn result;\n}\n#endif\n#endif\n\n\n"
+    )
+    emit(values["module_variable_accessors"])
+    emit("\n\n#if !defined(_NUITKA_EXPERIMENTAL_NEW_CODE_OBJECTS)\n\n")
+    emit(values["module_code_objects_decl"])
+    emit("\n\nstatic void createModuleCodeObjects(void) {\n")
+    emit(values["module_code_objects_init"])
+    emit("\n}\n#endif\n\n\n")
+    emit(values["module_functions_decl"])
+    emit("\n\n\n")
+    emit(values["module_functions_code"])
+    emit(
+        "\n\nextern void _initCompiledCellType();\nextern void _initCompiledGeneratorType();\nextern void _initCompiledFunctionType();\nextern void _initCompiledMethodType();\nextern void _initCompiledFrameType();\n\nextern PyTypeObject Nuitka_Loader_Type;\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n\n\nextern void registerDillPluginTables(PyThreadState *tstate, char const *module_name, PyMethodDef *reduce_compiled_function, PyMethodDef *create_compiled_function);\n\nstatic function_impl_code const function_table_"
+    )
+    emit(values["module_identifier"])
+    emit("[] = {\n")
+    emit(values["module_function_table_entries"])
+    emit(
+        '\nNULL\n};\n\nstatic PyObject *_reduce_compiled_function(PyObject *self, PyObject *args, PyObject *kwds) {\nPyObject *func;\n\nif (!PyArg_ParseTuple(args, "O:reduce_compiled_function", &func, NULL)) {\nreturn NULL;\n}\n\nif (Nuitka_Function_Check(func) == false) {\nPyThreadState *tstate = PyThreadState_GET();\n\nSET_CURRENT_EXCEPTION_TYPE0_STR(tstate, PyExc_TypeError, "not a compiled function");\nreturn NULL;\n}\n\nstruct Nuitka_FunctionObject *function = (struct Nuitka_FunctionObject *)func;\n\nreturn Nuitka_Function_GetFunctionState(function, function_table_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ');\n}\n\nstatic PyMethodDef _method_def_reduce_compiled_function = {"reduce_compiled_function", (PyCFunction)_reduce_compiled_function,\nMETH_VARARGS, NULL};\n\n\nstatic PyObject *_create_compiled_function(PyObject *self, PyObject *args, PyObject *kwds) {\nCHECK_OBJECT_DEEP(args);\n\nPyObject *function_index;\nPyObject *code_object_desc;\nPyObject *defaults;\nPyObject *kw_defaults;\nPyObject *doc;\nPyObject *constant_return_value;\nPyObject *function_qualname;\nPyObject *closure;\nPyObject *annotations;\nPyObject *func_dict;\n\nif (!PyArg_ParseTuple(args, "OOOOOOOOOO:create_compiled_function", &function_index, &code_object_desc, &defaults, &kw_defaults, &doc, &constant_return_value, &function_qualname, &closure, &annotations, &func_dict, NULL)) {\nreturn NULL;\n}\n\nreturn (PyObject *)Nuitka_Function_CreateFunctionViaCodeIndex(\nmodule_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\nfunction_qualname,\nfunction_index,\ncode_object_desc,\nconstant_return_value,\ndefaults,\nkw_defaults,\ndoc,\nclosure,\nannotations,\nfunc_dict,\nfunction_table_"
+    )
+    emit(values["module_identifier"])
+    emit(",\nsizeof(function_table_")
+    emit(values["module_identifier"])
+    emit(
+        ') / sizeof(function_impl_code)\n);\n}\n\nstatic PyMethodDef _method_def_create_compiled_function = {\n"create_compiled_function",\n(PyCFunction)_create_compiled_function,\nMETH_VARARGS, NULL\n};\n\n\n#endif\n\n\n#if _NUITKA_MODULE_MODE && '
+    )
+    emit(str(values["is_top"]))
+    emit("\nstatic char const *module_full_name = ")
+    emit(values["module_name_cstr"])
+    emit(";\n#endif\n\n\nPyObject *module_code_")
+    emit(values["module_identifier"])
+    emit(
+        '(PyThreadState *tstate, PyObject *module, struct Nuitka_MetaPathBasedLoaderEntry const *loader_entry) {\n\nPGO_onModuleEntered("'
+    )
+    emit(values["module_identifier"])
+    emit('");\n\n// Store the module for future use.\nmodule_')
+    emit(values["module_identifier"])
+    emit("= module;\n\nmoduledict_")
+    emit(values["module_identifier"])
+    emit("= MODULE_DICT(module_")
+    emit(values["module_identifier"])
+    emit(
+        ");\n\n\nstatic bool init_done = false;\n\nif (init_done == false) {\n#if _NUITKA_MODULE_MODE && "
+    )
+    emit(str(values["is_top"]))
+    emit(
+        '\n\n\n\n#if PYTHON_VERSION > 0x350 && !defined(_NUITKA_EXPERIMENTAL_DISABLE_ALLOCATORS)\ninitNuitkaAllocators();\n#endif\n\n_initBuiltinModule(tstate);\n\nPyObject *real_module_name = PyObject_GetAttrString(module, "__name__");\nCHECK_OBJECT(real_module_name);\nmodule_full_name = strdup(Nuitka_String_AsString(real_module_name));\n\ncreateGlobalConstants(tstate, real_module_name);\n\n\n_initCompiledCellType();\n_initCompiledGeneratorType();\n_initCompiledFunctionType();\n_initCompiledMethodType();\n_initCompiledFrameType();\n\n_initSlotCompare();\n#if PYTHON_VERSION >= 0x270\n_initSlotIterNext();\n#endif\n\npatchTypeComparison();\n\n\n#ifdef _NUITKA_TRACE\nPRINT_STRING("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ': Calling setupMetaPathBasedLoader().\\n");\n#endif\nsetupMetaPathBasedLoader(tstate);\n#if '
+    )
+    emit(values["module_def_size"])
+    emit('>= 0\n#ifdef _NUITKA_TRACE\nPRINT_STRING("')
+    emit(values["module_identifier"])
+    emit(
+        ': Calling updateMetaPathBasedLoaderModuleRoot().\\n");\n#endif\nupdateMetaPathBasedLoaderModuleRoot(module_full_name);\n#endif\n\n\n#if PYTHON_VERSION >= 0x300\npatchInspectModule(tstate);\n#endif\n\n#endif\n\n/* The constants only used by this module are created now. */\nNUITKA_PRINT_TRACE("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ': Calling createModuleConstants().\\n");\ncreateModuleConstants(tstate);\n\n#if !defined(_NUITKA_EXPERIMENTAL_NEW_CODE_OBJECTS)\ncreateModuleCodeObjects();\n#endif\ninit_done = true;\n}\n\n#if _NUITKA_MODULE_MODE && '
+    )
+    emit(str(values["is_top"]))
+    emit("\nPyObject *pre_load = IMPORT_EMBEDDED_MODULE(tstate, ")
+    emit(values["module_name_cstr"])
+    emit('"-preLoad");\nif (pre_load == NULL) {\nreturn NULL;\n}\n#endif\n\n')
+    emit(values["module_identifier"])
+    emit(
+        '\\n");\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n{\nchar const *module_name_c;\nif (loader_entry != NULL) {\nmodule_name_c = loader_entry->name;\n} else {\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\nmodule_name_c = Nuitka_String_AsString(module_name);\n}\n\nregisterDillPluginTables(tstate, module_name_c, &_method_def_reduce_compiled_function, &_method_def_create_compiled_function);\n}\n#endif\n\n\n\n\n#if PYTHON_VERSION >= 0x3b0 && PYTHON_VERSION < 0x3c0 && _NUITKA_STANDALONE_MODE && !"
+    )
+    emit(values["is_package"])
+    emit("\nUPDATE_STRING_DICT0(\nmoduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___compiled__,\nNuitka_dunder_compiled_value\n);\n#endif\n\n\n{\n#if "
+    )
+    emit(values["is_dunder_main"])
+    emit("\nUPDATE_STRING_DICT0(\nmoduledict_")
+    emit(values["module_identifier"])
+    emit(",\n(Nuitka_StringObject *)const_str_plain___package__,\n")
+    emit(values["dunder_main_package"])
+    emit("\n);\n#elif ")
+    emit(values["is_package"])
+    emit("\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\n\nUPDATE_STRING_DICT0(\nmoduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___package__,\nmodule_name\n);\n#else\n\n#if PYTHON_VERSION < 0x300\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\nchar const *module_name_cstr = PyString_AS_STRING(module_name);\n\nchar const *last_dot = strrchr(module_name_cstr, '.');\n\nif (last_dot != NULL) {\nUPDATE_STRING_DICT1(\nmoduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___package__,\nPyString_FromStringAndSize(module_name_cstr, last_dot - module_name_cstr)\n);\n}\n#else\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\nPy_ssize_t dot_index = PyUnicode_Find(module_name, const_str_dot, 0, PyUnicode_GetLength(module_name), -1);\n\nif (dot_index != -1) {\nUPDATE_STRING_DICT1(\nmoduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___package__,\nPyUnicode_Substring(module_name, 0, dot_index)\n);\n}\n#endif\n#endif\n}\n\nCHECK_OBJECT(module_"
+    )
+    emit(values["module_identifier"])
+    emit(");\n\n\n\n\n\nif (GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___builtins__) == NULL) {\nPyObject *value = (PyObject *)builtin_module;\n\n\n#if _NUITKA_MODULE_MODE || !"
+    )
+    emit(values["is_dunder_main"])
+    emit(
+        "\nvalue = PyModule_GetDict(value);\n#endif\n\nUPDATE_STRING_DICT0(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___builtins__, value);\n}\n\nPyObject *module_loader = Nuitka_Loader_New(loader_entry);\nUPDATE_STRING_DICT0(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___loader__, module_loader);\n\n#if PYTHON_VERSION >= 0x300\n\n\n#if "
+    )
+    emit(values["is_dunder_main"])
+    emit("\n\nUPDATE_STRING_DICT0(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___spec__, Py_None);\n#else\n\n{\nPyObject *bootstrap_module = getImportLibBootstrapModule();\nCHECK_OBJECT(bootstrap_module);\n\nPyObject *_spec_from_module = PyObject_GetAttrString(bootstrap_module, "_spec_from_module");\nCHECK_OBJECT(_spec_from_module);\n\nPyObject *spec_value = CALL_FUNCTION_WITH_SINGLE_ARG(tstate, _spec_from_module, module_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ");\nPy_DECREF(_spec_from_module);\n\n\n\n\nif (spec_value == NULL) {\nPyErr_PrintEx(0);\nabort();\n}\n\n\nSET_ATTRIBUTE(tstate, spec_value, const_str_plain__initializing, Py_True);\n\n#if _NUITKA_MODULE_MODE && "
+    )
+    emit(str(values["is_top"]))
+    emit("&& ")
+    emit(values["module_def_size"])
+    emit(
+        ">= 0\n\nSET_ATTRIBUTE(tstate, spec_value, const_str_plain_loader, module_loader);\n#endif\n\nUPDATE_STRING_DICT1(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___spec__, spec_value);\n}\n#endif\n#endif\n\n\n"
+    )
+    emit(values["temps_decl"])
+    emit("\n\n\n")
+    emit(values["module_init_codes"])
+    emit("\n\n\n")
+    emit(values["module_codes"])
+    emit('\n\n\nPGO_onModuleExit("')
+    emit(values["module_identifier"])
+    emit('", false);\n\n#if _NUITKA_MODULE_MODE && ')
+    emit(str(values["is_top"]))
+    emit("\n{\nPyObject *post_load = IMPORT_EMBEDDED_MODULE(tstate, ")
+    emit(values["module_name_cstr"])
+    emit(
+        '"-postLoad");\nif (post_load == NULL) {\nreturn NULL;\n}\n}\n#endif\n\nPy_INCREF(module_'
+    )
+    emit(values["module_identifier"])
+    emit(");\nreturn module_")
+    emit(values["module_identifier"])
+    emit(";\n")
+    emit(values["module_exit"])
+    emit("\n")
+
+
+def _emit_037_template_module_body_template_readable(emit, values):
+    emit(
+        '\n#include "nuitka/prelude.h"\n\n#include "nuitka/unfreezing.h"\n\n#include "__helpers.h"\n\n'
+    )
+    emit(values["module_includes"])
+    emit('\n\n/* The "module_')
+    emit(values["module_identifier"])
+    emit(
+        '" is a Python object pointer of module type.\n *\n * Note: For full compatibility with CPython, every module variable access\n * needs to go through it except for cases where the module cannot possibly\n * have changed in the mean time.\n */\n\nPyObject *module_'
+    )
+    emit(values["module_identifier"])
+    emit(";\nPyDictObject *moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ";\n\n/* The declarations of module constants used, if any. */\nstatic struct ModuleConstants {\n"
+    )
+    emit(values["module_constants_decl"])
+    emit(
+        "\n} mod_consts;\n#ifndef __NUITKA_NO_ASSERT__\nstatic Py_hash_t mod_consts_hash["
+    )
+    emit(str(values["constants_count"]))
+    emit(
+        "];\n#endif\n\nstatic PyObject *module_filename_obj = NULL;\n\n/* Indicator if this modules private constants were created yet. */\nstatic bool constants_created = false;\n\nNUITKA_DECLARE_CONSTANT_BLOB(\n    "
+    )
+    emit(values["module_const_blob_symbol_name"])
+    emit(",\n    ")
+    emit(values["module_const_blob_symbol_name"])
+    emit(
+        ",\n    const\n);\n\n/* Function to create module private constants. */\nstatic void createModuleConstants(PyThreadState *tstate) {\n    if (constants_created == false) {\n#if "
+    )
+    emit(str(values["use_direct_constant_blobs"]))
+    emit("\n        LOAD_DIRECT_CONSTANTS_BLOB(tstate, (PyObject **)&mod_consts, ")
+    emit(values["module_const_blob_symbol_name"])
+    emit(");\n#else\n        loadConstantsBlob(tstate, &mod_consts, UN_TRANSLATE(")
+    emit(values["module_const_blob_name"])
+    emit(
+        "));\n#endif\n        constants_created = true;\n\n#ifndef __NUITKA_NO_ASSERT__\n"
+    )
+    emit(values["module_constants_check_hash"])
+    emit(
+        '\n#endif\n    }\n}\n\n// We want to be able to initialize the "__main__" constants in any case.\n#if '
+    )
+    emit(values["is_dunder_main"])
+    emit(
+        "\nvoid createMainModuleConstants(PyThreadState *tstate) {\n    createModuleConstants(tstate);\n}\n#endif\n\n/* Function to verify module private constants for non-corruption. */\n#ifndef __NUITKA_NO_ASSERT__\nvoid checkModuleConstants_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        "(PyThreadState *tstate) {\n    // The module may not have been used at all, then ignore this.\n    if (constants_created == false) return;\n\n"
+    )
+    emit(values["module_constants_check_object"])
+    emit(
+        "\n}\n#endif\n\n// Helper to preserving module variables for Python3.11+\n#if "
+    )
+    emit(str(values["module_variable_accessors_count"]))
+    emit(
+        "\n#if PYTHON_VERSION >= 0x3c0\nNUITKA_MAY_BE_UNUSED static uint32_t _Nuitka_PyDictKeys_GetVersionForCurrentState(PyInterpreterState *interp, PyDictKeysObject *dk)\n{\n    if (dk->dk_version != 0) {\n        return dk->dk_version;\n    }\n    uint32_t result = Nuitka_PyInterpreterState_GetDictState(interp)->next_keys_version++;\n    dk->dk_version = result;\n    return result;\n}\n#elif PYTHON_VERSION >= 0x3b0\nstatic uint32_t _Nuitka_next_dict_keys_version = 2;\n\nNUITKA_MAY_BE_UNUSED static uint32_t _Nuitka_PyDictKeys_GetVersionForCurrentState(PyDictKeysObject *dk)\n{\n    if (dk->dk_version != 0) {\n        return dk->dk_version;\n    }\n    uint32_t result = _Nuitka_next_dict_keys_version++;\n    dk->dk_version = result;\n    return result;\n}\n#endif\n#endif\n\n// Accessors to module variables.\n"
+    )
+    emit(values["module_variable_accessors"])
+    emit(
+        "\n\n#if !defined(_NUITKA_EXPERIMENTAL_NEW_CODE_OBJECTS)\n// The module code objects.\n"
+    )
+    emit(values["module_code_objects_decl"])
+    emit("\n\nstatic void createModuleCodeObjects(void) {\n")
+    emit(values["module_code_objects_init"])
+    emit("\n}\n#endif\n\n// The module function declarations.\n")
+    emit(values["module_functions_decl"])
+    emit("\n\n// The module function definitions.\n")
+    emit(values["module_functions_code"])
+    emit(
+        "\n\nextern void _initCompiledCellType();\nextern void _initCompiledGeneratorType();\nextern void _initCompiledFunctionType();\nextern void _initCompiledMethodType();\nextern void _initCompiledFrameType();\n\nextern PyTypeObject Nuitka_Loader_Type;\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n// Provide a way to create find a function via its C code and create it back\n// in another process, useful for multiprocessing extensions like dill\nextern void registerDillPluginTables(PyThreadState *tstate, char const *module_name, PyMethodDef *reduce_compiled_function, PyMethodDef *create_compiled_function);\n\nstatic function_impl_code const function_table_"
+    )
+    emit(values["module_identifier"])
+    emit("[] = {\n")
+    emit(values["module_function_table_entries"])
+    emit(
+        '\n    NULL\n};\n\nstatic PyObject *_reduce_compiled_function(PyObject *self, PyObject *args, PyObject *kwds) {\n    PyObject *func;\n\n    if (!PyArg_ParseTuple(args, "O:reduce_compiled_function", &func, NULL)) {\n        return NULL;\n    }\n\n    if (Nuitka_Function_Check(func) == false) {\n        PyThreadState *tstate = PyThreadState_GET();\n\n        SET_CURRENT_EXCEPTION_TYPE0_STR(tstate, PyExc_TypeError, "not a compiled function");\n        return NULL;\n    }\n\n    struct Nuitka_FunctionObject *function = (struct Nuitka_FunctionObject *)func;\n\n    return Nuitka_Function_GetFunctionState(function, function_table_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ');\n}\n\nstatic PyMethodDef _method_def_reduce_compiled_function = {"reduce_compiled_function", (PyCFunction)_reduce_compiled_function,\n                                                           METH_VARARGS, NULL};\n\n\nstatic PyObject *_create_compiled_function(PyObject *self, PyObject *args, PyObject *kwds) {\n    CHECK_OBJECT_DEEP(args);\n\n    PyObject *function_index;\n    PyObject *code_object_desc;\n    PyObject *defaults;\n    PyObject *kw_defaults;\n    PyObject *doc;\n    PyObject *constant_return_value;\n    PyObject *function_qualname;\n    PyObject *closure;\n    PyObject *annotations;\n    PyObject *func_dict;\n\n    if (!PyArg_ParseTuple(args, "OOOOOOOOOO:create_compiled_function", &function_index, &code_object_desc, &defaults, &kw_defaults, &doc, &constant_return_value, &function_qualname, &closure, &annotations, &func_dict, NULL)) {\n        return NULL;\n    }\n\n    return (PyObject *)Nuitka_Function_CreateFunctionViaCodeIndex(\n        module_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n        function_qualname,\n        function_index,\n        code_object_desc,\n        constant_return_value,\n        defaults,\n        kw_defaults,\n        doc,\n        closure,\n        annotations,\n        func_dict,\n        function_table_"
+    )
+    emit(values["module_identifier"])
+    emit(",\n        sizeof(function_table_")
+    emit(values["module_identifier"])
+    emit(
+        ') / sizeof(function_impl_code)\n    );\n}\n\nstatic PyMethodDef _method_def_create_compiled_function = {\n    "create_compiled_function",\n    (PyCFunction)_create_compiled_function,\n    METH_VARARGS, NULL\n};\n\n\n#endif\n\n// Actual name might be different when loaded as a package.\n#if _NUITKA_MODULE_MODE && '
+    )
+    emit(str(values["is_top"]))
+    emit("\nstatic char const *module_full_name = ")
+    emit(values["module_name_cstr"])
+    emit(
+        ";\n#endif\n\n// Internal entry point for module code.\nPyObject *module_code_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        '(PyThreadState *tstate, PyObject *module, struct Nuitka_MetaPathBasedLoaderEntry const *loader_entry) {\n    // Report entry to PGO.\n    PGO_onModuleEntered("'
+    )
+    emit(values["module_identifier"])
+    emit('");\n\n    // Store the module for future use.\n    module_')
+    emit(values["module_identifier"])
+    emit(" = module;\n\n    moduledict_")
+    emit(values["module_identifier"])
+    emit(" = MODULE_DICT(module_")
+    emit(values["module_identifier"])
+    emit(
+        ");\n\n    // Modules can be loaded again in case of errors, avoid the init being done again.\n    static bool init_done = false;\n\n    if (init_done == false) {\n#if _NUITKA_MODULE_MODE && "
+    )
+    emit(str(values["is_top"]))
+    emit(
+        '\n        // In case of an extension module loaded into a process, we need to call\n        // initialization here because that\'s the first and potentially only time\n        // we are going called.\n#if PYTHON_VERSION > 0x350 && !defined(_NUITKA_EXPERIMENTAL_DISABLE_ALLOCATORS)\n        initNuitkaAllocators();\n#endif\n        // Initialize the constant values used.\n        _initBuiltinModule(tstate);\n\n        PyObject *real_module_name = PyObject_GetAttrString(module, "__name__");\n        CHECK_OBJECT(real_module_name);\n        module_full_name = strdup(Nuitka_String_AsString(real_module_name));\n\n        createGlobalConstants(tstate, real_module_name);\n\n        /* Initialize the compiled types of Nuitka. */\n        _initCompiledCellType();\n        _initCompiledGeneratorType();\n        _initCompiledFunctionType();\n        _initCompiledMethodType();\n        _initCompiledFrameType();\n\n        _initSlotCompare();\n#if PYTHON_VERSION >= 0x270\n        _initSlotIterNext();\n#endif\n\n        patchTypeComparison();\n\n        // Enable meta path based loader if not already done.\n#ifdef _NUITKA_TRACE\n        PRINT_STRING("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ': Calling setupMetaPathBasedLoader().\\n");\n#endif\n        setupMetaPathBasedLoader(tstate);\n#if '
+    )
+    emit(values["module_def_size"])
+    emit(' >= 0\n#ifdef _NUITKA_TRACE\n        PRINT_STRING("')
+    emit(values["module_identifier"])
+    emit(
+        ': Calling updateMetaPathBasedLoaderModuleRoot().\\n");\n#endif\n        updateMetaPathBasedLoaderModuleRoot(module_full_name);\n#endif\n\n\n#if PYTHON_VERSION >= 0x300\n        patchInspectModule(tstate);\n#endif\n\n#endif\n\n        /* The constants only used by this module are created now. */\n        NUITKA_PRINT_TRACE("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ': Calling createModuleConstants().\\n");\n        createModuleConstants(tstate);\n\n#if !defined(_NUITKA_EXPERIMENTAL_NEW_CODE_OBJECTS)\n        createModuleCodeObjects();\n#endif\n        init_done = true;\n    }\n\n#if _NUITKA_MODULE_MODE && '
+    )
+    emit(str(values["is_top"]))
+    emit("\n    PyObject *pre_load = IMPORT_EMBEDDED_MODULE(tstate, ")
+    emit(values["module_name_cstr"])
+    emit(
+        ' "-preLoad");\n    if (pre_load == NULL) {\n        return NULL;\n    }\n#endif\n\n    // PRINT_STRING("in init'
+    )
+    emit(values["module_identifier"])
+    emit(
+        '\\n");\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n    {\n        char const *module_name_c;\n        if (loader_entry != NULL) {\n            module_name_c = loader_entry->name;\n        } else {\n            PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___name__);\n            module_name_c = Nuitka_String_AsString(module_name);\n        }\n\n        registerDillPluginTables(tstate, module_name_c, &_method_def_reduce_compiled_function, &_method_def_create_compiled_function);\n    }\n#endif\n\n    // For Python 3.11 standalone modules, package "__path__" is inserted by the\n    // loader before module code runs. Pre-seed "__compiled__" for non-packages\n    // to keep their dangerous dict slots aligned with packages.\n#if PYTHON_VERSION >= 0x3b0 && PYTHON_VERSION < 0x3c0 && _NUITKA_STANDALONE_MODE && !'
+    )
+    emit(values["is_package"])
+    emit("\n    UPDATE_STRING_DICT0(\n        moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ',\n        (Nuitka_StringObject *)const_str_plain___compiled__,\n        Nuitka_dunder_compiled_value\n    );\n#endif\n\n    // Update "__package__" value to what it ought to be.\n    {\n#if '
+    )
+    emit(values["is_dunder_main"])
+    emit("\n        UPDATE_STRING_DICT0(\n            moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ",\n            (Nuitka_StringObject *)const_str_plain___package__,\n            "
+    )
+    emit(values["dunder_main_package"])
+    emit("\n        );\n#elif ")
+    emit(values["is_package"])
+    emit("\n        PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\n\n        UPDATE_STRING_DICT0(\n            moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n            (Nuitka_StringObject *)const_str_plain___package__,\n            module_name\n        );\n#else\n\n#if PYTHON_VERSION < 0x300\n        PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\n        char const *module_name_cstr = PyString_AS_STRING(module_name);\n\n        char const *last_dot = strrchr(module_name_cstr, '.');\n\n        if (last_dot != NULL) {\n            UPDATE_STRING_DICT1(\n                moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n                (Nuitka_StringObject *)const_str_plain___package__,\n                PyString_FromStringAndSize(module_name_cstr, last_dot - module_name_cstr)\n            );\n        }\n#else\n        PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___name__);\n        Py_ssize_t dot_index = PyUnicode_Find(module_name, const_str_dot, 0, PyUnicode_GetLength(module_name), -1);\n\n        if (dot_index != -1) {\n            UPDATE_STRING_DICT1(\n                moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n                (Nuitka_StringObject *)const_str_plain___package__,\n                PyUnicode_Substring(module_name, 0, dot_index)\n            );\n        }\n#endif\n#endif\n    }\n\n    CHECK_OBJECT(module_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ');\n\n    // For deep importing of a module we need to have "__builtins__", so we set\n    // it ourselves in the same way than CPython does. Note: This must be done\n    // before the frame object is allocated, or else it may fail.\n\n    if (GET_STRING_DICT_VALUE(moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___builtins__) == NULL) {\n        PyObject *value = (PyObject *)builtin_module;\n\n        // Check if main module, not a dict then but the module itself.\n#if _NUITKA_MODULE_MODE || !"
+    )
+    emit(values["is_dunder_main"])
+    emit(
+        "\n        value = PyModule_GetDict(value);\n#endif\n\n        UPDATE_STRING_DICT0(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___builtins__, value);\n    }\n\n    PyObject *module_loader = Nuitka_Loader_New(loader_entry);\n    UPDATE_STRING_DICT0(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___loader__, module_loader);\n\n#if PYTHON_VERSION >= 0x300\n// Set the "__spec__" value\n\n#if '
+    )
+    emit(values["is_dunder_main"])
+    emit(
+        '\n    // Main modules just get "None" as spec.\n    UPDATE_STRING_DICT0(moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___spec__, Py_None);\n#else\n    // Other modules get a "ModuleSpec" from the standard mechanism.\n    {\n        PyObject *bootstrap_module = getImportLibBootstrapModule();\n        CHECK_OBJECT(bootstrap_module);\n\n        PyObject *_spec_from_module = PyObject_GetAttrString(bootstrap_module, "_spec_from_module");\n        CHECK_OBJECT(_spec_from_module);\n\n        PyObject *spec_value = CALL_FUNCTION_WITH_SINGLE_ARG(tstate, _spec_from_module, module_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ');\n        Py_DECREF(_spec_from_module);\n\n        // We can assume this to never fail, or else we are in trouble anyway.\n        // CHECK_OBJECT(spec_value);\n\n        if (spec_value == NULL) {\n            PyErr_PrintEx(0);\n            abort();\n        }\n\n        // Mark the execution in the "__spec__" value.\n        SET_ATTRIBUTE(tstate, spec_value, const_str_plain__initializing, Py_True);\n\n#if _NUITKA_MODULE_MODE && '
+    )
+    emit(str(values["is_top"]))
+    emit(" && ")
+    emit(values["module_def_size"])
+    emit(
+        ' >= 0\n        // Set our loader object in the "__spec__" value.\n        SET_ATTRIBUTE(tstate, spec_value, const_str_plain_loader, module_loader);\n#endif\n\n        UPDATE_STRING_DICT1(moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", (Nuitka_StringObject *)const_str_plain___spec__, spec_value);\n    }\n#endif\n#endif\n\n    // Temp variables if any\n"
+    )
+    emit(values["temps_decl"])
+    emit("\n\n    // Module init code if any\n")
+    emit(values["module_init_codes"])
+    emit("\n\n    // Module code.\n")
+    emit(values["module_codes"])
+    emit(
+        '\n\n    // Report to PGO about leaving the module without error.\n    PGO_onModuleExit("'
+    )
+    emit(values["module_identifier"])
+    emit('", false);\n\n#if _NUITKA_MODULE_MODE && ')
+    emit(str(values["is_top"]))
+    emit("\n    {\n        PyObject *post_load = IMPORT_EMBEDDED_MODULE(tstate, ")
+    emit(values["module_name_cstr"])
+    emit(
+        ' "-postLoad");\n        if (post_load == NULL) {\n            return NULL;\n        }\n    }\n#endif\n\n    Py_INCREF(module_'
+    )
+    emit(values["module_identifier"])
+    emit(");\n    return module_")
+    emit(values["module_identifier"])
+    emit(";\n")
+    emit(values["module_exit"])
+    emit("\n")
+
+
+def _emit_038_template_module_external_entry_point(emit, values):
+    emit(
+        '\n\n\n#if defined(__GNUC__)\n\n#if PYTHON_VERSION < 0x300\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyMODINIT_FUNC\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC __attribute__((visibility("default")))\n#endif\n\n#else\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyObject *\n#else\n\n#ifdef __cplusplus\n#define NUITKA_MODULE_INIT_FUNCTION extern "C" __attribute__((visibility("default"))) PyObject *\n#else\n#define NUITKA_MODULE_INIT_FUNCTION __attribute__((visibility("default"))) PyObject *\n#endif\n\n#endif\n#endif\n\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC\n#endif\n\nstatic PyObject *orig_dunder_file_value;\n\n#if PYTHON_VERSION >= 0x300\nstatic setattrofunc orig_PyModule_Type_tp_setattro;\n\n\nstatic int Nuitka_TopLevelModule_tp_setattro(PyObject *module, PyObject *name, PyObject *value) {\nPyModule_Type.tp_setattro = orig_PyModule_Type_tp_setattro;\n\nif (orig_dunder_file_value != NULL) {\nUPDATE_STRING_DICT0(\nmoduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___file__,\norig_dunder_file_value\n);\n}\n\n\n#if PYTHON_VERSION >= 0x300\nif (PyUnicode_Check(name) && PyUnicode_Compare(name, const_str_plain___spec__) == 0) {\nreturn 0;\n}\n#endif\n\nreturn orig_PyModule_Type_tp_setattro(module, name, value);\n}\n#endif\n\n#if PYTHON_VERSION >= 0x300\nstatic struct PyModuleDef mdef_"
+    )
+    emit(values["module_identifier"])
+    emit("= {\nPyModuleDef_HEAD_INIT,\nNULL,                \nNULL,                \n")
+    emit(values["module_def_size"])
+    emit(
+        ", \nNULL,                \nNULL,                \nNULL,                \nNULL,                \nNULL,                \n};\n#endif\n\n#if PYTHON_VERSION < 0x300\nstatic void onModuleFileValueRelease(void *v) {\nif (orig_dunder_file_value != NULL) {\nUPDATE_STRING_DICT0(\nmoduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___file__,\norig_dunder_file_value\n);\n}\n}\n#endif\n\n\n\n\n\n\nextern struct Nuitka_MetaPathBasedLoaderEntry const *getLoaderEntry(char const *name);\n\nstatic PyObject *"
+    )
+    emit(values["module_dll_entry_point"])
+    emit(
+        "_phase2(PyObject *module) {\nPyThreadState *tstate = PyThreadState_GET();\n\nPyObject *result = module_code_"
+    )
+    emit(values["module_identifier"])
+    emit("(tstate, module, getLoaderEntry(")
+    emit(values["module_name_cstr"])
+    emit(
+        "));\n\n#if PYTHON_VERSION < 0x300\n\n\n\n\nif (HAS_ERROR_OCCURRED(tstate) == false) {\norig_dunder_file_value = DICT_GET_ITEM_WITH_HASH_ERROR1(tstate, (PyObject *)moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", const_str_plain___file__);\n\nPyObject *fake_file_value = PyCObject_FromVoidPtr(NULL, onModuleFileValueRelease);\n\nUPDATE_STRING_DICT1(\nmoduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n(Nuitka_StringObject *)const_str_plain___file__,\nfake_file_value\n);\n}\n#else\nif (result != NULL) {\n\n\norig_PyModule_Type_tp_setattro = PyModule_Type.tp_setattro;\nPyModule_Type.tp_setattro = Nuitka_TopLevelModule_tp_setattro;\n\norig_dunder_file_value = DICT_GET_ITEM_WITH_HASH_ERROR1(tstate, (PyObject *)moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(", const_str_plain___file__);\n}\n#endif\n\nreturn result;\n}\n\n#if ")
+    emit(values["module_def_size"])
+    emit(">= 0\nstatic int ")
+    emit(values["module_dll_entry_point"])
+    emit("_slot(PyObject *module) {\nPyObject *result = ")
+    emit(values["module_dll_entry_point"])
+    emit(
+        "_phase2(module);\n\nif (unlikely(result == NULL)) {\nreturn 1;\n} else {\nreturn 0;\n}\n}\n#endif\n\nNUITKA_MODULE_INIT_FUNCTION ("
+    )
+    emit(values["module_dll_entry_point"])
+    emit(
+        ")(void) {\n#if PYTHON_VERSION < 0x3c0\nif (_Py_PackageContext != NULL) {\nif (strcmp(module_full_name, _Py_PackageContext) != 0) {\nmodule_full_name = strdup(_Py_PackageContext);\n}\n}\n#endif\n\n#if PYTHON_VERSION < 0x300\nPyObject *module = Py_InitModule4(\nmodule_full_name,        \nNULL,                    \n\nNULL,                    \n\n\nNULL,                    \nPYTHON_API_VERSION\n);\n#else\nmdef_"
+    )
+    emit(values["module_identifier"])
+    emit(".m_name = module_full_name;\n\n#if ")
+    emit(values["module_def_size"])
+    emit("== -1\nPyObject *module = PyModule_Create(&mdef_")
+    emit(values["module_identifier"])
+    emit(
+        ");\nCHECK_OBJECT(module);\n\n{\nNUITKA_MAY_BE_UNUSED bool res = Nuitka_SetModuleString(module_full_name, module);\nassert(res != false);\n}\n\n#endif\n#endif\n\n#if "
+    )
+    emit(values["module_def_size"])
+    emit(">= 0\nstatic PyModuleDef_Slot _module_slots[] = {\n{Py_mod_exec, (void *)")
+    emit(values["module_dll_entry_point"])
+    emit("_slot},\n{0, NULL}\n};\n\nmdef_")
+    emit(values["module_identifier"])
+    emit(".m_slots = _module_slots;\n\nreturn PyModuleDef_Init(&mdef_")
+    emit(values["module_identifier"])
+    emit(");\n#elif PYTHON_VERSION >= 0x300\nreturn ")
+    emit(values["module_dll_entry_point"])
+    emit("_phase2(module);\n#else\n")
+    emit(values["module_dll_entry_point"])
+    emit("_phase2(module);\n#endif\n}\n")
+
+
+def _emit_038_template_module_external_entry_point_readable(emit, values):
+    emit(
+        '\n\n/* Visibility definitions to make the DLL entry point exported */\n#if defined(__GNUC__)\n\n#if PYTHON_VERSION < 0x300\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyMODINIT_FUNC\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC __attribute__((visibility("default")))\n#endif\n\n#else\n\n#if defined(_WIN32)\n#define NUITKA_MODULE_INIT_FUNCTION __declspec(dllexport) PyObject *\n#else\n\n#ifdef __cplusplus\n#define NUITKA_MODULE_INIT_FUNCTION extern "C" __attribute__((visibility("default"))) PyObject *\n#else\n#define NUITKA_MODULE_INIT_FUNCTION __attribute__((visibility("default"))) PyObject *\n#endif\n\n#endif\n#endif\n\n#else\n#define NUITKA_MODULE_INIT_FUNCTION PyMODINIT_FUNC\n#endif\n\nstatic PyObject *orig_dunder_file_value;\n\n#if PYTHON_VERSION >= 0x300\nstatic setattrofunc orig_PyModule_Type_tp_setattro;\n\n/* This is used one time only. */\nstatic int Nuitka_TopLevelModule_tp_setattro(PyObject *module, PyObject *name, PyObject *value) {\n    PyModule_Type.tp_setattro = orig_PyModule_Type_tp_setattro;\n\n    if (orig_dunder_file_value != NULL) {\n        UPDATE_STRING_DICT0(\n            moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ',\n            (Nuitka_StringObject *)const_str_plain___file__,\n            orig_dunder_file_value\n        );\n    }\n\n    // Prevent "__spec__" update as well.\n#if PYTHON_VERSION >= 0x300\n    if (PyUnicode_Check(name) && PyUnicode_Compare(name, const_str_plain___spec__) == 0) {\n        return 0;\n    }\n#endif\n\n    return orig_PyModule_Type_tp_setattro(module, name, value);\n}\n#endif\n\n#if PYTHON_VERSION >= 0x300\nstatic struct PyModuleDef mdef_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        " = {\n    PyModuleDef_HEAD_INIT,\n    NULL,                /* m_name, filled later */\n    NULL,                /* m_doc */\n    "
+    )
+    emit(values["module_def_size"])
+    emit(
+        ", /* m_size */\n    NULL,                /* m_methods */\n    NULL,                /* m_slots */\n    NULL,                /* m_traverse */\n    NULL,                /* m_clear */\n    NULL,                /* m_free */\n};\n#endif\n\n#if PYTHON_VERSION < 0x300\nstatic void onModuleFileValueRelease(void *v) {\n    if (orig_dunder_file_value != NULL) {\n        UPDATE_STRING_DICT0(\n            moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ",\n            (Nuitka_StringObject *)const_str_plain___file__,\n            orig_dunder_file_value\n        );\n    }\n}\n#endif\n\n/* The exported interface to CPython. On import of the module, this function\n * gets called. It has to have an exact function name, in cases it's a shared\n * library export.\n */\n\nextern struct Nuitka_MetaPathBasedLoaderEntry const *getLoaderEntry(char const *name);\n\nstatic PyObject *"
+    )
+    emit(values["module_dll_entry_point"])
+    emit(
+        "_phase2(PyObject *module) {\n    PyThreadState *tstate = PyThreadState_GET();\n\n    PyObject *result = module_code_"
+    )
+    emit(values["module_identifier"])
+    emit("(tstate, module, getLoaderEntry(")
+    emit(values["module_name_cstr"])
+    emit(
+        '));\n\n#if PYTHON_VERSION < 0x300\n    // Our "__file__" value will not be respected by CPython and one\n    // way we can avoid it, is by having a capsule type, that when\n    // it gets released, we are called and repair the value.\n\n    if (HAS_ERROR_OCCURRED(tstate) == false) {\n        orig_dunder_file_value = DICT_GET_ITEM_WITH_HASH_ERROR1(tstate, (PyObject *)moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(
+        ", const_str_plain___file__);\n\n        PyObject *fake_file_value = PyCObject_FromVoidPtr(NULL, onModuleFileValueRelease);\n\n        UPDATE_STRING_DICT1(\n            moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        ',\n            (Nuitka_StringObject *)const_str_plain___file__,\n            fake_file_value\n        );\n    }\n#else\n    if (result != NULL) {\n        // Make sure we undo the change of the "__file__" attribute during importing. We do not\n        // know how to achieve it for Python2 though. TODO: Find something for Python2 too.\n        orig_PyModule_Type_tp_setattro = PyModule_Type.tp_setattro;\n        PyModule_Type.tp_setattro = Nuitka_TopLevelModule_tp_setattro;\n\n        orig_dunder_file_value = DICT_GET_ITEM_WITH_HASH_ERROR1(tstate, (PyObject *)moduledict_'
+    )
+    emit(values["module_identifier"])
+    emit(", const_str_plain___file__);\n    }\n#endif\n\n    return result;\n}\n\n#if ")
+    emit(values["module_def_size"])
+    emit(" >= 0\nstatic int ")
+    emit(values["module_dll_entry_point"])
+    emit("_slot(PyObject *module) {\n    PyObject *result = ")
+    emit(values["module_dll_entry_point"])
+    emit(
+        "_phase2(module);\n\n    if (unlikely(result == NULL)) {\n        return 1;\n    } else {\n        return 0;\n    }\n}\n#endif\n\nNUITKA_MODULE_INIT_FUNCTION ("
+    )
+    emit(values["module_dll_entry_point"])
+    emit(
+        ')(void) {\n#if PYTHON_VERSION < 0x3c0\n    if (_Py_PackageContext != NULL) {\n        if (strcmp(module_full_name, _Py_PackageContext) != 0) {\n            module_full_name = strdup(_Py_PackageContext);\n        }\n    }\n#endif\n\n#if PYTHON_VERSION < 0x300\n    PyObject *module = Py_InitModule4(\n        module_full_name,        // Module Name\n        NULL,                    // No methods initially, all are added\n                                 // dynamically in actual module code only.\n        NULL,                    // No "__doc__" is initially set, as it could\n                                 // not contain NUL this way, added early in\n                                 // actual code.\n        NULL,                    // No self for modules, we don\'t use it.\n        PYTHON_API_VERSION\n    );\n#else\n    mdef_'
+    )
+    emit(values["module_identifier"])
+    emit(".m_name = module_full_name;\n\n#if ")
+    emit(values["module_def_size"])
+    emit(" == -1\n    PyObject *module = PyModule_Create(&mdef_")
+    emit(values["module_identifier"])
+    emit(
+        ");\n    CHECK_OBJECT(module);\n\n    {\n        NUITKA_MAY_BE_UNUSED bool res = Nuitka_SetModuleString(module_full_name, module);\n        assert(res != false);\n    }\n\n#endif\n#endif\n\n#if "
+    )
+    emit(values["module_def_size"])
+    emit(
+        " >= 0\n    static PyModuleDef_Slot _module_slots[] = {\n        {Py_mod_exec, (void *)"
+    )
+    emit(values["module_dll_entry_point"])
+    emit("_slot},\n        {0, NULL}\n    };\n\n    mdef_")
+    emit(values["module_identifier"])
+    emit(".m_slots = _module_slots;\n\n    return PyModuleDef_Init(&mdef_")
+    emit(values["module_identifier"])
+    emit(");\n#elif PYTHON_VERSION >= 0x300\n    return ")
+    emit(values["module_dll_entry_point"])
+    emit("_phase2(module);\n#else\n    ")
+    emit(values["module_dll_entry_point"])
+    emit("_phase2(module);\n#endif\n}\n")
+
+
+def _emit_039_template_module_exception_exit(emit, values):
+    emit("module_exception_exit:\n\n#if _NUITKA_MODULE_MODE && ")
+    emit(str(values["is_top"]))
+    emit("\n{\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___name__);\n\nif (module_name != NULL) {\nNuitka_DelModule(tstate, module_name);\n}\n}\n#endif\nPGO_onModuleExit("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        '", false);\n\nRESTORE_ERROR_OCCURRED_STATE(tstate, &exception_state);\nreturn NULL;\n}'
+    )
+
+
+def _emit_039_template_module_exception_exit_readable(emit, values):
+    emit("    module_exception_exit:\n\n#if _NUITKA_MODULE_MODE && ")
+    emit(str(values["is_top"]))
+    emit("\n    {\n        PyObject *module_name = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(
+        ', (Nuitka_StringObject *)const_str_plain___name__);\n\n        if (module_name != NULL) {\n            Nuitka_DelModule(tstate, module_name);\n        }\n    }\n#endif\n    PGO_onModuleExit("'
+    )
+    emit(values["module_identifier"])
+    emit(
+        '", false);\n\n    RESTORE_ERROR_OCCURRED_STATE(tstate, &exception_state);\n    return NULL;\n}'
+    )
+
+
+def _emit_040_template_module_no_exception_exit(emit, values):
+    emit("}")
+
+
+def _emit_040_template_module_no_exception_exit_readable(emit, values):
+    emit("}")
+
+
+def _emit_041_template_helper_impl_decl(emit, values):
+    emit(
+        '\n\n\n#include "nuitka/prelude.h"\n\nextern PyObject *callPythonFunction(PyObject *func, PyObject *const *args, int count);\n\n'
+    )
+
+
+def _emit_041_template_helper_impl_decl_readable(emit, values):
+    emit(
+        '// This file contains helper functions that are automatically created from\n// templates.\n\n#include "nuitka/prelude.h"\n\nextern PyObject *callPythonFunction(PyObject *func, PyObject *const *args, int count);\n\n'
+    )
+
+
+def _emit_042_template_header_guard(emit, values):
+    emit("#ifndef ")
+    emit(values["header_guard_name"])
+    emit("\n#define ")
+    emit(values["header_guard_name"])
+    emit("\n\n")
+    emit(values["header_body"])
+    emit("\n#endif\n")
+
+
+def _emit_042_template_header_guard_readable(emit, values):
+    emit("#ifndef ")
+    emit(values["header_guard_name"])
+    emit("\n#define ")
+    emit(values["header_guard_name"])
+    emit("\n\n")
+    emit(values["header_body"])
+    emit("\n#endif\n")
+
+
+def _emit_043_template_write_local_unclear_ref0(emit, values):
+    emit("{\nPyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_043_template_write_local_unclear_ref0_readable(emit, values):
+    emit("{\n    PyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n    ")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_044_template_write_local_unclear_ref1(emit, values):
+    emit("{\nPyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";\nPy_INCREF(")
+    emit(values["identifier"])
+    emit(");\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_044_template_write_local_unclear_ref1_readable(emit, values):
+    emit("{\n    PyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n    ")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";\n    Py_INCREF(")
+    emit(values["identifier"])
+    emit(");\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_045_template_write_local_empty_ref0(emit, values):
+    emit("assert(")
+    emit(values["identifier"])
+    emit("== NULL);\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";")
+
+
+def _emit_045_template_write_local_empty_ref0_readable(emit, values):
+    emit("assert(")
+    emit(values["identifier"])
+    emit(" == NULL);\n")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";")
+
+
+def _emit_046_template_write_local_empty_ref1(emit, values):
+    emit("assert(")
+    emit(values["identifier"])
+    emit("== NULL);\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";")
+
+
+def _emit_046_template_write_local_empty_ref1_readable(emit, values):
+    emit("assert(")
+    emit(values["identifier"])
+    emit(" == NULL);\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";")
+
+
+def _emit_047_template_write_local_clear_ref0(emit, values):
+    emit("{\nPyObject *old = ")
+    emit(values["identifier"])
+    emit(";\nassert(old != NULL);\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";\nPy_DECREF(old);\n}\n")
+
+
+def _emit_047_template_write_local_clear_ref0_readable(emit, values):
+    emit("{\n    PyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n    assert(old != NULL);\n    ")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";\n    Py_DECREF(old);\n}\n")
+
+
+def _emit_048_template_write_local_inplace(emit, values):
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";\n")
+
+
+def _emit_048_template_write_local_inplace_readable(emit, values):
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";\n")
+
+
+def _emit_049_template_write_shared_inplace(emit, values):
+    emit("Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_049_template_write_shared_inplace_readable(emit, values):
+    emit("Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_050_template_write_local_clear_ref1(emit, values):
+    emit("{\nPyObject *old = ")
+    emit(values["identifier"])
+    emit(";\nassert(old != NULL);\n")
+    emit(values["identifier"])
+    emit("= ")
+    emit(values["tmp_name"])
+    emit(";\nPy_INCREF(")
+    emit(values["identifier"])
+    emit(");\nPy_DECREF(old);\n}\n")
+
+
+def _emit_050_template_write_local_clear_ref1_readable(emit, values):
+    emit("{\n    PyObject *old = ")
+    emit(values["identifier"])
+    emit(";\n    assert(old != NULL);\n    ")
+    emit(values["identifier"])
+    emit(" = ")
+    emit(values["tmp_name"])
+    emit(";\n    Py_INCREF(")
+    emit(values["identifier"])
+    emit(");\n    Py_DECREF(old);\n}\n")
+
+
+def _emit_051_template_write_shared_unclear_ref0(emit, values):
+    emit("{\nPyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_051_template_write_shared_unclear_ref0_readable(emit, values):
+    emit("{\n    PyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n    Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_052_template_write_shared_unclear_ref1(emit, values):
+    emit("{\nPyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_052_template_write_shared_unclear_ref1_readable(emit, values):
+    emit("{\n    PyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n    Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n    Py_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_053_template_write_shared_clear_ref0(emit, values):
+    emit("assert(Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(") == NULL);\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_053_template_write_shared_clear_ref0_readable(emit, values):
+    emit("assert(Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(") == NULL);\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_054_template_write_shared_clear_ref1(emit, values):
+    emit("assert(Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(") == NULL);\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_054_template_write_shared_clear_ref1_readable(emit, values):
+    emit("assert(Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(") == NULL);\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_055_template_del_local_tolerant(emit, values):
+    emit("Py_XDECREF(")
+    emit(values["identifier"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit("= NULL;\n")
+
+
+def _emit_055_template_del_local_tolerant_readable(emit, values):
+    emit("Py_XDECREF(")
+    emit(values["identifier"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit(" = NULL;\n")
+
+
+def _emit_056_template_del_shared_tolerant(emit, values):
+    emit("{\nPyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_056_template_del_shared_tolerant_readable(emit, values):
+    emit("{\n    PyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n    Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_057_template_del_local_intolerant(emit, values):
+    emit(values["result"])
+    emit("= ")
+    emit(values["identifier"])
+    emit("!= NULL;\nif (likely(")
+    emit(values["result"])
+    emit(")) {\nPy_DECREF(")
+    emit(values["identifier"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit("= NULL;\n}\n")
+
+
+def _emit_057_template_del_local_intolerant_readable(emit, values):
+    emit(values["result"])
+    emit(" = ")
+    emit(values["identifier"])
+    emit(" != NULL;\nif (likely(")
+    emit(values["result"])
+    emit(")) {\n    Py_DECREF(")
+    emit(values["identifier"])
+    emit(");\n    ")
+    emit(values["identifier"])
+    emit(" = NULL;\n}\n")
+
+
+def _emit_058_template_del_shared_intolerant(emit, values):
+    emit("{\nPyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\nPy_XDECREF(old);\n\n")
+    emit(values["result"])
+    emit("= old != NULL;\n}\n")
+
+
+def _emit_058_template_del_shared_intolerant_readable(emit, values):
+    emit("{\n    PyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n    Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\n    Py_XDECREF(old);\n\n    ")
+    emit(values["result"])
+    emit(" = old != NULL;\n}\n")
+
+
+def _emit_059_template_del_local_known(emit, values):
+    emit("CHECK_OBJECT(")
+    emit(values["identifier"])
+    emit(");\nPy_DECREF(")
+    emit(values["identifier"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit("= NULL;\n")
+
+
+def _emit_059_template_del_local_known_readable(emit, values):
+    emit("CHECK_OBJECT(")
+    emit(values["identifier"])
+    emit(");\nPy_DECREF(")
+    emit(values["identifier"])
+    emit(");\n")
+    emit(values["identifier"])
+    emit(" = NULL;\n")
+
+
+def _emit_060_template_del_shared_known(emit, values):
+    emit("{\nPyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\nNuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\n\nCHECK_OBJECT(old);\nPy_DECREF(old);\n}\n")
+
+
+def _emit_060_template_del_shared_known_readable(emit, values):
+    emit("{\n    PyObject *old = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n    Nuitka_Cell_SET(")
+    emit(values["identifier"])
+    emit(", NULL);\n\n    CHECK_OBJECT(old);\n    Py_DECREF(old);\n}\n")
+
+
+def _emit_061_template_release_object_unclear(emit, values):
+    emit("Py_XDECREF(")
+    emit(values["identifier"])
+    emit(");")
+
+
+def _emit_061_template_release_object_unclear_readable(emit, values):
+    emit("Py_XDECREF(")
+    emit(values["identifier"])
+    emit(");")
+
+
+def _emit_062_template_release_object_clear(emit, values):
+    emit("CHECK_OBJECT(")
+    emit(values["identifier"])
+    emit(");\nPy_DECREF(")
+    emit(values["identifier"])
+    emit(");")
+
+
+def _emit_062_template_release_object_clear_readable(emit, values):
+    emit("CHECK_OBJECT(")
+    emit(values["identifier"])
+    emit(");\nPy_DECREF(")
+    emit(values["identifier"])
+    emit(");")
+
+
+def _emit_063_template_read_shared_known(emit, values):
+    emit(values["tmp_name"])
+    emit("= Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n")
+
+
+def _emit_063_template_read_shared_known_readable(emit, values):
+    emit(values["tmp_name"])
+    emit(" = Nuitka_Cell_GET(")
+    emit(values["identifier"])
+    emit(");\n")
+
+
+def _emit_064_template_read_mvar_unclear(emit, values):
+    emit(values["tmp_name"])
+    emit("= LOOKUP_MODULE_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_064_template_read_mvar_unclear_readable(emit, values):
+    emit(values["tmp_name"])
+    emit(" = LOOKUP_MODULE_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_065_template_read_locals_dict_with_fallback(emit, values):
+    emit(values["to_name"])
+    emit("= ")
+    emit(values["dict_get_item"])
+    emit("(tstate, ")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit("== NULL) {\n")
+    emit(values["fallback"])
+    emit("\n}\n")
+
+
+def _emit_065_template_read_locals_dict_with_fallback_readable(emit, values):
+    emit(values["to_name"])
+    emit(" = ")
+    emit(values["dict_get_item"])
+    emit("(tstate, ")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit(" == NULL) {\n")
+    emit(values["fallback"])
+    emit("\n}\n")
+
+
+def _emit_066_template_read_locals_dict_without_fallback(emit, values):
+    emit(values["to_name"])
+    emit("= DICT_GET_ITEM0(tstate, ")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_066_template_read_locals_dict_without_fallback_readable(emit, values):
+    emit(values["to_name"])
+    emit(" = DICT_GET_ITEM0(tstate, ")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_067_template_read_locals_mapping_with_fallback_no_ref(emit, values):
+    emit(values["to_name"])
+    emit("= PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit("== NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(values["fallback"])
+    emit("\nPy_INCREF(")
+    emit(values["to_name"])
+    emit(");\n} else {\nFETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n}\n")
+
+
+def _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable(emit, values):
+    emit(values["to_name"])
+    emit(" = PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit(" == NULL) {\n    if (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(values["fallback"])
+    emit("\n        Py_INCREF(")
+    emit(values["to_name"])
+    emit(");\n    } else {\n        FETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n        goto ")
+    emit(values["exception_exit"])
+    emit(";\n    }\n}\n")
+
+
+def _emit_068_template_read_locals_mapping_with_fallback_ref(emit, values):
+    emit(values["to_name"])
+    emit("= PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit("== NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(values["fallback"])
+    emit("\n} else {\nFETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\ngoto ")
+    emit(values["exception_exit"])
+    emit(";\n}\n}\n")
+
+
+def _emit_068_template_read_locals_mapping_with_fallback_ref_readable(emit, values):
+    emit(values["to_name"])
+    emit(" = PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n\nif (")
+    emit(values["to_name"])
+    emit(" == NULL) {\n    if (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(values["fallback"])
+    emit("\n    } else {\n        FETCH_ERROR_OCCURRED_STATE(tstate, &")
+    emit(values["exception_state_name"])
+    emit(");\n        goto ")
+    emit(values["exception_exit"])
+    emit(";\n    }\n}\n")
+
+
+def _emit_069_template_read_locals_mapping_without_fallback(emit, values):
+    emit(values["to_name"])
+    emit("= PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_069_template_read_locals_mapping_without_fallback_readable(emit, values):
+    emit(values["to_name"])
+    emit(" = PyObject_GetItem(")
+    emit(values["locals_dict"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\n")
+
+
+def _emit_070_template_del_global_unclear(emit, values):
+    emit(values["result"])
+    emit("= DICT_REMOVE_ITEM((PyObject *)moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\nif (")
+    emit(values["result"])
+    emit("== false) CLEAR_ERROR_OCCURRED(tstate);\n")
+
+
+def _emit_070_template_del_global_unclear_readable(emit, values):
+    emit(values["result"])
+    emit(" = DICT_REMOVE_ITEM((PyObject *)moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(");\nif (")
+    emit(values["result"])
+    emit(" == false) CLEAR_ERROR_OCCURRED(tstate);\n")
+
+
+def _emit_071_template_del_global_known(emit, values):
+    emit("if (DICT_REMOVE_ITEM((PyObject *)moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(") == false) {\nCLEAR_ERROR_OCCURRED(tstate);\n}\n")
+
+
+def _emit_071_template_del_global_known_readable(emit, values):
+    emit("if (DICT_REMOVE_ITEM((PyObject *)moduledict_")
+    emit(values["module_identifier"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(") == false) {\n    CLEAR_ERROR_OCCURRED(tstate);\n}\n")
+
+
+def _emit_072_template_update_locals_dict_value(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\nPyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\nUPDATE_STRING_DICT0((PyDictObject *)")
+    emit(values["dict_name"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(", value);\n} else {\nif (DICT_REMOVE_ITEM(")
+    emit(values["dict_name"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(") == false) {\nCLEAR_ERROR_OCCURRED(tstate);\n}\n}\n")
+
+
+def _emit_072_template_update_locals_dict_value_readable(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\n    PyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\n    UPDATE_STRING_DICT0((PyDictObject *)")
+    emit(values["dict_name"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(", value);\n} else {\n    if (DICT_REMOVE_ITEM(")
+    emit(values["dict_name"])
+    emit(", ")
+    emit(values["var_name"])
+    emit(") == false) {\n        CLEAR_ERROR_OCCURRED(tstate);\n    }\n}\n")
+
+
+def _emit_073_template_set_locals_dict_value(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\nPyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\nint res = PyDict_SetItem(\n")
+    emit(values["dict_name"])
+    emit(",\n")
+    emit(values["var_name"])
+    emit(",\nvalue\n);\n\nassert(res == 0);\n}\n")
+
+
+def _emit_073_template_set_locals_dict_value_readable(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\n    PyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\n    int res = PyDict_SetItem(\n        ")
+    emit(values["dict_name"])
+    emit(",\n        ")
+    emit(values["var_name"])
+    emit(",\n        value\n    );\n\n    assert(res == 0);\n}\n")
+
+
+def _emit_074_template_update_locals_mapping_value(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\nPyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\nint res = PyObject_SetItem(\n")
+    emit(values["mapping_name"])
+    emit(",\n")
+    emit(values["var_name"])
+    emit(",\nvalue\n);\n\n")
+    emit(values["tmp_name"])
+    emit("= res == 0;\n} else {\nPyObject *test_value = PyObject_GetItem(\n")
+    emit(values["mapping_name"])
+    emit(",\n")
+    emit(values["var_name"])
+    emit(
+        "\n);\n\nif (test_value) {\nPy_DECREF(test_value);\n\nint res = PyObject_DelItem(\n"
+    )
+    emit(values["mapping_name"])
+    emit(",\n")
+    emit(values["var_name"])
+    emit("\n);\n\n")
+    emit(values["tmp_name"])
+    emit("= res == 0;\n} else {\nCLEAR_ERROR_OCCURRED(tstate);\n")
+    emit(values["tmp_name"])
+    emit("= true;\n}\n}\n")
+
+
+def _emit_074_template_update_locals_mapping_value_readable(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\n    PyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\n    int res = PyObject_SetItem(\n        ")
+    emit(values["mapping_name"])
+    emit(",\n        ")
+    emit(values["var_name"])
+    emit(",\n        value\n    );\n\n    ")
+    emit(values["tmp_name"])
+    emit(
+        " = res == 0;\n} else {\n    PyObject *test_value = PyObject_GetItem(\n        "
+    )
+    emit(values["mapping_name"])
+    emit(",\n        ")
+    emit(values["var_name"])
+    emit(
+        "\n    );\n\n    if (test_value) {\n        Py_DECREF(test_value);\n\n        int res = PyObject_DelItem(\n            "
+    )
+    emit(values["mapping_name"])
+    emit(",\n            ")
+    emit(values["var_name"])
+    emit("\n        );\n\n        ")
+    emit(values["tmp_name"])
+    emit(" = res == 0;\n    } else {\n        CLEAR_ERROR_OCCURRED(tstate);\n        ")
+    emit(values["tmp_name"])
+    emit(" = true;\n    }\n}\n")
+
+
+def _emit_075_template_set_locals_mapping_value(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\nPyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\n")
+    emit(values["tmp_name"])
+    emit("= SET_SUBSCRIPT(\ntstate,\n")
+    emit(values["mapping_name"])
+    emit(",\n")
+    emit(values["var_name"])
+    emit(",\nvalue\n);\n} else {\n")
+    emit(values["tmp_name"])
+    emit("= true;\n}\n")
+
+
+def _emit_075_template_set_locals_mapping_value_readable(emit, values):
+    emit("if (")
+    emit(values["test_code"])
+    emit(") {\n    PyObject *value;\n")
+    emit(values["access_code"])
+    emit("\n\n    ")
+    emit(values["tmp_name"])
+    emit(" = SET_SUBSCRIPT(\n        tstate,\n        ")
+    emit(values["mapping_name"])
+    emit(",\n        ")
+    emit(values["var_name"])
+    emit(",\n        value\n    );\n} else {\n    ")
+    emit(values["tmp_name"])
+    emit(" = true;\n}\n")
+
+
+def _emit_076_template_module_variable_accessor_function(emit, values):
+    emit("static PyObject *")
+    emit(values["accessor_function_name"])
+    emit("(PyThreadState *tstate) {\n#if ")
+    emit(values["caching"])
+    emit(
+        "\nPyObject *result;\n\n#if PYTHON_VERSION < 0x3b0\nstatic uint64_t dict_version = 0;\nstatic PyObject *cache_value = NULL;\n\nif (moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        "->ma_version_tag == dict_version) {\nCHECK_OBJECT_X(cache_value);\nresult = cache_value;\n} else {\ndict_version = moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit("->ma_version_tag;\n\nresult = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(
+        ");\ncache_value = result;\n}\n#else\nstatic uint32_t dict_keys_version = 0xFFFFFFFF;\nstatic Py_ssize_t cache_dk_index = 0;\n\nPyDictKeysObject *dk = moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        "->ma_keys;\nif (likely(DK_IS_UNICODE(dk))) {\n\n#if PYTHON_VERSION >= 0x3c0\nuint32_t current_dk_version = _Nuitka_PyDictKeys_GetVersionForCurrentState(tstate->interp, dk);\n#else\nuint32_t current_dk_version = _Nuitka_PyDictKeys_GetVersionForCurrentState(dk);\n#endif\n\nif (current_dk_version != dict_keys_version) {\ndict_keys_version = current_dk_version;\nPy_hash_t hash = Nuitka_Py_unicode_get_hash("
+    )
+    emit(values["var_name"])
+    emit(
+        ");\nassert(hash != -1);\n\ncache_dk_index = Nuitka_Py_unicodekeys_lookup_unicode(dk, "
+    )
+    emit(values["var_name"])
+    emit(
+        ", hash);\n}\n\nif (cache_dk_index >= 0) {\nassert(dk->dk_kind != DICT_KEYS_SPLIT);\n\nPyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(dk);\n\nresult = entries[cache_dk_index].me_value;\n\nif (unlikely(result == NULL)) {\nPy_hash_t hash = Nuitka_Py_unicode_get_hash("
+    )
+    emit(values["var_name"])
+    emit(
+        ");\nassert(hash != -1);\n\ncache_dk_index = Nuitka_Py_unicodekeys_lookup_unicode(dk, "
+    )
+    emit(values["var_name"])
+    emit(
+        ", hash);\n\nif (cache_dk_index >= 0) {\nresult = entries[cache_dk_index].me_value;\n}\n}\n} else {\nresult = NULL;\n}\n} else {\nresult = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(");\n}\n#endif\n\n#else\nPyObject *result = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(
+        ");\n#endif\n\nif (unlikely(result == NULL)) {\nresult = GET_STRING_DICT_VALUE(dict_builtin, (Nuitka_StringObject *)"
+    )
+    emit(values["var_name"])
+    emit(");\n}\n\nreturn result;\n}\n")
+
+
+def _emit_076_template_module_variable_accessor_function_readable(emit, values):
+    emit("static PyObject *")
+    emit(values["accessor_function_name"])
+    emit("(PyThreadState *tstate) {\n#if ")
+    emit(values["caching"])
+    emit(
+        "\n    PyObject *result;\n\n#if PYTHON_VERSION < 0x3b0\n    static uint64_t dict_version = 0;\n    static PyObject *cache_value = NULL;\n\n    if (moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        "->ma_version_tag == dict_version) {\n        CHECK_OBJECT_X(cache_value);\n        result = cache_value;\n    } else {\n        dict_version = moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit("->ma_version_tag;\n\n        result = GET_STRING_DICT_VALUE(moduledict_")
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(
+        ");\n        cache_value = result;\n    }\n#else\n    static uint32_t dict_keys_version = 0xFFFFFFFF;\n    static Py_ssize_t cache_dk_index = 0;\n\n    PyDictKeysObject *dk = moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(
+        "->ma_keys;\n    if (likely(DK_IS_UNICODE(dk))) {\n\n#if PYTHON_VERSION >= 0x3c0\n        uint32_t current_dk_version = _Nuitka_PyDictKeys_GetVersionForCurrentState(tstate->interp, dk);\n#else\n        uint32_t current_dk_version = _Nuitka_PyDictKeys_GetVersionForCurrentState(dk);\n#endif\n\n        if (current_dk_version != dict_keys_version) {\n            dict_keys_version = current_dk_version;\n            Py_hash_t hash = Nuitka_Py_unicode_get_hash("
+    )
+    emit(values["var_name"])
+    emit(
+        ");\n            assert(hash != -1);\n\n            cache_dk_index = Nuitka_Py_unicodekeys_lookup_unicode(dk, "
+    )
+    emit(values["var_name"])
+    emit(
+        ", hash);\n        }\n\n        if (cache_dk_index >= 0) {\n            assert(dk->dk_kind != DICT_KEYS_SPLIT);\n\n            PyDictUnicodeEntry *entries = DK_UNICODE_ENTRIES(dk);\n\n            result = entries[cache_dk_index].me_value;\n\n            if (unlikely(result == NULL)) {\n                Py_hash_t hash = Nuitka_Py_unicode_get_hash("
+    )
+    emit(values["var_name"])
+    emit(
+        ");\n                assert(hash != -1);\n\n                cache_dk_index = Nuitka_Py_unicodekeys_lookup_unicode(dk, "
+    )
+    emit(values["var_name"])
+    emit(
+        ", hash);\n\n                if (cache_dk_index >= 0) {\n                    result = entries[cache_dk_index].me_value;\n                }\n            }\n        } else {\n            result = NULL;\n        }\n    } else {\n        result = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(
+        ");\n    }\n#endif\n\n#else\n    PyObject *result = GET_STRING_DICT_VALUE(moduledict_"
+    )
+    emit(values["module_identifier"])
+    emit(", (Nuitka_StringObject *)")
+    emit(values["var_name"])
+    emit(
+        ");\n#endif\n\n    if (unlikely(result == NULL)) {\n        result = GET_STRING_DICT_VALUE(dict_builtin, (Nuitka_StringObject *)"
+    )
+    emit(values["var_name"])
+    emit(");\n    }\n\n    return result;\n}\n")
+
+
+def _emit_077_template_write_py_cell_inplace(emit, values):
+    emit("PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_077_template_write_py_cell_inplace_readable(emit, values):
+    emit("PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n")
+
+
+def _emit_078_template_write_py_cell_unclear_ref0(emit, values):
+    emit("{\nPyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\nPyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_078_template_write_py_cell_unclear_ref0_readable(emit, values):
+    emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\n    PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_079_template_write_py_cell_unclear_ref1(emit, values):
+    emit("{\nPyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\nPyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\nPy_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_079_template_write_py_cell_unclear_ref1_readable(emit, values):
+    emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\n    PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", ")
+    emit(values["tmp_name"])
+    emit(");\n    Py_INCREF(")
+    emit(values["tmp_name"])
+    emit(");\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_080_template_del_py_cell_tolerant(emit, values):
+    emit("{\nPyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\nPyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\nPy_XDECREF(old);\n}\n")
+
+
+def _emit_080_template_del_py_cell_tolerant_readable(emit, values):
+    emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\n    PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\n    Py_XDECREF(old);\n}\n")
+
+
+def _emit_081_template_del_py_cell_intolerant(emit, values):
+    emit("{\nPyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\nPyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\nPy_XDECREF(old);\n\n")
+    emit(values["result"])
+    emit("= old != NULL;\n}\n")
+
+
+def _emit_081_template_del_py_cell_intolerant_readable(emit, values):
+    emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\n    PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\n    Py_XDECREF(old);\n\n    ")
+    emit(values["result"])
+    emit(" = old != NULL;\n}\n")
+
+
+def _emit_082_template_del_py_cell_known(emit, values):
+    emit("{\nPyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\nPyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\n\nCHECK_OBJECT(old);\nPy_DECREF(old);\n}\n")
+
+
+def _emit_082_template_del_py_cell_known_readable(emit, values):
+    emit("{\n    PyObject *old = PyCell_GET((PyObject *)")
+    emit(values["identifier"])
+    emit(");\n    PyCell_SET((PyObject *)")
+    emit(values["identifier"])
+    emit(", NULL);\n\n    CHECK_OBJECT(old);\n    Py_DECREF(old);\n}\n")
+
+
+template_infos = {
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_exception_exit": (
+        "fdfee2c9f7bccad9a853084c86a456e406070ec5757624d1a4c997a6f4a64992",
+        ("exception_state_name", "function_cleanup"),
+        _emit_003_template_asyncgen_exception_exit,
+        _emit_003_template_asyncgen_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_no_exception_exit": (
+        "9ad77684635c02f14f189cffc115a6434f5dbce53b39573feca479db33741696",
+        ("function_cleanup",),
+        _emit_004_template_asyncgen_no_exception_exit,
+        _emit_004_template_asyncgen_no_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_object_body": (
+        "0ce04e63a80c615fff789a587fc892167450e0c4e95c3ea1a9bd04d400f32e4f",
+        (
+            "asyncgen_creation_args",
+            "asyncgen_exit",
+            "asyncgen_maker_identifier",
+            "asyncgen_module",
+            "asyncgen_name_obj",
+            "asyncgen_qualname_obj",
+            "closure_count",
+            "closure_name",
+            "code_identifier",
+            "function_body",
+            "function_dispatch",
+            "function_identifier",
+            "function_local_types",
+            "function_var_inits",
+            "has_heap_declaration",
+            "heap_declaration",
+        ),
+        _emit_001_template_asyncgen_object_body,
+        _emit_001_template_asyncgen_object_body_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_object_maker_template": (
+        "af9933f64c3277bc73d7422d7e7235a8f1d36b6dfdf2acb93db9cb20a939bebb",
+        ("asyncgen_creation_args", "asyncgen_maker_identifier"),
+        _emit_000_template_asyncgen_object_maker_template,
+        _emit_000_template_asyncgen_object_maker_template_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_return_exit": (
+        "0fc8594ba021dfbeaa4188a2a278130d668b9c4380b1d16ff16186f3204d121a",
+        (),
+        _emit_005_template_asyncgen_return_exit,
+        _emit_005_template_asyncgen_return_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_make_asyncgen": (
+        "4b09731eaa7056d9f36803f846959e6ce25beb4a7b7a339f8610c22387f56218",
+        ("args", "asyncgen_maker_identifier", "closure_copy", "to_name"),
+        _emit_002_template_make_asyncgen,
+        _emit_002_template_make_asyncgen_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesConstants.template_constants_reading": (
+        "7729d73fd61b541277e3d8f59c670ddd4aedf197c29abfe5a013a6495a93f9f4",
+        (
+            "global_constants_blob_symbol_name",
+            "global_constants_count",
+            "metadata_values",
+            "nuitka_version_level",
+            "nuitka_version_major",
+            "nuitka_version_micro",
+            "nuitka_version_minor",
+            "sys_base_exec_prefix",
+            "sys_base_prefix",
+            "sys_exec_prefix",
+            "sys_executable",
+            "sys_prefix",
+            "use_direct_constant_blobs",
+        ),
+        _emit_006_template_constants_reading,
+        _emit_006_template_constants_reading_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_exception_exit": (
+        "7664a919ec522a97beb762c44ef5fe22c93234801469b476a8d83860068fe7bd",
+        ("exception_state_name", "function_cleanup"),
+        _emit_010_template_coroutine_exception_exit,
+        _emit_010_template_coroutine_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_no_exception_exit": (
+        "9d03b9ebe9900efec98234b09b34f09c119c4b3b1e3cc8e5558b6bb243f52970",
+        ("function_cleanup",),
+        _emit_011_template_coroutine_no_exception_exit,
+        _emit_011_template_coroutine_no_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_object_body": (
+        "ee293a333a6815606344706122d3c7430750a49d17068ba0839790701347582a",
+        (
+            "closure_count",
+            "closure_name",
+            "code_identifier",
+            "coroutine_creation_args",
+            "coroutine_exit",
+            "coroutine_maker_identifier",
+            "coroutine_module",
+            "coroutine_name_obj",
+            "coroutine_qualname_obj",
+            "function_body",
+            "function_dispatch",
+            "function_identifier",
+            "function_local_types",
+            "function_var_inits",
+            "has_heap_declaration",
+            "heap_declaration",
+        ),
+        _emit_008_template_coroutine_object_body,
+        _emit_008_template_coroutine_object_body_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_object_maker": (
+        "d9e27395be5157a8e15227a2d458f9466a7f7bc8ded156a9331cf0be256fd2c5",
+        ("coroutine_creation_args", "coroutine_maker_identifier"),
+        _emit_007_template_coroutine_object_maker,
+        _emit_007_template_coroutine_object_maker_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_return_exit": (
+        "552fe90a12d730bf51d0d4b493946a15da05c4c251540c97f0acb17583089587",
+        ("return_value",),
+        _emit_012_template_coroutine_return_exit,
+        _emit_012_template_coroutine_return_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_make_coroutine": (
+        "9405f5447ee6ee02231e05f690b3ee8134c21c065085595ba553b5bd502edae1",
+        ("args", "closure_copy", "coroutine_maker_identifier", "to_name"),
+        _emit_009_template_make_coroutine,
+        _emit_009_template_make_coroutine_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_catch_exception": (
+        "5cd3c7520240314c1b45cd9b5ea038aac3fc725eab596a8edf360d871eff8a2d",
+        (
+            "condition",
+            "exception_exit",
+            "exception_state_name",
+            "line_number_code",
+            "release_temps",
+            "var_description_code",
+        ),
+        _emit_015_template_error_catch_exception,
+        _emit_015_template_error_catch_exception_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_catch_fetched_exception": (
+        "e91473cc9899908ac56d77a2c673496a82a700de12ebb2c3bd39fdbcfdc8fe51",
+        (
+            "condition",
+            "exception_exit",
+            "exception_state_name",
+            "line_number_code",
+            "release_temps",
+            "var_description_code",
+        ),
+        _emit_014_template_error_catch_fetched_exception,
+        _emit_014_template_error_catch_fetched_exception_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_format_name_error_exception": (
+        "d21d6d44207ff6637e0b9edbee7027ed766a7d1f3e44f9ffd54af1875f1bc07d",
+        (
+            "condition",
+            "exception_exit",
+            "exception_state_name",
+            "line_number_code",
+            "raise_name_error_helper",
+            "release_temps",
+            "var_description_code",
+            "variable_name",
+        ),
+        _emit_017_template_error_format_name_error_exception,
+        _emit_017_template_error_format_name_error_exception_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_format_string_exception": (
+        "303553f8e179c9ced0148190114ea69e79ebf98447ebc404f674660bb56ce770",
+        (
+            "condition",
+            "exception_exit",
+            "line_number_code",
+            "release_temps",
+            "set_exception",
+            "var_description_code",
+        ),
+        _emit_016_template_error_format_string_exception,
+        _emit_016_template_error_format_string_exception_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_publish_exception_to_handler": (
+        "03d8dbaab51f6f10b340bb432c93883c6b26742c68d8d681f6a330d5b94cff65",
+        (
+            "frame_identifier",
+            "keeper_exception_state_name",
+            "keeper_lineno",
+            "tb_making",
+        ),
+        _emit_013_template_publish_exception_to_handler,
+        _emit_013_template_publish_exception_to_handler_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFrames.template_frame_attach_locals": (
+        "69b906d206fc8eb6abbce373d76189f2b4c08b93359b8abc976aca51aabd8be0",
+        ("frame_identifier", "frame_variable_refs", "type_description"),
+        _emit_018_template_frame_attach_locals,
+        _emit_018_template_frame_attach_locals_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFrames.template_frame_guard_generator_return_handler": (
+        "423327429dc8ae7813f026afbe6bbe50877d81a49fd35e5fa40cfbda7e1c3c56",
+        ("context_identifier", "frame_return_exit", "return_exit"),
+        _emit_019_template_frame_guard_generator_return_handler,
+        _emit_019_template_frame_guard_generator_return_handler_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_body": (
+        "2d7cb5291aae792b27e74052c346322d2afc5264235acd0487e128235c19ff5b",
+        (
+            "function_body",
+            "function_exit",
+            "function_identifier",
+            "function_locals",
+            "parameter_objects_decl",
+        ),
+        _emit_024_template_function_body,
+        _emit_024_template_function_body_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_direct_declaration": (
+        "5fd5c08bee3a373a51d5e622b3f64fe6b2065ef75e0d37382a73eb3c944dac02",
+        ("direct_call_arg_spec", "file_scope", "function_identifier"),
+        _emit_021_template_function_direct_declaration,
+        _emit_021_template_function_direct_declaration_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_exception_exit": (
+        "79a829dcd03d3765d6d3119424156540102d4dd8edbc75d51bdb46839f972450",
+        ("exception_state_name", "function_cleanup"),
+        _emit_025_template_function_exception_exit,
+        _emit_025_template_function_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_make_declaration": (
+        "ebb127bc1a6bc70379b85971b4b8c5ac16ae8b34605a199cf15f075649475858",
+        ("function_creation_args", "function_identifier"),
+        _emit_020_template_function_make_declaration,
+        _emit_020_template_function_make_declaration_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_return_exit": (
+        "629e15e23d40f87a4fa746d0c00ce0ce6d5a774265bf8dd6ff68f9b8da328e03",
+        ("function_cleanup",),
+        _emit_026_template_function_return_exit,
+        _emit_026_template_function_return_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_make_function": (
+        "34110e3ef76b33413f79ac563ae66882d50fe418730fc4ba6eae28a900bd1dff",
+        ("args", "closure_copy", "function_maker_identifier", "to_name"),
+        _emit_023_template_make_function,
+        _emit_023_template_make_function_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_maker_function_body": (
+        "8803e28f801aceac25ab81dd23e2881909c43b7aa9ebabb79d396606df9c2c0b",
+        (
+            "annotations",
+            "closure_count",
+            "closure_name",
+            "code_identifier",
+            "constant_return_code",
+            "defaults",
+            "function_creation_args",
+            "function_doc",
+            "function_impl_identifier",
+            "function_maker_identifier",
+            "function_name_obj",
+            "function_qualname_obj",
+            "kw_defaults",
+            "module_identifier",
+            "type_params",
+        ),
+        _emit_022_template_maker_function_body,
+        _emit_022_template_maker_function_body_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_context_body_template": (
+        "9ec657d601dcab36c0062329c6e2a59683f3b4c162af0d2edfa6341915b1e323",
+        (
+            "closure_count",
+            "closure_name",
+            "code_identifier",
+            "function_body",
+            "function_dispatch",
+            "function_identifier",
+            "function_local_types",
+            "function_var_inits",
+            "generator_creation_args",
+            "generator_exit",
+            "generator_maker_identifier",
+            "generator_module",
+            "generator_name_obj",
+            "generator_qualname_obj",
+            "has_heap_declaration",
+            "heap_declaration",
+        ),
+        _emit_028_template_generator_context_body_template,
+        _emit_028_template_generator_context_body_template_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_context_maker_decl": (
+        "4841f0b6421846e27390df65257fe96abf7e40d49834810445261474ca913234",
+        ("generator_creation_args", "generator_maker_identifier"),
+        _emit_027_template_generator_context_maker_decl,
+        _emit_027_template_generator_context_maker_decl_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_exception_exit": (
+        "430ad39a236f3d3c0e4c34d54d8a77b3e62dd83968284b2adfe52cd12a2f9b91",
+        ("exception_state_name", "function_cleanup"),
+        _emit_031_template_generator_exception_exit,
+        _emit_031_template_generator_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_no_exception_exit": (
+        "87995cc27186872b078370fc4dfba2b182d6a19360233f080640b3061ce0c4ed",
+        ("function_cleanup",),
+        _emit_032_template_generator_no_exception_exit,
+        _emit_032_template_generator_no_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_return_exit": (
+        "f06ad373e40a6038b3e2569fc28ca1ab262ef37815156fd2e0c6fbe6f3589b60",
+        ("function_cleanup", "return_value"),
+        _emit_033_template_generator_return_exit,
+        _emit_033_template_generator_return_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_empty_generator": (
+        "b99cf335642cd23e7ce6dd8de5d28c547e4dce566169ba9a137990b9c53fc676",
+        (
+            "closure_copy",
+            "closure_count",
+            "closure_name",
+            "code_identifier",
+            "generator_module",
+            "generator_name_obj",
+            "generator_qualname_obj",
+            "to_name",
+        ),
+        _emit_030_template_make_empty_generator,
+        _emit_030_template_make_empty_generator_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_generator": (
+        "ef18f2f53fae77d87d02568d173349aab047ab21aeba825b26ab6473ff665c7e",
+        ("args", "closure_copy", "generator_maker_identifier", "to_name"),
+        _emit_029_template_make_generator,
+        _emit_029_template_make_generator_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesIterators.template_loop_break_next": (
+        "92add9ba69be2a694b88e75c06b386542d271d43c9a21dd11bd2f47516b8eb20",
+        (
+            "break_indicator_code",
+            "break_target",
+            "exception_state_name",
+            "exception_target",
+            "line_number_code",
+            "release_temps",
+            "to_name",
+            "var_description_code",
+        ),
+        _emit_034_template_loop_break_next,
+        _emit_034_template_loop_break_next_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesLoader.template_metapath_loader_body": (
+        "1f90f9fd9849405949fd86dc4397208da06b0b8f3239f4c751e05ffa6af3e7ce",
+        (
+            "bytecode_count",
+            "entry_count",
+            "frozen_modules",
+            "metapath_loader_inittab",
+            "metapath_module_decls",
+        ),
+        _emit_035_template_metapath_loader_body,
+        _emit_035_template_metapath_loader_body_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_global_copyright": (
+        "16bd6ceb6d060356654eb1bf718a9e1b04d44ad1a3ed96d41f30c0346de14001",
+        ("module_identifier", "version", "year"),
+        _emit_036_template_global_copyright,
+        _emit_036_template_global_copyright_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_header_guard": (
+        "1fffdd3b3c781d73b532acd2667d4c3701bf8da886bed3bc5be2a948e01f3008",
+        ("header_body", "header_guard_name"),
+        _emit_042_template_header_guard,
+        _emit_042_template_header_guard_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_helper_impl_decl": (
+        "b4dbfc627b20fb92231456a7edb1a3a689ede4ddcb1b01b879911ab239a2fd3a",
+        (),
+        _emit_041_template_helper_impl_decl,
+        _emit_041_template_helper_impl_decl_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_body_template": (
+        "929231ce442e0b271649c7b370813a1d7e7296b0aeb68d585e28fc4ae0943f9e",
+        (
+            "constants_count",
+            "dunder_main_package",
+            "is_dunder_main",
+            "is_package",
+            "is_top",
+            "module_code_objects_decl",
+            "module_code_objects_init",
+            "module_codes",
+            "module_const_blob_name",
+            "module_const_blob_symbol_name",
+            "module_constants_check_hash",
+            "module_constants_check_object",
+            "module_constants_decl",
+            "module_def_size",
+            "module_exit",
+            "module_function_table_entries",
+            "module_functions_code",
+            "module_functions_decl",
+            "module_identifier",
+            "module_includes",
+            "module_init_codes",
+            "module_name_cstr",
+            "module_variable_accessors",
+            "module_variable_accessors_count",
+            "temps_decl",
+            "use_direct_constant_blobs",
+        ),
+        _emit_037_template_module_body_template,
+        _emit_037_template_module_body_template_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_exception_exit": (
+        "7545624bdd6f885197f6c6962c271d2169176b2619f7cbab5175f2558524d452",
+        ("is_top", "module_identifier"),
+        _emit_039_template_module_exception_exit,
+        _emit_039_template_module_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_external_entry_point": (
+        "e6ccf0cd90836dcc9581272fc6769743f2d933010dcaa9c40fe2faed75d0c68e",
+        (
+            "module_def_size",
+            "module_dll_entry_point",
+            "module_identifier",
+            "module_name_cstr",
+        ),
+        _emit_038_template_module_external_entry_point,
+        _emit_038_template_module_external_entry_point_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_no_exception_exit": (
+        "d10b36aa74a59bcf4a88185837f658afaf3646eff2bb16c3928d0e9335e945d2",
+        (),
+        _emit_040_template_module_no_exception_exit,
+        _emit_040_template_module_no_exception_exit_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_known": (
+        "d52dabfbda2d73a75b60f8517c134170b673ebc5625dab0e4b117113f1aaa277",
+        ("module_identifier", "var_name"),
+        _emit_071_template_del_global_known,
+        _emit_071_template_del_global_known_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_unclear": (
+        "e19f5a72a151a717a270dc98327195283acfd7b8e7d64ceaf4f9b69202a0ac4d",
+        ("module_identifier", "result", "var_name"),
+        _emit_070_template_del_global_unclear,
+        _emit_070_template_del_global_unclear_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_intolerant": (
+        "fc2bcef2d97262102249aad6861201353e36b8cbd127c98a74d4532d99e040c6",
+        ("identifier", "result"),
+        _emit_057_template_del_local_intolerant,
+        _emit_057_template_del_local_intolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_known": (
+        "ae5576a4e417926a6b8eaa943c8c79acfa65a057eb58f9997b1481e891bda0b0",
+        ("identifier",),
+        _emit_059_template_del_local_known,
+        _emit_059_template_del_local_known_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_tolerant": (
+        "7c519e95013bbe50865ee8bdf7e1927a9b98f8d10e67604acd13b76b12462295",
+        ("identifier",),
+        _emit_055_template_del_local_tolerant,
+        _emit_055_template_del_local_tolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_intolerant": (
+        "26d8c64439200a202fd0963d8b602913897455bfec7faf97303e84d1a2172d68",
+        ("identifier", "result"),
+        _emit_081_template_del_py_cell_intolerant,
+        _emit_081_template_del_py_cell_intolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_known": (
+        "9b803de889dc98ab0a644cbe18256966ecd44342a12f8f76446175bf9ef5bc52",
+        ("identifier",),
+        _emit_082_template_del_py_cell_known,
+        _emit_082_template_del_py_cell_known_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_tolerant": (
+        "70b2303a20bfc14342ed69a42e0c0d204f02fe207056d5aa6bc6cc2375450eb9",
+        ("identifier",),
+        _emit_080_template_del_py_cell_tolerant,
+        _emit_080_template_del_py_cell_tolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_intolerant": (
+        "ddf1157ea0de7012d54093e6cffdee00f8dd5050b6d63162d17b66c166d3ae54",
+        ("identifier", "result"),
+        _emit_058_template_del_shared_intolerant,
+        _emit_058_template_del_shared_intolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_known": (
+        "417c1768ca66c155bd9c48d2ada3bf6aebdeedd6da4643b5620fdc39f5fce0f4",
+        ("identifier",),
+        _emit_060_template_del_shared_known,
+        _emit_060_template_del_shared_known_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_tolerant": (
+        "2e0d1aa2d273ac3be4aa858f4ad5d60ca15295a09fc0107cd151d16766143abf",
+        ("identifier",),
+        _emit_056_template_del_shared_tolerant,
+        _emit_056_template_del_shared_tolerant_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_module_variable_accessor_function": (
+        "e6d5affebd0b8808d0fd3537203650ed25009ab4f65d6b0bce4d95c25b982dd6",
+        ("accessor_function_name", "caching", "module_identifier", "var_name"),
+        _emit_076_template_module_variable_accessor_function,
+        _emit_076_template_module_variable_accessor_function_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_with_fallback": (
+        "26ee6849e18e5334d362a7e2411510fa02896be7b9fff97bfdc47b46f3d06f36",
+        ("dict_get_item", "fallback", "locals_dict", "to_name", "var_name"),
+        _emit_065_template_read_locals_dict_with_fallback,
+        _emit_065_template_read_locals_dict_with_fallback_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_without_fallback": (
+        "5f07e5195932f38611856adaddbc68ff3452e5ffa81a93a035aff354250c6842",
+        ("locals_dict", "to_name", "var_name"),
+        _emit_066_template_read_locals_dict_without_fallback,
+        _emit_066_template_read_locals_dict_without_fallback_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_no_ref": (
+        "4d673ff262ce29766823cbfef3c60f8e264e8d6210d36dfbf42631163a77f3be",
+        (
+            "exception_exit",
+            "exception_state_name",
+            "fallback",
+            "locals_dict",
+            "to_name",
+            "var_name",
+        ),
+        _emit_067_template_read_locals_mapping_with_fallback_no_ref,
+        _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_ref": (
+        "bea3d667173723884aeb8e387b9bd2882b365b49ef26d2507a0a4a3d13079ce1",
+        (
+            "exception_exit",
+            "exception_state_name",
+            "fallback",
+            "locals_dict",
+            "to_name",
+            "var_name",
+        ),
+        _emit_068_template_read_locals_mapping_with_fallback_ref,
+        _emit_068_template_read_locals_mapping_with_fallback_ref_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_without_fallback": (
+        "a1e8dceb6a326ffbf9e3492637406666a6cf25770e66df8db00e82b80c93a2ff",
+        ("locals_dict", "to_name", "var_name"),
+        _emit_069_template_read_locals_mapping_without_fallback,
+        _emit_069_template_read_locals_mapping_without_fallback_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_mvar_unclear": (
+        "edfa07c85fa85055bf44003e44de9dc22aab0bcad78ceec5c8282846d8a79c76",
+        ("module_identifier", "tmp_name", "var_name"),
+        _emit_064_template_read_mvar_unclear,
+        _emit_064_template_read_mvar_unclear_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_shared_known": (
+        "fd308f64b50e21c8f68921086401e41b3c0a4dd16d84644d2a05dd085547f69e",
+        ("identifier", "tmp_name"),
+        _emit_063_template_read_shared_known,
+        _emit_063_template_read_shared_known_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_clear": (
+        "6cc31fe6f8c8c5bc622389deb2a50a23baa6e33861249043997def820b8cc5ca",
+        ("identifier",),
+        _emit_062_template_release_object_clear,
+        _emit_062_template_release_object_clear_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_unclear": (
+        "4673b63d7274ed62ee911fab568304a54ba15172fac5807feb319f40980413ac",
+        ("identifier",),
+        _emit_061_template_release_object_unclear,
+        _emit_061_template_release_object_unclear_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_dict_value": (
+        "e12be7b1c99f8ce52bca406a677a0e2b4c3f91a34d0166674077b6c9009234e9",
+        ("access_code", "dict_name", "test_code", "var_name"),
+        _emit_073_template_set_locals_dict_value,
+        _emit_073_template_set_locals_dict_value_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_mapping_value": (
+        "65e3faa0b16044876f203e0e27b89c01d61bc2fffa0f34a1e331289db87abf4f",
+        ("access_code", "mapping_name", "test_code", "tmp_name", "var_name"),
+        _emit_075_template_set_locals_mapping_value,
+        _emit_075_template_set_locals_mapping_value_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_dict_value": (
+        "d138fbf7934aea407c19732e68a8d428f3be62e9f8d009a804a22829ca8bac6f",
+        ("access_code", "dict_name", "test_code", "var_name"),
+        _emit_072_template_update_locals_dict_value,
+        _emit_072_template_update_locals_dict_value_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_mapping_value": (
+        "2763851919448fde41dbd1a23d1a1f6d865d3219a3241c873c062c6cc11412c6",
+        ("access_code", "mapping_name", "test_code", "tmp_name", "var_name"),
+        _emit_074_template_update_locals_mapping_value,
+        _emit_074_template_update_locals_mapping_value_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref0": (
+        "a79a193ae3f6f03bb44483feb56bce2461277064436ecc4e62bba12d99d87a44",
+        ("identifier", "tmp_name"),
+        _emit_047_template_write_local_clear_ref0,
+        _emit_047_template_write_local_clear_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref1": (
+        "7187806a4d01c37782eb5b370cc23b688465b881a0cc5c86ae928978dbb9073a",
+        ("identifier", "tmp_name"),
+        _emit_050_template_write_local_clear_ref1,
+        _emit_050_template_write_local_clear_ref1_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref0": (
+        "0f28bb1b6eb41e78703952a33bb5bb3c49601bc22dd1ea52f8efd9c36a752360",
+        ("identifier", "tmp_name"),
+        _emit_045_template_write_local_empty_ref0,
+        _emit_045_template_write_local_empty_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref1": (
+        "6231a9e663b590213380cd3e0f8e9f56655c7d89f437ff4c9ce6f256d73b593e",
+        ("identifier", "tmp_name"),
+        _emit_046_template_write_local_empty_ref1,
+        _emit_046_template_write_local_empty_ref1_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_inplace": (
+        "6b24114fbcb93f554d4781e910348485bc78f481a014561090ada2455a5ec3fd",
+        ("identifier", "tmp_name"),
+        _emit_048_template_write_local_inplace,
+        _emit_048_template_write_local_inplace_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref0": (
+        "68600ea7a983e8b1aa261d952eac01d16b755a50fc9471a38420ee6b46f8e044",
+        ("identifier", "tmp_name"),
+        _emit_043_template_write_local_unclear_ref0,
+        _emit_043_template_write_local_unclear_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref1": (
+        "0f9acd29e95ee650e8a1fd1da3f93b7a203824f3fd4653f35187c8c926651eab",
+        ("identifier", "tmp_name"),
+        _emit_044_template_write_local_unclear_ref1,
+        _emit_044_template_write_local_unclear_ref1_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_inplace": (
+        "fc77fd03121d1e92e3fe96f671c15ac7b2ae79a48aca3c7ad54244cfe03b19a3",
+        ("identifier", "tmp_name"),
+        _emit_077_template_write_py_cell_inplace,
+        _emit_077_template_write_py_cell_inplace_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref0": (
+        "4c6ebda925fecb94e4ddb776400505503e564fe6826f0a7406553b25b00e9fa4",
+        ("identifier", "tmp_name"),
+        _emit_078_template_write_py_cell_unclear_ref0,
+        _emit_078_template_write_py_cell_unclear_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref1": (
+        "585df5b46aee34892618de24cd09ace82adc3896f5933ac50b774eea56f55b59",
+        ("identifier", "tmp_name"),
+        _emit_079_template_write_py_cell_unclear_ref1,
+        _emit_079_template_write_py_cell_unclear_ref1_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref0": (
+        "9ef33805b0a960ae8d02ed8ec5e301511cf817db9fac344f022d35500b084bfb",
+        ("identifier", "tmp_name"),
+        _emit_053_template_write_shared_clear_ref0,
+        _emit_053_template_write_shared_clear_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref1": (
+        "9e6b8b16a7e64f00f1e7a4af6351c029804798364c40cf4832e5db20bf6de789",
+        ("identifier", "tmp_name"),
+        _emit_054_template_write_shared_clear_ref1,
+        _emit_054_template_write_shared_clear_ref1_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_inplace": (
+        "e8d516dfe1e92289de7d98e57e5ca7276fedb034c40fc670225c3af9c2850215",
+        ("identifier", "tmp_name"),
+        _emit_049_template_write_shared_inplace,
+        _emit_049_template_write_shared_inplace_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref0": (
+        "fdc9447573fc677fc96af34112a885dda897ee604699ff2e7d86f9c195f25002",
+        ("identifier", "tmp_name"),
+        _emit_051_template_write_shared_unclear_ref0,
+        _emit_051_template_write_shared_unclear_ref0_readable,
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref1": (
+        "4b91c4cfef66190226abf7510f5c24ae23b23c9bbf410048b91e9632c3494349",
+        ("identifier", "tmp_name"),
+        _emit_052_template_write_shared_unclear_ref1,
+        _emit_052_template_write_shared_unclear_ref1_readable,
+    ),
+}
+
+template_variables = {
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_exception_exit": (
+        ("function_cleanup", "s"),
+        ("exception_state_name", "s"),
+        ("exception_state_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_no_exception_exit": (
+        ("function_cleanup", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_object_body": (
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+        ("function_local_types", "s"),
+        ("function_identifier", "s"),
+        ("has_heap_declaration", "s"),
+        ("heap_declaration", "s"),
+        ("function_dispatch", "s"),
+        ("function_var_inits", "s"),
+        ("function_body", "s"),
+        ("asyncgen_exit", "s"),
+        ("asyncgen_maker_identifier", "s"),
+        ("asyncgen_creation_args", "s"),
+        ("function_identifier", "s"),
+        ("asyncgen_module", "s"),
+        ("asyncgen_name_obj", "s"),
+        ("asyncgen_qualname_obj", "s"),
+        ("code_identifier", "s"),
+        ("closure_name", "s"),
+        ("closure_count", "d"),
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_object_maker_template": (
+        ("asyncgen_maker_identifier", "s"),
+        ("asyncgen_creation_args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_asyncgen_return_exit": (),
+    "nuitka.code_generation.templates.CodeTemplatesAsyncgens.template_make_asyncgen": (
+        ("closure_copy", "s"),
+        ("to_name", "s"),
+        ("asyncgen_maker_identifier", "s"),
+        ("args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesConstants.template_constants_reading": (
+        ("global_constants_count", "d"),
+        ("global_constants_blob_symbol_name", "s"),
+        ("global_constants_blob_symbol_name", "s"),
+        ("use_direct_constant_blobs", "d"),
+        ("global_constants_blob_symbol_name", "s"),
+        ("sys_executable", "s"),
+        ("sys_executable", "s"),
+        ("sys_prefix", "s"),
+        ("sys_exec_prefix", "s"),
+        ("sys_base_prefix", "s"),
+        ("sys_base_exec_prefix", "s"),
+        ("nuitka_version_major", "s"),
+        ("nuitka_version_minor", "s"),
+        ("nuitka_version_micro", "s"),
+        ("nuitka_version_level", "s"),
+        ("metadata_values", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_exception_exit": (
+        ("function_cleanup", "s"),
+        ("exception_state_name", "s"),
+        ("exception_state_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_no_exception_exit": (
+        ("function_cleanup", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_object_body": (
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+        ("function_local_types", "s"),
+        ("function_identifier", "s"),
+        ("has_heap_declaration", "s"),
+        ("heap_declaration", "s"),
+        ("function_dispatch", "s"),
+        ("function_var_inits", "s"),
+        ("function_body", "s"),
+        ("coroutine_exit", "s"),
+        ("coroutine_maker_identifier", "s"),
+        ("coroutine_creation_args", "s"),
+        ("function_identifier", "s"),
+        ("coroutine_module", "s"),
+        ("coroutine_name_obj", "s"),
+        ("coroutine_qualname_obj", "s"),
+        ("code_identifier", "s"),
+        ("closure_name", "s"),
+        ("closure_count", "d"),
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_object_maker": (
+        ("coroutine_maker_identifier", "s"),
+        ("coroutine_creation_args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_coroutine_return_exit": (
+        ("return_value", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesCoroutines.template_make_coroutine": (
+        ("closure_copy", "s"),
+        ("to_name", "s"),
+        ("coroutine_maker_identifier", "s"),
+        ("args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_catch_exception": (
+        ("condition", "s"),
+        ("exception_state_name", "s"),
+        ("release_temps", "s"),
+        ("line_number_code", "s"),
+        ("var_description_code", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_catch_fetched_exception": (
+        ("condition", "s"),
+        ("exception_state_name", "s"),
+        ("release_temps", "s"),
+        ("line_number_code", "s"),
+        ("var_description_code", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_format_name_error_exception": (
+        ("condition", "s"),
+        ("release_temps", "s"),
+        ("raise_name_error_helper", "s"),
+        ("exception_state_name", "s"),
+        ("variable_name", "s"),
+        ("line_number_code", "s"),
+        ("var_description_code", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_error_format_string_exception": (
+        ("condition", "s"),
+        ("release_temps", "s"),
+        ("set_exception", "s"),
+        ("line_number_code", "s"),
+        ("var_description_code", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesExceptions.template_publish_exception_to_handler": (
+        ("keeper_exception_state_name", "s"),
+        ("tb_making", "s"),
+        ("keeper_exception_state_name", "s"),
+        ("keeper_lineno", "s"),
+        ("frame_identifier", "s"),
+        ("keeper_lineno", "s"),
+        ("keeper_exception_state_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFrames.template_frame_attach_locals": (
+        ("frame_identifier", "s"),
+        ("type_description", "s"),
+        ("frame_variable_refs", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFrames.template_frame_guard_generator_return_handler": (
+        ("frame_return_exit", "s"),
+        ("context_identifier", "s"),
+        ("context_identifier", "s"),
+        ("context_identifier", "s"),
+        ("return_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_body": (
+        ("function_identifier", "s"),
+        ("parameter_objects_decl", "s"),
+        ("function_locals", "s"),
+        ("function_body", "s"),
+        ("function_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_direct_declaration": (
+        ("file_scope", "s"),
+        ("function_identifier", "s"),
+        ("direct_call_arg_spec", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_exception_exit": (
+        ("function_cleanup", "s"),
+        ("exception_state_name", "s"),
+        ("exception_state_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_make_declaration": (
+        ("function_identifier", "s"),
+        ("function_creation_args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_function_return_exit": (
+        ("function_cleanup", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_make_function": (
+        ("closure_copy", "s"),
+        ("to_name", "s"),
+        ("function_maker_identifier", "s"),
+        ("args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesFunction.template_maker_function_body": (
+        ("function_maker_identifier", "s"),
+        ("function_creation_args", "s"),
+        ("function_impl_identifier", "s"),
+        ("function_name_obj", "s"),
+        ("function_qualname_obj", "s"),
+        ("code_identifier", "s"),
+        ("defaults", "s"),
+        ("kw_defaults", "s"),
+        ("annotations", "s"),
+        ("module_identifier", "s"),
+        ("function_doc", "s"),
+        ("closure_name", "s"),
+        ("closure_count", "d"),
+        ("type_params", "s"),
+        ("constant_return_code", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_context_body_template": (
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+        ("function_local_types", "s"),
+        ("function_identifier", "s"),
+        ("has_heap_declaration", "s"),
+        ("heap_declaration", "s"),
+        ("function_dispatch", "s"),
+        ("function_var_inits", "s"),
+        ("function_body", "s"),
+        ("generator_exit", "s"),
+        ("generator_maker_identifier", "s"),
+        ("generator_creation_args", "s"),
+        ("function_identifier", "s"),
+        ("generator_module", "s"),
+        ("generator_name_obj", "s"),
+        ("generator_qualname_obj", "s"),
+        ("code_identifier", "s"),
+        ("closure_name", "s"),
+        ("closure_count", "d"),
+        ("has_heap_declaration", "s"),
+        ("function_identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_context_maker_decl": (
+        ("generator_maker_identifier", "s"),
+        ("generator_creation_args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_exception_exit": (
+        ("function_cleanup", "s"),
+        ("function_cleanup", "s"),
+        ("exception_state_name", "s"),
+        ("exception_state_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_no_exception_exit": (
+        ("function_cleanup", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_generator_return_exit": (
+        ("return_value", "s"),
+        ("function_cleanup", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_empty_generator": (
+        ("closure_copy", "s"),
+        ("to_name", "s"),
+        ("generator_module", "s"),
+        ("generator_name_obj", "s"),
+        ("generator_qualname_obj", "s"),
+        ("code_identifier", "s"),
+        ("closure_name", "s"),
+        ("closure_count", "d"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesGeneratorFunction.template_make_generator": (
+        ("closure_copy", "s"),
+        ("to_name", "s"),
+        ("generator_maker_identifier", "s"),
+        ("args", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesIterators.template_loop_break_next": (
+        ("to_name", "s"),
+        ("break_indicator_code", "s"),
+        ("break_target", "s"),
+        ("release_temps", "s"),
+        ("exception_state_name", "s"),
+        ("var_description_code", "s"),
+        ("line_number_code", "s"),
+        ("exception_target", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesLoader.template_metapath_loader_body": (
+        ("bytecode_count", "d"),
+        ("bytecode_count", "d"),
+        ("metapath_module_decls", "s"),
+        ("entry_count", "d"),
+        ("metapath_loader_inittab", "s"),
+        ("entry_count", "d"),
+        ("frozen_modules", "s"),
+        ("entry_count", "d"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_global_copyright": (
+        ("module_identifier", "s"),
+        ("version", "s"),
+        ("year", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_header_guard": (
+        ("header_guard_name", "s"),
+        ("header_guard_name", "s"),
+        ("header_body", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_helper_impl_decl": (),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_body_template": (
+        ("module_includes", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_constants_decl", "s"),
+        ("constants_count", "d"),
+        ("module_const_blob_symbol_name", "s"),
+        ("module_const_blob_symbol_name", "s"),
+        ("use_direct_constant_blobs", "d"),
+        ("module_const_blob_symbol_name", "s"),
+        ("module_const_blob_name", "s"),
+        ("module_constants_check_hash", "s"),
+        ("is_dunder_main", "s"),
+        ("module_identifier", "s"),
+        ("module_constants_check_object", "s"),
+        ("module_variable_accessors_count", "d"),
+        ("module_variable_accessors", "s"),
+        ("module_code_objects_decl", "s"),
+        ("module_code_objects_init", "s"),
+        ("module_functions_decl", "s"),
+        ("module_functions_code", "s"),
+        ("module_identifier", "s"),
+        ("module_function_table_entries", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_top", "d"),
+        ("module_name_cstr", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_top", "d"),
+        ("module_identifier", "s"),
+        ("module_def_size", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_top", "d"),
+        ("module_name_cstr", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_package", "s"),
+        ("module_identifier", "s"),
+        ("is_dunder_main", "s"),
+        ("module_identifier", "s"),
+        ("dunder_main_package", "s"),
+        ("is_package", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_dunder_main", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_dunder_main", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("is_top", "d"),
+        ("module_def_size", "s"),
+        ("module_identifier", "s"),
+        ("temps_decl", "s"),
+        ("module_init_codes", "s"),
+        ("module_codes", "s"),
+        ("module_identifier", "s"),
+        ("is_top", "d"),
+        ("module_name_cstr", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_exception_exit": (
+        ("is_top", "d"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_external_entry_point": (
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_def_size", "s"),
+        ("module_identifier", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_identifier", "s"),
+        ("module_name_cstr", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_def_size", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_identifier", "s"),
+        ("module_def_size", "s"),
+        ("module_identifier", "s"),
+        ("module_def_size", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_dll_entry_point", "s"),
+        ("module_dll_entry_point", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesModules.template_module_no_exception_exit": (),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_known": (
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_global_unclear": (
+        ("result", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+        ("result", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_intolerant": (
+        ("result", "s"),
+        ("identifier", "s"),
+        ("result", "s"),
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_known": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_local_tolerant": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_intolerant": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("result", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_known": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_py_cell_tolerant": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_intolerant": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("result", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_known": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_del_shared_tolerant": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_module_variable_accessor_function": (
+        ("accessor_function_name", "s"),
+        ("caching", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+        ("var_name", "s"),
+        ("var_name", "s"),
+        ("var_name", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_with_fallback": (
+        ("to_name", "s"),
+        ("dict_get_item", "s"),
+        ("locals_dict", "s"),
+        ("var_name", "s"),
+        ("to_name", "s"),
+        ("fallback", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_dict_without_fallback": (
+        ("to_name", "s"),
+        ("locals_dict", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_no_ref": (
+        ("to_name", "s"),
+        ("locals_dict", "s"),
+        ("var_name", "s"),
+        ("to_name", "s"),
+        ("fallback", "s"),
+        ("to_name", "s"),
+        ("exception_state_name", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_with_fallback_ref": (
+        ("to_name", "s"),
+        ("locals_dict", "s"),
+        ("var_name", "s"),
+        ("to_name", "s"),
+        ("fallback", "s"),
+        ("exception_state_name", "s"),
+        ("exception_exit", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_locals_mapping_without_fallback": (
+        ("to_name", "s"),
+        ("locals_dict", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_mvar_unclear": (
+        ("tmp_name", "s"),
+        ("module_identifier", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_read_shared_known": (
+        ("tmp_name", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_clear": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_release_object_unclear": (
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_dict_value": (
+        ("test_code", "s"),
+        ("access_code", "s"),
+        ("dict_name", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_set_locals_mapping_value": (
+        ("test_code", "s"),
+        ("access_code", "s"),
+        ("tmp_name", "s"),
+        ("mapping_name", "s"),
+        ("var_name", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_dict_value": (
+        ("test_code", "s"),
+        ("access_code", "s"),
+        ("dict_name", "s"),
+        ("var_name", "s"),
+        ("dict_name", "s"),
+        ("var_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_update_locals_mapping_value": (
+        ("test_code", "s"),
+        ("access_code", "s"),
+        ("mapping_name", "s"),
+        ("var_name", "s"),
+        ("tmp_name", "s"),
+        ("mapping_name", "s"),
+        ("var_name", "s"),
+        ("mapping_name", "s"),
+        ("var_name", "s"),
+        ("tmp_name", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_clear_ref1": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_empty_ref1": (
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_inplace": (
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_local_unclear_ref1": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("identifier", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_inplace": (
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_py_cell_unclear_ref1": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_clear_ref1": (
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_inplace": (
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref0": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+    ),
+    "nuitka.code_generation.templates.CodeTemplatesVariables.template_write_shared_unclear_ref1": (
+        ("identifier", "s"),
+        ("identifier", "s"),
+        ("tmp_name", "s"),
+        ("tmp_name", "s"),
+    ),
+}
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the GNU Affero General Public License, Version 3 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        https://www.gnu.org/licenses/agpl-3.0.txt
+#
+#     See also: "Nuitka Runtime Library Exception, Version 1.0" in file
+#     "LICENSE-RUNTIME.txt" for additional permissions granted under Section 7.
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/code_generation/templates/CodeTemplatesGenerated.py
+++ b/nuitka/code_generation/templates/CodeTemplatesGenerated.py
@@ -150,7 +150,7 @@ def _emit_002_template_make_asyncgen(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
-    emit("= ")
+    emit(" = ")
     emit(values["asyncgen_maker_identifier"])
     emit("(")
     emit(values["args"])
@@ -452,7 +452,7 @@ def _emit_009_template_make_coroutine(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
-    emit("= ")
+    emit(" = ")
     emit(values["coroutine_maker_identifier"])
     emit("(")
     emit(values["args"])
@@ -527,7 +527,7 @@ def _emit_013_template_publish_exception_to_handler(emit, values):
     emit(values["keeper_exception_state_name"])
     emit(", exception_tb);\n} else if (")
     emit(values["keeper_lineno"])
-    emit("!= 0) {\nexception_tb = ADD_TRACEBACK(exception_tb, ")
+    emit(" != 0) {\nexception_tb = ADD_TRACEBACK(exception_tb, ")
     emit(values["frame_identifier"])
     emit(", ")
     emit(values["keeper_lineno"])
@@ -760,7 +760,7 @@ def _emit_020_template_function_make_declaration_readable(emit, values):
 
 def _emit_021_template_function_direct_declaration(emit, values):
     emit(values["file_scope"])
-    emit("PyObject *impl_")
+    emit(" PyObject *impl_")
     emit(values["function_identifier"])
     emit("(PyThreadState *tstate, ")
     emit(values["direct_call_arg_spec"])
@@ -850,7 +850,7 @@ def _emit_023_template_make_function(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
-    emit("= ")
+    emit(" = ")
     emit(values["function_maker_identifier"])
     emit("(")
     emit(values["args"])
@@ -1052,7 +1052,7 @@ def _emit_029_template_make_generator(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
-    emit("= ")
+    emit(" = ")
     emit(values["generator_maker_identifier"])
     emit("(")
     emit(values["args"])
@@ -1074,7 +1074,7 @@ def _emit_030_template_make_empty_generator(emit, values):
     emit(values["closure_copy"])
     emit("\n")
     emit(values["to_name"])
-    emit("= Nuitka_Generator_NewEmpty(\n")
+    emit(" = Nuitka_Generator_NewEmpty(\n")
     emit(values["generator_module"])
     emit(",\n")
     emit(values["generator_name_obj"])
@@ -1165,7 +1165,7 @@ def _emit_033_template_generator_return_exit_readable(emit, values):
 def _emit_034_template_loop_break_next(emit, values):
     emit("if (")
     emit(values["to_name"])
-    emit("== NULL) {\nif (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
+    emit(" == NULL) {\nif (CHECK_AND_CLEAR_STOP_ITERATION_OCCURRED(tstate)) {\n")
     emit(values["break_indicator_code"])
     emit("\ngoto ")
     emit(values["break_target"])
@@ -1207,7 +1207,7 @@ def _emit_035_template_metapath_loader_body(emit, values):
         '\n\n\n#include "nuitka/prelude.h"\n\n\n#if PY_MICRO_VERSION < 16\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + PY_MICRO_VERSION)\n#else\n#define PYTHON_VERSION (PY_MAJOR_VERSION * 256 + PY_MINOR_VERSION * 16 + 15)\n#endif\n\n#include "nuitka/constants_blob.h"\n\n#include "nuitka/tracing.h"\n#include "nuitka/unfreezing.h"\n\n\n#ifndef __cplusplus\n#include <stdbool.h>\n#endif\n\n#if '
     )
     emit(str(values["bytecode_count"]))
-    emit("> 0\nstatic unsigned char *bytecode_data[")
+    emit(" > 0\nstatic unsigned char *bytecode_data[")
     emit(str(values["bytecode_count"]))
     emit(
         "];\n#else\nstatic unsigned char **bytecode_data = NULL;\n#endif\n\n\n#ifdef __cplusplus\n#define NUITKA_CAST_INIT_REASON(x) reinterpret_cast<module_init_func>((void*)(x))\n#else\n#define NUITKA_CAST_INIT_REASON(x) (module_init_func)(x)\n#endif\n\n\n\n\n\n"
@@ -1273,7 +1273,7 @@ def _emit_036_template_global_copyright(emit, values):
     emit("\n*\n* This code is in part copyright ")
     emit(values["year"])
     emit(
-        'Kay Hayen.\n*\n* Licensed under the GNU Affero General Public License, Version 3 (the "License");\n* you may not use this file except in compliance with the License.\n*\n* You may obtain a copy of the License in "LICENSE.txt" and the runtime\n* exception granted in "LICENSE-RUNTIME.txt" from Nuitka source code. For\n* deploying the generated code it is intended to not restrict distributing\n* created binaries.\n*\n* Unless required by applicable law or agreed to in writing, software\n* distributed under the License is distributed on an "AS IS" BASIS,\n* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n* See the License for the specific language governing permissions and\n* limitations under the License.\n*/\n'
+        ' Kay Hayen.\n*\n* Licensed under the GNU Affero General Public License, Version 3 (the "License");\n* you may not use this file except in compliance with the License.\n*\n* You may obtain a copy of the License in "LICENSE.txt" and the runtime\n* exception granted in "LICENSE-RUNTIME.txt" from Nuitka source code. For\n* deploying the generated code it is intended to not restrict distributing\n* created binaries.\n*\n* Unless required by applicable law or agreed to in writing, software\n* distributed under the License is distributed on an "AS IS" BASIS,\n* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n* See the License for the specific language governing permissions and\n* limitations under the License.\n*/\n'
     )
 
 
@@ -1380,9 +1380,9 @@ def _emit_037_template_module_body_template(emit, values):
     emit(values["module_identifier"])
     emit('");\n\n// Store the module for future use.\nmodule_')
     emit(values["module_identifier"])
-    emit("= module;\n\nmoduledict_")
+    emit(" = module;\n\nmoduledict_")
     emit(values["module_identifier"])
-    emit("= MODULE_DICT(module_")
+    emit(" = MODULE_DICT(module_")
     emit(values["module_identifier"])
     emit(
         ");\n\n\nstatic bool init_done = false;\n\nif (init_done == false) {\n#if _NUITKA_MODULE_MODE && "
@@ -1396,7 +1396,7 @@ def _emit_037_template_module_body_template(emit, values):
         ': Calling setupMetaPathBasedLoader().\\n");\n#endif\nsetupMetaPathBasedLoader(tstate);\n#if '
     )
     emit(values["module_def_size"])
-    emit('>= 0\n#ifdef _NUITKA_TRACE\nPRINT_STRING("')
+    emit(' >= 0\n#ifdef _NUITKA_TRACE\nPRINT_STRING("')
     emit(values["module_identifier"])
     emit(
         ': Calling updateMetaPathBasedLoaderModuleRoot().\\n");\n#endif\nupdateMetaPathBasedLoaderModuleRoot(module_full_name);\n#endif\n\n\n#if PYTHON_VERSION >= 0x300\npatchInspectModule(tstate);\n#endif\n\n#endif\n\n/* The constants only used by this module are created now. */\nNUITKA_PRINT_TRACE("'
@@ -1408,7 +1408,7 @@ def _emit_037_template_module_body_template(emit, values):
     emit(str(values["is_top"]))
     emit("\nPyObject *pre_load = IMPORT_EMBEDDED_MODULE(tstate, ")
     emit(values["module_name_cstr"])
-    emit('"-preLoad");\nif (pre_load == NULL) {\nreturn NULL;\n}\n#endif\n\n')
+    emit(' "-preLoad");\nif (pre_load == NULL) {\nreturn NULL;\n}\n#endif\n\n')
     emit(values["module_identifier"])
     emit(
         '\\n");\n\n#ifdef _NUITKA_PLUGIN_DILL_ENABLED\n{\nchar const *module_name_c;\nif (loader_entry != NULL) {\nmodule_name_c = loader_entry->name;\n} else {\nPyObject *module_name = GET_STRING_DICT_VALUE(moduledict_'
@@ -1484,10 +1484,10 @@ def _emit_037_template_module_body_template(emit, values):
         ");\nPy_DECREF(_spec_from_module);\n\n\n\n\nif (spec_value == NULL) {\nPyErr_PrintEx(0);\nabort();\n}\n\n\nSET_ATTRIBUTE(tstate, spec_value, const_str_plain__initializing, Py_True);\n\n#if _NUITKA_MODULE_MODE && "
     )
     emit(str(values["is_top"]))
-    emit("&& ")
+    emit(" && ")
     emit(values["module_def_size"])
     emit(
-        ">= 0\n\nSET_ATTRIBUTE(tstate, spec_value, const_str_plain_loader, module_loader);\n#endif\n\nUPDATE_STRING_DICT1(moduledict_"
+        " >= 0\n\nSET_ATTRIBUTE(tstate, spec_value, const_str_plain_loader, module_loader);\n#endif\n\nUPDATE_STRING_DICT1(moduledict_"
     )
     emit(values["module_identifier"])
     emit(
@@ -1505,7 +1505,7 @@ def _emit_037_template_module_body_template(emit, values):
     emit("\n{\nPyObject *post_load = IMPORT_EMBEDDED_MODULE(tstate, ")
     emit(values["module_name_cstr"])
     emit(
-        '"-postLoad");\nif (post_load == NULL) {\nreturn NULL;\n}\n}\n#endif\n\nPy_INCREF(module_'
+        ' "-postLoad");\nif (post_load == NULL) {\nreturn NULL;\n}\n}\n#endif\n\nPy_INCREF(module_'
     )
     emit(values["module_identifier"])
     emit(");\nreturn module_")
@@ -1774,7 +1774,7 @@ def _emit_038_template_module_external_entry_point(emit, values):
         ",\n(Nuitka_StringObject *)const_str_plain___file__,\norig_dunder_file_value\n);\n}\n\n\n#if PYTHON_VERSION >= 0x300\nif (PyUnicode_Check(name) && PyUnicode_Compare(name, const_str_plain___spec__) == 0) {\nreturn 0;\n}\n#endif\n\nreturn orig_PyModule_Type_tp_setattro(module, name, value);\n}\n#endif\n\n#if PYTHON_VERSION >= 0x300\nstatic struct PyModuleDef mdef_"
     )
     emit(values["module_identifier"])
-    emit("= {\nPyModuleDef_HEAD_INIT,\nNULL,                \nNULL,                \n")
+    emit(" = {\nPyModuleDef_HEAD_INIT,\nNULL,                \nNULL,                \n")
     emit(values["module_def_size"])
     emit(
         ", \nNULL,                \nNULL,                \nNULL,                \nNULL,                \nNULL,                \n};\n#endif\n\n#if PYTHON_VERSION < 0x300\nstatic void onModuleFileValueRelease(void *v) {\nif (orig_dunder_file_value != NULL) {\nUPDATE_STRING_DICT0(\nmoduledict_"
@@ -1804,7 +1804,7 @@ def _emit_038_template_module_external_entry_point(emit, values):
     emit(values["module_identifier"])
     emit(", const_str_plain___file__);\n}\n#endif\n\nreturn result;\n}\n\n#if ")
     emit(values["module_def_size"])
-    emit(">= 0\nstatic int ")
+    emit(" >= 0\nstatic int ")
     emit(values["module_dll_entry_point"])
     emit("_slot(PyObject *module) {\nPyObject *result = ")
     emit(values["module_dll_entry_point"])
@@ -1818,13 +1818,13 @@ def _emit_038_template_module_external_entry_point(emit, values):
     emit(values["module_identifier"])
     emit(".m_name = module_full_name;\n\n#if ")
     emit(values["module_def_size"])
-    emit("== -1\nPyObject *module = PyModule_Create(&mdef_")
+    emit(" == -1\nPyObject *module = PyModule_Create(&mdef_")
     emit(values["module_identifier"])
     emit(
         ");\nCHECK_OBJECT(module);\n\n{\nNUITKA_MAY_BE_UNUSED bool res = Nuitka_SetModuleString(module_full_name, module);\nassert(res != false);\n}\n\n#endif\n#endif\n\n#if "
     )
     emit(values["module_def_size"])
-    emit(">= 0\nstatic PyModuleDef_Slot _module_slots[] = {\n{Py_mod_exec, (void *)")
+    emit(" >= 0\nstatic PyModuleDef_Slot _module_slots[] = {\n{Py_mod_exec, (void *)")
     emit(values["module_dll_entry_point"])
     emit("_slot},\n{0, NULL}\n};\n\nmdef_")
     emit(values["module_identifier"])
@@ -1986,7 +1986,7 @@ def _emit_043_template_write_local_unclear_ref0(emit, values):
     emit(values["identifier"])
     emit(";\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";\nPy_XDECREF(old);\n}\n")
 
@@ -2006,7 +2006,7 @@ def _emit_044_template_write_local_unclear_ref1(emit, values):
     emit(values["identifier"])
     emit(";\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";\nPy_INCREF(")
     emit(values["identifier"])
@@ -2028,9 +2028,9 @@ def _emit_044_template_write_local_unclear_ref1_readable(emit, values):
 def _emit_045_template_write_local_empty_ref0(emit, values):
     emit("assert(")
     emit(values["identifier"])
-    emit("== NULL);\n")
+    emit(" == NULL);\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";")
 
@@ -2048,11 +2048,11 @@ def _emit_045_template_write_local_empty_ref0_readable(emit, values):
 def _emit_046_template_write_local_empty_ref1(emit, values):
     emit("assert(")
     emit(values["identifier"])
-    emit("== NULL);\nPy_INCREF(")
+    emit(" == NULL);\nPy_INCREF(")
     emit(values["tmp_name"])
     emit(");\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";")
 
@@ -2074,7 +2074,7 @@ def _emit_047_template_write_local_clear_ref0(emit, values):
     emit(values["identifier"])
     emit(";\nassert(old != NULL);\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";\nPy_DECREF(old);\n}\n")
 
@@ -2091,7 +2091,7 @@ def _emit_047_template_write_local_clear_ref0_readable(emit, values):
 
 def _emit_048_template_write_local_inplace(emit, values):
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";\n")
 
@@ -2124,7 +2124,7 @@ def _emit_050_template_write_local_clear_ref1(emit, values):
     emit(values["identifier"])
     emit(";\nassert(old != NULL);\n")
     emit(values["identifier"])
-    emit("= ")
+    emit(" = ")
     emit(values["tmp_name"])
     emit(";\nPy_INCREF(")
     emit(values["identifier"])
@@ -2236,7 +2236,7 @@ def _emit_055_template_del_local_tolerant(emit, values):
     emit(values["identifier"])
     emit(");\n")
     emit(values["identifier"])
-    emit("= NULL;\n")
+    emit(" = NULL;\n")
 
 
 def _emit_055_template_del_local_tolerant_readable(emit, values):
@@ -2265,15 +2265,15 @@ def _emit_056_template_del_shared_tolerant_readable(emit, values):
 
 def _emit_057_template_del_local_intolerant(emit, values):
     emit(values["result"])
-    emit("= ")
+    emit(" = ")
     emit(values["identifier"])
-    emit("!= NULL;\nif (likely(")
+    emit(" != NULL;\nif (likely(")
     emit(values["result"])
     emit(")) {\nPy_DECREF(")
     emit(values["identifier"])
     emit(");\n")
     emit(values["identifier"])
-    emit("= NULL;\n}\n")
+    emit(" = NULL;\n}\n")
 
 
 def _emit_057_template_del_local_intolerant_readable(emit, values):
@@ -2296,7 +2296,7 @@ def _emit_058_template_del_shared_intolerant(emit, values):
     emit(values["identifier"])
     emit(", NULL);\nPy_XDECREF(old);\n\n")
     emit(values["result"])
-    emit("= old != NULL;\n}\n")
+    emit(" = old != NULL;\n}\n")
 
 
 def _emit_058_template_del_shared_intolerant_readable(emit, values):
@@ -2316,7 +2316,7 @@ def _emit_059_template_del_local_known(emit, values):
     emit(values["identifier"])
     emit(");\n")
     emit(values["identifier"])
-    emit("= NULL;\n")
+    emit(" = NULL;\n")
 
 
 def _emit_059_template_del_local_known_readable(emit, values):
@@ -2375,7 +2375,7 @@ def _emit_062_template_release_object_clear_readable(emit, values):
 
 def _emit_063_template_read_shared_known(emit, values):
     emit(values["tmp_name"])
-    emit("= Nuitka_Cell_GET(")
+    emit(" = Nuitka_Cell_GET(")
     emit(values["identifier"])
     emit(");\n")
 
@@ -2389,7 +2389,7 @@ def _emit_063_template_read_shared_known_readable(emit, values):
 
 def _emit_064_template_read_mvar_unclear(emit, values):
     emit(values["tmp_name"])
-    emit("= LOOKUP_MODULE_VALUE(moduledict_")
+    emit(" = LOOKUP_MODULE_VALUE(moduledict_")
     emit(values["module_identifier"])
     emit(", ")
     emit(values["var_name"])
@@ -2407,7 +2407,7 @@ def _emit_064_template_read_mvar_unclear_readable(emit, values):
 
 def _emit_065_template_read_locals_dict_with_fallback(emit, values):
     emit(values["to_name"])
-    emit("= ")
+    emit(" = ")
     emit(values["dict_get_item"])
     emit("(tstate, ")
     emit(values["locals_dict"])
@@ -2415,7 +2415,7 @@ def _emit_065_template_read_locals_dict_with_fallback(emit, values):
     emit(values["var_name"])
     emit(");\n\nif (")
     emit(values["to_name"])
-    emit("== NULL) {\n")
+    emit(" == NULL) {\n")
     emit(values["fallback"])
     emit("\n}\n")
 
@@ -2437,7 +2437,7 @@ def _emit_065_template_read_locals_dict_with_fallback_readable(emit, values):
 
 def _emit_066_template_read_locals_dict_without_fallback(emit, values):
     emit(values["to_name"])
-    emit("= DICT_GET_ITEM0(tstate, ")
+    emit(" = DICT_GET_ITEM0(tstate, ")
     emit(values["locals_dict"])
     emit(", ")
     emit(values["var_name"])
@@ -2455,13 +2455,13 @@ def _emit_066_template_read_locals_dict_without_fallback_readable(emit, values):
 
 def _emit_067_template_read_locals_mapping_with_fallback_no_ref(emit, values):
     emit(values["to_name"])
-    emit("= PyObject_GetItem(")
+    emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
     emit(", ")
     emit(values["var_name"])
     emit(");\n\nif (")
     emit(values["to_name"])
-    emit("== NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(" == NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
     emit(values["fallback"])
     emit("\nPy_INCREF(")
     emit(values["to_name"])
@@ -2493,13 +2493,13 @@ def _emit_067_template_read_locals_mapping_with_fallback_no_ref_readable(emit, v
 
 def _emit_068_template_read_locals_mapping_with_fallback_ref(emit, values):
     emit(values["to_name"])
-    emit("= PyObject_GetItem(")
+    emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
     emit(", ")
     emit(values["var_name"])
     emit(");\n\nif (")
     emit(values["to_name"])
-    emit("== NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
+    emit(" == NULL) {\nif (CHECK_AND_CLEAR_KEY_ERROR_OCCURRED(tstate)) {\n")
     emit(values["fallback"])
     emit("\n} else {\nFETCH_ERROR_OCCURRED_STATE(tstate, &")
     emit(values["exception_state_name"])
@@ -2527,7 +2527,7 @@ def _emit_068_template_read_locals_mapping_with_fallback_ref_readable(emit, valu
 
 def _emit_069_template_read_locals_mapping_without_fallback(emit, values):
     emit(values["to_name"])
-    emit("= PyObject_GetItem(")
+    emit(" = PyObject_GetItem(")
     emit(values["locals_dict"])
     emit(", ")
     emit(values["var_name"])
@@ -2545,13 +2545,13 @@ def _emit_069_template_read_locals_mapping_without_fallback_readable(emit, value
 
 def _emit_070_template_del_global_unclear(emit, values):
     emit(values["result"])
-    emit("= DICT_REMOVE_ITEM((PyObject *)moduledict_")
+    emit(" = DICT_REMOVE_ITEM((PyObject *)moduledict_")
     emit(values["module_identifier"])
     emit(", ")
     emit(values["var_name"])
     emit(");\nif (")
     emit(values["result"])
-    emit("== false) CLEAR_ERROR_OCCURRED(tstate);\n")
+    emit(" == false) CLEAR_ERROR_OCCURRED(tstate);\n")
 
 
 def _emit_070_template_del_global_unclear_readable(emit, values):
@@ -2648,7 +2648,7 @@ def _emit_074_template_update_locals_mapping_value(emit, values):
     emit(values["var_name"])
     emit(",\nvalue\n);\n\n")
     emit(values["tmp_name"])
-    emit("= res == 0;\n} else {\nPyObject *test_value = PyObject_GetItem(\n")
+    emit(" = res == 0;\n} else {\nPyObject *test_value = PyObject_GetItem(\n")
     emit(values["mapping_name"])
     emit(",\n")
     emit(values["var_name"])
@@ -2660,9 +2660,9 @@ def _emit_074_template_update_locals_mapping_value(emit, values):
     emit(values["var_name"])
     emit("\n);\n\n")
     emit(values["tmp_name"])
-    emit("= res == 0;\n} else {\nCLEAR_ERROR_OCCURRED(tstate);\n")
+    emit(" = res == 0;\n} else {\nCLEAR_ERROR_OCCURRED(tstate);\n")
     emit(values["tmp_name"])
-    emit("= true;\n}\n}\n")
+    emit(" = true;\n}\n}\n")
 
 
 def _emit_074_template_update_locals_mapping_value_readable(emit, values):
@@ -2702,13 +2702,13 @@ def _emit_075_template_set_locals_mapping_value(emit, values):
     emit(values["access_code"])
     emit("\n\n")
     emit(values["tmp_name"])
-    emit("= SET_SUBSCRIPT(\ntstate,\n")
+    emit(" = SET_SUBSCRIPT(\ntstate,\n")
     emit(values["mapping_name"])
     emit(",\n")
     emit(values["var_name"])
     emit(",\nvalue\n);\n} else {\n")
     emit(values["tmp_name"])
-    emit("= true;\n}\n")
+    emit(" = true;\n}\n")
 
 
 def _emit_075_template_set_locals_mapping_value_readable(emit, values):
@@ -2920,7 +2920,7 @@ def _emit_081_template_del_py_cell_intolerant(emit, values):
     emit(values["identifier"])
     emit(", NULL);\nPy_XDECREF(old);\n\n")
     emit(values["result"])
-    emit("= old != NULL;\n}\n")
+    emit(" = old != NULL;\n}\n")
 
 
 def _emit_081_template_del_py_cell_intolerant_readable(emit, values):

--- a/nuitka/code_generation/templates/TemplateDebugWrapper.py
+++ b/nuitka/code_generation/templates/TemplateDebugWrapper.py
@@ -6,9 +6,19 @@
 This wraps strings with a class derived from "str" that does more checks.
 """
 
+import hashlib
+
 from nuitka.__past__ import iterItems
+from nuitka.code_generation.Emission import getCodeString
 from nuitka.States import states
 from nuitka.Tracing import optimization_logger
+
+
+def _getTemplateHash(value):
+    if type(value) is not bytes:
+        value = value.encode("utf8")
+
+    return hashlib.sha256(value).hexdigest()
 
 
 class TemplateWrapper(object):
@@ -46,6 +56,132 @@ class TemplateWrapper(object):
         return self.value.split(sep)
 
 
+class PreparedTemplate(object):
+    """Wrapper around generated template emitter code."""
+
+    def __init__(
+        self, name, value, template_hash, variables, emit_func, readable_emit_func
+    ):
+        self.name = name
+        self.value = value
+        self.template_hash = template_hash
+        self.variables = variables
+        self.emit_func = emit_func
+        self.readable_emit_func = readable_emit_func
+
+        if _getTemplateHash(value) != template_hash:
+            raise AssertionError(
+                "Generated template code for %r is out of date." % name
+            )
+
+    def __str__(self):
+        return self.value
+
+    def __add__(self, other):
+        return self.value + str(other)
+
+    def __radd__(self, other):
+        return str(other) + self.value
+
+    def _checkValues(self, values):
+        assert type(values) is dict, self.name
+
+        for key in values.keys():
+            if key not in self.variables:
+                optimization_logger.warning(
+                    "Extra value %r provided to template %r." % (key, self.name)
+                )
+
+    def __mod__(self, other):
+        if states.is_debug:
+            self._checkValues(other)
+        else:
+            assert type(other) is dict, self.name
+
+        try:
+            return self.value % other
+        except KeyError as e:
+            raise KeyError(self.name, *e.args)
+
+    def render(self, values):
+        result = []
+
+        self.emit(result.append, values)
+
+        return "".join(getCodeString(value) for value in result)
+
+    def emit(self, emit, values):
+        if states.is_debug:
+            self._checkValues(values)
+        else:
+            assert type(values) is dict, self.name
+
+        try:
+            if states.is_readable_code:
+                emit_func = self.readable_emit_func
+            else:
+                emit_func = self.emit_func
+
+            emit_func(emit, values)
+        except KeyError as e:
+            raise KeyError(self.name, *e.args)
+
+    def __call__(self, emit, values):
+        self.emit(emit, values)
+
+    def split(self, sep):
+        return self.value.split(sep)
+
+
+def _getGeneratedTemplateInfos():
+    try:
+        from .CodeTemplatesGenerated import template_infos
+    except ImportError:
+        return {}
+    else:
+        return template_infos
+
+
+def enablePrepared(globals_dict):
+    template_infos = _getGeneratedTemplateInfos()
+    module_name = globals_dict["__name__"]
+
+    for template_name, template_value in iterItems(dict(globals_dict)):
+        if not template_name.startswith("template_") or type(template_value) is not str:
+            continue
+
+        template_key = "%s.%s" % (module_name, template_name)
+
+        if template_key not in template_infos:
+            continue
+
+        template_info = template_infos[template_key]
+
+        if len(template_info) == 3:
+            template_hash, variables, emit_func = template_info
+            readable_emit_func = emit_func
+        else:
+            template_hash, variables, emit_func, readable_emit_func = template_info
+
+        globals_dict[template_name] = PreparedTemplate(
+            name=template_key,
+            value=template_value,
+            template_hash=template_hash,
+            variables=variables,
+            emit_func=emit_func,
+            readable_emit_func=readable_emit_func,
+        )
+
+
+def emitTemplate(template, emit, values):
+    if hasattr(template, "emit") and hasattr(emit, "emitTemplate"):
+        emit.emitTemplate(template, values)
+    elif hasattr(template, "render"):
+        emit(template.render(values))
+    else:
+        emit(template % values)
+
+
 def enableDebug(globals_dict):
     templates = dict(globals_dict)
 
@@ -60,6 +196,8 @@ def enableDebug(globals_dict):
 
 
 def checkDebug(globals_dict):
+    enablePrepared(globals_dict)
+
     if states.is_debug:
         enableDebug(globals_dict)
 

--- a/nuitka/code_generation/templates/TemplateDebugWrapper.py
+++ b/nuitka/code_generation/templates/TemplateDebugWrapper.py
@@ -179,7 +179,17 @@ def emitTemplate(template, emit, values):
     elif hasattr(template, "render"):
         emit(template.render(values))
     else:
-        emit(template % values)
+        # Fallback for a plain, non-prepared template string. Deferred code
+        # objects (collectors, template expansions) must be rendered to their
+        # source string here, as '%s' formatting would otherwise emit their
+        # Python repr into the generated code.
+        emit(
+            template
+            % {
+                key: value.asCode() if hasattr(value, "asCode") else value
+                for key, value in values.items()
+            }
+        )
 
 
 def enableDebug(globals_dict):

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -331,6 +331,7 @@ def parseArgs():
 
     states.is_debug = _isDebug()
     states.is_non_debug = not states.is_debug
+    states.is_readable_code = shallGenerateReadableCode()
     states.is_full_compat = _isFullCompat()
 
     if hasattr(options, "experimental"):

--- a/nuitka/tools/specialize/BenchmarkPreparedTemplates.py
+++ b/nuitka/tools/specialize/BenchmarkPreparedTemplates.py
@@ -1,0 +1,156 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Benchmark prepared code templates against legacy '%' formatting."""
+
+import sys
+import time
+
+from nuitka.code_generation.Emission import SourceCodeCollector
+from nuitka.code_generation.Indentation import indented
+from nuitka.code_generation.templates.TemplateDebugWrapper import emitTemplate
+
+from .CheckPreparedTemplates import iterPreparedTemplateChecks
+
+
+def _emitUnused(_value):
+    pass
+
+
+def _parseIterations():
+    for arg in sys.argv[1:]:
+        if arg.startswith("--iterations="):
+            return int(arg.split("=", 1)[1])
+
+    return 2000
+
+
+def _benchmarkLegacy(templates, iterations):
+    collector = SourceCodeCollector()
+    start_time = time.time()
+
+    for _i in range(iterations):
+        for _template_key, template, values in templates:
+            collector(str(template) % values)
+
+        collector.reset()
+
+    return time.time() - start_time
+
+
+def _benchmarkLegacyCollectorJoin(templates, iterations):
+    collector = SourceCodeCollector()
+    start_time = time.time()
+
+    for _i in range(iterations):
+        for _template_key, template, values in templates:
+            collector(str(template) % values)
+
+        _emitUnused(indented(collector))
+        collector.reset()
+
+    return time.time() - start_time
+
+
+def _benchmarkPrepared(templates, iterations):
+    start_time = time.time()
+
+    for _i in range(iterations):
+        for _template_key, template, values in templates:
+            template.emit(_emitUnused, values)
+
+    return time.time() - start_time
+
+
+def _benchmarkPreparedCollector(templates, iterations):
+    collector = SourceCodeCollector()
+    start_time = time.time()
+
+    for _i in range(iterations):
+        for _template_key, template, values in templates:
+            emitTemplate(template, collector, values)
+
+        collector.reset()
+
+    return time.time() - start_time
+
+
+def _benchmarkPreparedCollectorJoin(templates, iterations):
+    collector = SourceCodeCollector()
+    start_time = time.time()
+
+    for _i in range(iterations):
+        for _template_key, template, values in templates:
+            emitTemplate(template, collector, values)
+
+        _emitUnused(indented(collector))
+        collector.reset()
+
+    return time.time() - start_time
+
+
+def main():
+    iterations = _parseIterations()
+    templates = tuple(iterPreparedTemplateChecks())
+
+    legacy_time = _benchmarkLegacy(templates, iterations)
+    legacy_collector_join_time = _benchmarkLegacyCollectorJoin(templates, iterations)
+    prepared_time = _benchmarkPrepared(templates, iterations)
+    prepared_collector_time = _benchmarkPreparedCollector(templates, iterations)
+    prepared_collector_join_time = _benchmarkPreparedCollectorJoin(
+        templates, iterations
+    )
+
+    if prepared_time:
+        speedup = legacy_time / prepared_time
+    else:
+        speedup = 0
+
+    if prepared_collector_time:
+        collector_speedup = legacy_time / prepared_collector_time
+    else:
+        collector_speedup = 0
+
+    if prepared_collector_join_time:
+        collector_join_speedup = (
+            legacy_collector_join_time / prepared_collector_join_time
+        )
+    else:
+        collector_join_speedup = 0
+
+    sys.stdout.write("Prepared template benchmark:\n")
+    sys.stdout.write("  Templates: %d\n" % len(templates))
+    sys.stdout.write("  Iterations: %d\n" % iterations)
+    sys.stdout.write("  Legacy format+emit: %.3fs\n" % legacy_time)
+    sys.stdout.write("  Legacy format+emit+join: %.3fs\n" % legacy_collector_join_time)
+    sys.stdout.write("  Prepared raw emit: %.3fs\n" % prepared_time)
+    sys.stdout.write("  Prepared collector emit: %.3fs\n" % prepared_collector_time)
+    sys.stdout.write(
+        "  Prepared collector emit+join: %.3fs\n" % prepared_collector_join_time
+    )
+    sys.stdout.write("  Raw emit speedup: %.2fx\n" % speedup)
+    sys.stdout.write("  Collector emit speedup: %.2fx\n" % collector_speedup)
+    sys.stdout.write("  Collector emit+join speedup: %.2fx\n" % collector_join_speedup)
+
+
+if __name__ == "__main__":
+    main()
+
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the GNU Affero General Public License, Version 3 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        https://www.gnu.org/licenses/agpl-3.0.txt
+#
+#     See also: "Nuitka Runtime Library Exception, Version 1.0" in file
+#     "LICENSE-RUNTIME.txt" for additional permissions granted under Section 7.
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/tools/specialize/CheckPreparedTemplates.py
+++ b/nuitka/tools/specialize/CheckPreparedTemplates.py
@@ -5,13 +5,13 @@
 
 import sys
 
+from nuitka.code_generation.Emission import SourceCodeCollector
+from nuitka.code_generation.Indentation import indented
 from nuitka.code_generation.templates.CodeTemplatesGenerated import (
     template_infos,
     template_variables,
 )
 from nuitka.code_generation.templates.TemplateDebugWrapper import emitTemplate
-from nuitka.code_generation.Emission import SourceCodeCollector
-from nuitka.code_generation.Indentation import indented
 from nuitka.States import states
 
 

--- a/nuitka/tools/specialize/CheckPreparedTemplates.py
+++ b/nuitka/tools/specialize/CheckPreparedTemplates.py
@@ -1,0 +1,136 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Check prepared code templates against legacy '%' formatting."""
+
+import sys
+
+from nuitka.code_generation.templates.CodeTemplatesGenerated import (
+    template_infos,
+    template_variables,
+)
+from nuitka.code_generation.templates.TemplateDebugWrapper import emitTemplate
+from nuitka.code_generation.Emission import SourceCodeCollector
+from nuitka.code_generation.Indentation import indented
+from nuitka.States import states
+
+
+def _importTemplate(template_key):
+    module_name, template_name = template_key.rsplit(".", 1)
+    module = __import__(module_name, fromlist=[template_name])
+
+    return getattr(module, template_name)
+
+
+def _makeTemplateValues(template_key):
+    value_types = {}
+
+    for variable_name, conversion in template_variables[template_key]:
+        if conversion == "d" or value_types.get(variable_name) == "d":
+            value_types[variable_name] = "d"
+        else:
+            value_types[variable_name] = "s"
+
+    result = {}
+
+    for variable_name, conversion in value_types.items():
+        if conversion == "d":
+            result[variable_name] = 123
+        else:
+            result[variable_name] = "VALUE_%s" % variable_name
+
+    return result
+
+
+def iterPreparedTemplateChecks():
+    for template_key in sorted(template_infos):
+        template = _importTemplate(template_key)
+        values = _makeTemplateValues(template_key)
+
+        yield template_key, template, values
+
+
+def checkPreparedTemplates():
+    old_readable_code = states.is_readable_code
+    checked = 0
+
+    try:
+        states.is_readable_code = True
+
+        for template_key, template, values in iterPreparedTemplateChecks():
+            if not hasattr(template, "emit"):
+                sys.stderr.write("Template is not prepared: %s\n" % template_key)
+                return False
+
+            legacy_result = str(template) % values
+
+            emitted = []
+            template.emit(emitted.append, values)
+            prepared_result = "".join(emitted)
+
+            if legacy_result != prepared_result:
+                sys.stderr.write("Template parity mismatch: %s\n" % template_key)
+                sys.stderr.write("Legacy result:\n%s\n" % legacy_result)
+                sys.stderr.write("Prepared result:\n%s\n" % prepared_result)
+
+                return False
+
+            collector = SourceCodeCollector()
+            emitTemplate(template, collector, values)
+            collector_result = indented(collector)
+
+            if legacy_result != collector_result:
+                sys.stderr.write(
+                    "Template collector parity mismatch: %s\n" % template_key
+                )
+                sys.stderr.write("Legacy result:\n%s\n" % legacy_result)
+                sys.stderr.write("Collector result:\n%s\n" % collector_result)
+
+                return False
+
+            states.is_readable_code = False
+            collector = SourceCodeCollector()
+            emitTemplate(template, collector, values)
+            indented(collector)
+            states.is_readable_code = True
+
+            checked += 1
+    finally:
+        states.is_readable_code = old_readable_code
+
+    sys.stdout.write(
+        "Validated %d prepared templates: legacy '%%' rendering matches prepared emission.\n"
+        % checked
+    )
+
+    return True
+
+
+def main():
+    if checkPreparedTemplates():
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the GNU Affero General Public License, Version 3 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        https://www.gnu.org/licenses/agpl-3.0.txt
+#
+#     See also: "Nuitka Runtime Library Exception, Version 1.0" in file
+#     "LICENSE-RUNTIME.txt" for additional permissions granted under Section 7.
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/tools/specialize/SpecializePython.py
+++ b/nuitka/tools/specialize/SpecializePython.py
@@ -3,6 +3,9 @@
 
 """This tool is generating node variants from Jinja templates."""
 
+import ast
+import hashlib
+import os
 import sys
 
 from nuitka.States import states
@@ -44,7 +47,7 @@ from nuitka.nodes.shapes.BuiltinTypeShapes import (
     tshape_str,
     tshape_tuple,
 )
-from nuitka.utils.FileOperations import getNormalizedPath
+from nuitka.utils.FileOperations import getFileContents, getNormalizedPath
 from nuitka.utils.Jinja2 import getTemplate
 
 from .Common import (
@@ -101,27 +104,388 @@ attribute_shape_static = {}
 node_factory_translations = {}
 
 
-def _getMixinForShape(shape):
-    # Return driven for better debugging experience, pylint: disable=too-many-return-statements
+def _getAstStringValue(node):
+    if (
+        hasattr(ast, "Constant")
+        and type(node) is ast.Constant
+        and type(node.value) is str
+    ):
+        return node.value
 
-    if shape is tshape_str:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionStrShapeExactMixin"
-    elif shape is tshape_list:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionListShapeExactMixin"
-    elif shape is tshape_tuple:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionTupleShapeExactMixin"
-    elif shape is tshape_int:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionIntShapeExactMixin"
-    elif shape is tshape_bool:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionBoolShapeExactMixin"
-    elif shape is tshape_none:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionNoneShapeExactMixin"
-    elif shape is tshape_dict:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionDictShapeExactMixin"
-    elif shape is tshape_bytes:
-        return "nuitka.nodes.ExpressionShapeMixins.ExpressionBytesShapeExactMixin"
+    if hasattr(ast, "Str") and type(node) is ast.Str:
+        return node.s
+
+    return None
+
+
+def _parseFormatSpec(template_value, percent_pos):
+    result = None
+
+    if percent_pos + 1 < len(template_value) and template_value[percent_pos + 1] == "(":
+        end_pos = template_value.find(")", percent_pos + 2)
+
+        if end_pos != -1:
+            variable_name = template_value[percent_pos + 2 : end_pos]
+            format_pos = end_pos + 1
+
+            while format_pos < len(template_value) and template_value[format_pos] in (
+                "#",
+                "0",
+                " ",
+                "+",
+                "-",
+            ):
+                format_pos += 1
+
+            while (
+                format_pos < len(template_value)
+                and template_value[format_pos].isdigit()
+            ):
+                format_pos += 1
+
+            if format_pos < len(template_value) and template_value[format_pos] == ".":
+                format_pos += 1
+
+            while (
+                format_pos < len(template_value)
+                and template_value[format_pos].isdigit()
+            ):
+                format_pos += 1
+
+            if format_pos < len(template_value):
+                conversion = template_value[format_pos]
+
+                if conversion in ("s", "d") and format_pos == end_pos + 1:
+                    result = variable_name, conversion, format_pos + 1
+
+    return result
+
+
+def _addTemplateLiteral(result, template_value, start_pos, end_pos):
+    if start_pos < end_pos:
+        result.append(("literal", template_value[start_pos:end_pos]))
+
+
+def _parsePercentTemplate(template_value):
+    if "{%" in template_value or "{{" in template_value:
+        return None
+
+    result = []
+    variables = []
+    pos = 0
+
+    while True:
+        percent_pos = template_value.find("%", pos)
+
+        if percent_pos == -1:
+            _addTemplateLiteral(result, template_value, pos, len(template_value))
+
+            return result, tuple(variables)
+
+        if percent_pos + 1 >= len(template_value):
+            return None
+
+        if template_value[percent_pos + 1] == "%":
+            _addTemplateLiteral(result, template_value, pos, percent_pos)
+            result.append(("literal", "%"))
+
+            pos = percent_pos + 2
+            continue
+
+        format_spec = _parseFormatSpec(template_value, percent_pos)
+        if format_spec is None:
+            return None
+
+        variable_name, conversion, next_pos = format_spec
+
+        _addTemplateLiteral(result, template_value, pos, percent_pos)
+        result.append((conversion, variable_name))
+        variables.append((variable_name, conversion))
+
+        pos = next_pos
+
+
+def _getCodeTemplateValues():
+    template_dir = getNormalizedPath("nuitka/code_generation/templates")
+
+    for filename in sorted(os.listdir(template_dir)):
+        if not filename.startswith("CodeTemplates") or not filename.endswith(".py"):
+            continue
+
+        if filename == "CodeTemplatesGenerated.py":
+            continue
+
+        module_name = (
+            "nuitka.code_generation.templates.%s" % os.path.splitext(filename)[0]
+        )
+        full_path = os.path.join(template_dir, filename)
+
+        tree = ast.parse(getFileContents(full_path, encoding="utf8"))
+
+        for node in ast.walk(tree):
+            if type(node) is not ast.Assign:
+                continue
+
+            template_value = _getAstStringValue(node.value)
+
+            if template_value is None:
+                continue
+
+            for target in node.targets:
+                if type(target) is not ast.Name:
+                    continue
+
+                if not target.id.startswith("template_"):
+                    continue
+
+                parse_result = _parsePercentTemplate(template_value)
+
+                if parse_result is None:
+                    continue
+
+                yield module_name, target.id, template_value, parse_result
+
+
+def _getTemplateHash(template_value):
+    return hashlib.sha256(template_value.encode("utf8")).hexdigest()
+
+
+def _getTemplateEmitFunctionName(template_name, count):
+    return "_emit_%03d_%s" % (count, template_name)
+
+
+def _stripCommentsFromTemplateLiteral(value):
+    result = []
+    pos = 0
+    in_string = None
+    escaped = False
+    length = len(value)
+
+    while pos < length:
+        char = value[pos]
+        next_char = value[pos + 1] if pos + 1 < length else ""
+
+        if in_string is not None:
+            result.append(char)
+
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == in_string:
+                in_string = None
+
+            pos += 1
+        elif char in ("'", '"'):
+            in_string = char
+            result.append(char)
+            pos += 1
+        elif char == "/" and next_char == "/":
+            pos += 2
+
+            while pos < length and value[pos] not in "\r\n":
+                pos += 1
+        elif char == "/" and next_char == "*":
+            pos += 2
+
+            while pos + 1 < length and not (
+                value[pos] == "*" and value[pos + 1] == "/"
+            ):
+                if value[pos] in "\r\n":
+                    result.append(value[pos])
+
+                pos += 1
+
+            pos += 2
+        else:
+            result.append(char)
+            pos += 1
+
+    return "".join(result)
+
+
+def _stripLeadingWhitespaceFromTemplateLiteral(value):
+    result = []
+    at_line_start = True
+
+    for char in value:
+        if at_line_start and char in (" ", "\t"):
+            continue
+
+        result.append(char)
+        at_line_start = char in "\r\n"
+
+    return "".join(result)
+
+
+def _compactTemplateLiteral(value):
+    value = _stripCommentsFromTemplateLiteral(value)
+    value = _stripLeadingWhitespaceFromTemplateLiteral(value)
+
+    return value
+
+
+def _compactTemplateParts(parts):
+    result = []
+
+    for kind, value in parts:
+        if kind == "literal":
+            value = _compactTemplateLiteral(value)
+
+            if value:
+                result.append((kind, value))
+        else:
+            result.append((kind, value))
+
+    return tuple(result)
+
+
+def _writePreparedTemplateEmitter(emit, function_name, parts):
+    emit("def %s(emit, values):" % function_name)
+
+    if parts:
+        for kind, value in parts:
+            if kind == "literal":
+                emit("    emit(%r)" % value)
+            elif kind == "s":
+                emit("    emit(values[%r])" % value)
+            elif kind == "d":
+                emit("    emit(str(values[%r]))" % value)
+            else:
+                assert False, kind
     else:
-        assert False, shape
+        emit("    pass")
+
+    emit()
+
+
+def _writePreparedTemplateInfoTables(emit, template_infos):
+    emit("template_infos = {")
+
+    for (
+        template_key,
+        function_name,
+        readable_function_name,
+        template_hash,
+        variables,
+        _variables,
+    ) in sorted(template_infos):
+        emit(
+            "    %r: (%r, %r, %s, %s),"
+            % (
+                template_key,
+                template_hash,
+                variables,
+                function_name,
+                readable_function_name,
+            )
+        )
+
+    emit("}")
+    emit()
+    emit("template_variables = {")
+
+    for (
+        template_key,
+        _function_name,
+        _readable_function_name,
+        _template_hash,
+        _variables,
+        variables,
+    ) in sorted(template_infos):
+        emit("    %r: %r," % (template_key, variables))
+
+    emit("}")
+
+
+def _makeTemplateInfo(template_desc, count):
+    module_name, template_name, template_value, parse_result = template_desc
+    parts, variables = parse_result
+
+    function_name = _getTemplateEmitFunctionName(template_name, count)
+    readable_function_name = function_name + "_readable"
+    template_key = "%s.%s" % (module_name, template_name)
+
+    return (
+        template_key,
+        function_name,
+        readable_function_name,
+        _getTemplateHash(template_value),
+        tuple(sorted(set(variable_name for variable_name, _ in variables))),
+        variables,
+        _compactTemplateParts(parts),
+        parts,
+    )
+
+
+def makeCodeTemplatesGenerated():
+    filename_python = getNormalizedPath(
+        "nuitka/code_generation/templates/CodeTemplatesGenerated.py"
+    )
+
+    with withFileOpenedAndAutoFormattedWithClaim(
+        filename_python,
+        ignore_errors=False,
+        claim=getLicenseGeneratedCode(),
+    ) as output_python:
+
+        def emit(*args):
+            writeLine(output_python, *args)
+
+        emitGenerationWarning(
+            emit, "Prepared code generation templates", "CodeTemplates*.py"
+        )
+        emit("# pylint: disable=unused-argument")
+        emit()
+
+        template_infos = []
+
+        for count, template_desc in enumerate(_getCodeTemplateValues()):
+            template_info = _makeTemplateInfo(template_desc, count)
+
+            (
+                template_key,
+                function_name,
+                readable_function_name,
+                template_hash,
+                variables,
+                variable_descriptions,
+                compact_parts,
+                parts,
+            ) = template_info
+
+            _writePreparedTemplateEmitter(emit, function_name, compact_parts)
+            _writePreparedTemplateEmitter(emit, readable_function_name, parts)
+
+            template_infos.append(
+                (
+                    template_key,
+                    function_name,
+                    readable_function_name,
+                    template_hash,
+                    variables,
+                    variable_descriptions,
+                )
+            )
+
+        _writePreparedTemplateInfoTables(emit, template_infos)
+
+
+def _getMixinForShape(shape):
+    mixin_names = {
+        tshape_bool: "nuitka.nodes.ExpressionShapeMixins.ExpressionBoolShapeExactMixin",
+        tshape_bytes: "nuitka.nodes.ExpressionShapeMixins.ExpressionBytesShapeExactMixin",
+        tshape_dict: "nuitka.nodes.ExpressionShapeMixins.ExpressionDictShapeExactMixin",
+        tshape_int: "nuitka.nodes.ExpressionShapeMixins.ExpressionIntShapeExactMixin",
+        tshape_list: "nuitka.nodes.ExpressionShapeMixins.ExpressionListShapeExactMixin",
+        tshape_none: "nuitka.nodes.ExpressionShapeMixins.ExpressionNoneShapeExactMixin",
+        tshape_str: "nuitka.nodes.ExpressionShapeMixins.ExpressionStrShapeExactMixin",
+        tshape_tuple: "nuitka.nodes.ExpressionShapeMixins.ExpressionTupleShapeExactMixin",
+    }
+
+    assert shape in mixin_names, shape
+
+    return mixin_names[shape]
 
 
 def processTypeShapeAttribute(
@@ -478,30 +842,35 @@ def makeCodeCased(value):
 
 
 def getCallModuleName(module_name, function_name):
-    # return driven, pylint: disable=too-many-return-statements
-
     if module_name in ("pkg_resources", "importlib.metadata", "importlib_metadata"):
         if function_name in ("resource_stream", "resource_string"):
             return "PackageResourceNodes"
 
         return "PackageMetadataNodes"
-    if module_name in ("pkgutil", "importlib.resources", "importlib_resources"):
-        return "PackageResourceNodes"
-    if module_name in ("os", "sys", "os.path"):
-        return "OsSysNodes"
-    if module_name == "ctypes":
-        return "CtypesNodes"
-    if module_name == "builtins":
-        if function_name == "open":
-            return "BuiltinOpenNodes"
 
-    if module_name == "tensorflow":
-        return "TensorflowNodes"
+    module_names = {
+        "builtins": {"open": "BuiltinOpenNodes"},
+        "ctypes": "CtypesNodes",
+        "importlib.resources": "PackageResourceNodes",
+        "importlib_resources": "PackageResourceNodes",
+        "os": "OsSysNodes",
+        "os.path": "OsSysNodes",
+        "pkgutil": "PackageResourceNodes",
+        "sys": "OsSysNodes",
+        "tensorflow": "TensorflowNodes",
+    }
 
     if module_name.startswith("networkx"):
-        return "NetworkxNodes"
+        result = "NetworkxNodes"
+    else:
+        result = module_names.get(module_name)
 
-    assert False, (module_name, function_name)
+        if type(result) is dict:
+            result = result.get(function_name)
+
+    assert result is not None, (module_name, function_name)
+
+    return result
 
 
 def translateNodeClassName(node_class_name):
@@ -763,9 +1132,8 @@ def addFromNodes():
 addFromNodes()
 
 
-def makeChildrenHavingMixinNodes():
+def makeChildrenHavingMixinNodes():  # pylint: disable=too-many-locals,too-many-statements
     # Complex stuff with many details due to 2 files and modes,
-    # pylint: disable=too-many-locals,too-many-statements
 
     filename_python = getNormalizedPath("nuitka/nodes/ChildrenHavingMixins.py")
     filename_python2 = getNormalizedPath("nuitka/nodes/ExpressionBasesGenerated.py")
@@ -985,9 +1353,7 @@ def getSpecVersions(spec_module):
     return tuple(sorted(result.values()))
 
 
-def makeHardImportNodes():
-    # Too many details, pylint: disable=too-many-locals
-
+def makeHardImportNodes():  # pylint: disable=too-many-locals
     filename_python = getNormalizedPath("nuitka/nodes/HardImportNodesGenerated.py")
 
     template_ref_node = getTemplate(
@@ -1130,6 +1496,7 @@ hard_import_node_classes = {}
 def main():
     parseOptions()
 
+    makeCodeTemplatesGenerated()
     makeHardImportNodes()
     makeAttributeNodes()
     makeBuiltinOperationNodes()

--- a/nuitka/tools/specialize/SpecializePython.py
+++ b/nuitka/tools/specialize/SpecializePython.py
@@ -304,9 +304,8 @@ def _stripCommentsFromTemplateLiteral(value):
     return "".join(result)
 
 
-def _stripLeadingWhitespaceFromTemplateLiteral(value):
+def _stripLeadingWhitespaceFromTemplateLiteral(value, at_line_start):
     result = []
-    at_line_start = True
 
     for char in value:
         if at_line_start and char in (" ", "\t"):
@@ -315,27 +314,39 @@ def _stripLeadingWhitespaceFromTemplateLiteral(value):
         result.append(char)
         at_line_start = char in "\r\n"
 
-    return "".join(result)
+    return "".join(result), at_line_start
 
 
-def _compactTemplateLiteral(value):
+def _compactTemplateLiteral(value, at_line_start):
     value = _stripCommentsFromTemplateLiteral(value)
-    value = _stripLeadingWhitespaceFromTemplateLiteral(value)
+    value, at_line_start = _stripLeadingWhitespaceFromTemplateLiteral(
+        value, at_line_start
+    )
 
-    return value
+    return value, at_line_start
 
 
 def _compactTemplateParts(parts):
     result = []
 
+    # Leading whitespace may only be stripped at the start of a line. Track this
+    # across parts, because a literal fragment can begin in the middle of a line,
+    # right after a substituted value. Stripping its leading whitespace there
+    # would join tokens, e.g. "%(file_scope)s PyObject" -> "<value>PyObject".
+    at_line_start = True
+
     for kind, value in parts:
         if kind == "literal":
-            value = _compactTemplateLiteral(value)
+            value, at_line_start = _compactTemplateLiteral(value, at_line_start)
 
             if value:
                 result.append((kind, value))
         else:
+            # A substituted value emits inline content of unknown shape, so the
+            # following literal is not at a line start and its leading
+            # whitespace must be preserved.
             result.append((kind, value))
+            at_line_start = False
 
     return tuple(result)
 

--- a/nuitka/tools/specialize/SpecializePython.py
+++ b/nuitka/tools/specialize/SpecializePython.py
@@ -254,101 +254,116 @@ def _getTemplateEmitFunctionName(template_name, count):
     return "_emit_%03d_%s" % (count, template_name)
 
 
-def _stripCommentsFromTemplateLiteral(value):
-    result = []
-    pos = 0
-    in_string = None
-    escaped = False
-    length = len(value)
+class _TemplateCompactor(object):
+    """Compact a template's literal parts for non-readable code generation.
 
-    while pos < length:
-        char = value[pos]
-        next_char = value[pos + 1] if pos + 1 < length else ""
+    Comment and whitespace stripping must track lexer state across the whole
+    template, not per fragment: a C comment or string literal can span a
+    substituted value, and a literal fragment can begin in the middle of a
+    line, right after a substituted value.
 
-        if in_string is not None:
-            result.append(char)
+    Handling each fragment independently previously (1) stripped a "/*" opener
+    while keeping its "*/" closer when a block comment spanned a value, and
+    (2) stripped inline leading whitespace after a value, joining tokens like
+    "%(file_scope)s PyObject" -> "<value>PyObject". Both produced invalid C in
+    compact (non-readable) builds.
+    """
 
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == in_string:
-                in_string = None
+    def __init__(self):
+        self.in_string = None
+        self.escaped = False
+        self.in_block_comment = False
+        self.in_line_comment = False
+        self.at_line_start = True
 
-            pos += 1
-        elif char in ("'", '"'):
-            in_string = char
-            result.append(char)
-            pos += 1
-        elif char == "/" and next_char == "/":
-            pos += 2
+    @property
+    def _in_comment(self):
+        return self.in_block_comment or self.in_line_comment
 
-            while pos < length and value[pos] not in "\r\n":
+    def _compactLiteral(self, value):
+        # Character-level lexer state machine, pylint: disable=too-many-branches
+        result = []
+        pos = 0
+        length = len(value)
+
+        while pos < length:
+            char = value[pos]
+            next_char = value[pos + 1] if pos + 1 < length else ""
+
+            if self.in_block_comment:
+                if char == "*" and next_char == "/":
+                    self.in_block_comment = False
+                    pos += 2
+                    continue
+
+                # Preserve newlines so line structure and line-start tracking
+                # stay intact even after a comment is removed.
+                if char in "\r\n":
+                    result.append(char)
+                    self.at_line_start = True
+
                 pos += 1
-        elif char == "/" and next_char == "*":
-            pos += 2
-
-            while pos + 1 < length and not (
-                value[pos] == "*" and value[pos + 1] == "/"
-            ):
-                if value[pos] in "\r\n":
-                    result.append(value[pos])
+            elif self.in_line_comment:
+                if char in "\r\n":
+                    self.in_line_comment = False
+                    result.append(char)
+                    self.at_line_start = True
 
                 pos += 1
+            elif self.in_string is not None:
+                result.append(char)
 
-            pos += 2
-        else:
-            result.append(char)
-            pos += 1
+                if self.escaped:
+                    self.escaped = False
+                elif char == "\\":
+                    self.escaped = True
+                elif char == self.in_string:
+                    self.in_string = None
 
-    return "".join(result)
+                self.at_line_start = char in "\r\n"
+                pos += 1
+            elif char in ("'", '"'):
+                self.in_string = char
+                result.append(char)
+                self.at_line_start = False
+                pos += 1
+            elif char == "/" and next_char == "/":
+                self.in_line_comment = True
+                pos += 2
+            elif char == "/" and next_char == "*":
+                self.in_block_comment = True
+                pos += 2
+            elif self.at_line_start and char in (" ", "\t"):
+                pos += 1
+            else:
+                result.append(char)
+                self.at_line_start = char in "\r\n"
+                pos += 1
 
+        return "".join(result)
 
-def _stripLeadingWhitespaceFromTemplateLiteral(value, at_line_start):
-    result = []
+    def compact(self, parts):
+        result = []
 
-    for char in value:
-        if at_line_start and char in (" ", "\t"):
-            continue
+        for kind, value in parts:
+            if kind == "literal":
+                value = self._compactLiteral(value)
 
-        result.append(char)
-        at_line_start = char in "\r\n"
+                if value:
+                    result.append((kind, value))
+            elif not self._in_comment:
+                # A substituted value is opaque inline content (a code
+                # identifier, type, number, ...). Keep it only when it is not
+                # inside a comment; it never toggles string or comment state,
+                # and it means the next literal is no longer at a line start.
+                result.append((kind, value))
+                self.at_line_start = False
 
-    return "".join(result), at_line_start
-
-
-def _compactTemplateLiteral(value, at_line_start):
-    value = _stripCommentsFromTemplateLiteral(value)
-    value, at_line_start = _stripLeadingWhitespaceFromTemplateLiteral(
-        value, at_line_start
-    )
-
-    return value, at_line_start
+        return tuple(result)
 
 
 def _compactTemplateParts(parts):
-    result = []
-
-    # Leading whitespace may only be stripped at the start of a line. Track this
-    # across parts, because a literal fragment can begin in the middle of a line,
-    # right after a substituted value. Stripping its leading whitespace there
-    # would join tokens, e.g. "%(file_scope)s PyObject" -> "<value>PyObject".
-    at_line_start = True
-
-    for kind, value in parts:
-        if kind == "literal":
-            value, at_line_start = _compactTemplateLiteral(value, at_line_start)
-
-            if value:
-                result.append((kind, value))
-        else:
-            # A substituted value emits inline content of unknown shape, so the
-            # following literal is not at a line start and its leading
-            # whitespace must be preserved.
-            result.append((kind, value))
-            at_line_start = False
-
-    return tuple(result)
+    return _TemplateCompactor().compact(parts)
 
 
 def _writePreparedTemplateEmitter(emit, function_name, parts):


### PR DESCRIPTION
# Description

## What does this PR do?

This PR adds generated prepared emitters for the plain `CodeTemplates*.py` templates that only use simple `%s` / `%d`-style placeholders. Instead of formatting full template strings at runtime, migrated code-generation paths now call `emitTemplate(...)`, allowing prepared templates to append static template fragments and already-built dynamic values directly into `SourceCodeCollector`.

It also adds:

- `CodeTemplatesGenerated.py`, produced by `bin/generate-specialized-python-code`.
- Runtime integrity checks via template hashes.
- Readable vs compact prepared emission, with `--devel-generate-readable-code` preserving exact legacy output.
- Prepared-template parity validation and benchmark commands.
- A CI check that runs the prepared-template validator in the existing `checks` job.

Jinja2 templates are intentionally not changed in this PR.

## Why was it initiated? Any relevant Issues?

This was initiated from the maintainer request/planning item: faster Nuitka templating with prepared templates, reducing runtime string formatting and short-lived string construction during code generation.

No separate GitHub issue number was supplied in the local task context.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build / CI System
- [ ] Documentation Update

## Performance

Prepared-template microbenchmark command:

```text
python bin\benchmark-prepared-code-templates --iterations=5000
```

Results from this checkout:

```text
Prepared template benchmark:
  Templates: 83
  Iterations: 5000
  Legacy format+emit: 0.342s
  Legacy format+emit+join: 0.352s
  Prepared raw emit: 0.137s
  Prepared collector emit: 0.070s
  Prepared collector emit+join: 0.247s
  Raw emit speedup: 2.51x
  Collector emit speedup: 4.89x
  Collector emit+join speedup: 1.43x
```

The collector stores prepared template calls as deferred template expansions and expands them directly into the final assembly list. This avoids building a per-template parts list during emission, keeps passed dynamic strings by reference until final assembly, and gets the focused `emit+join` benchmark above 1x.

Real Nuitka code-generation benchmark results are more conservative. Commands used `--generate-c-only` to focus on Nuitka Python optimization and C source generation rather than C compilation.

```text
# warmed, alternating, 5 iterations each
python bin\nuitka --generate-c-only --mode=accelerated tests\basics\ReferencingTest.py

develop mean:          1.24s
prepared mean:         1.22s
```

```text
# larger followed-import compile, sequential runs under the same current conditions
python bin\nuitka --generate-c-only --mode=accelerated --follow-imports bin\nuitka

develop:               129.74s
prepared:              138.03s
```

The prepared emitter path removes runtime `%` template formatting and reduces generated source size in earlier larger self-follow runs (`~828 MB` vs `~849 MB`), and the focused template `emit+join` path is now faster. The larger real code-generation run is still slower in this local measurement, so this PR should be read as removing template-formatting overhead and improving the targeted emission benchmark, not as a proven end-to-end Nuitka compile-time speedup yet.

## Tests Added For CI

- Added `bin/check-prepared-code-templates`.
- Added `.github/workflows/testing.yml` step: `python ./bin/check-prepared-code-templates`.
- The validator checks all generated prepared templates against legacy `%` rendering in readable mode, including direct emission and `SourceCodeCollector` emission, and smoke-checks compact emission.

## Validation

- [x] `python bin\autoformat-nuitka-source --un-pushed --assume-yes-for-downloads`
- [x] `python bin\check-nuitka-with-pylint --un-pushed`
- [x] `python bin\check-nuitka-with-yamllint --assume-yes-for-downloads`
- [x] `python bin\generate-specialized-python-code --check`
- [x] `python bin\generate-specialized-c-code --check`
- [x] `python bin\check-prepared-code-templates`
- [x] `python -m compileall -q ...` for touched Python modules
- [x] `python bin\nuitka --generate-c-only --mode=accelerated --output-dir=tests\scratch\prepared-template-expansion-check tests\basics\AssertsTest.py`
- [x] `git diff --check`
- [x] `python bin\benchmark-prepared-code-templates --iterations=5000`
- [x] Real code-generation benchmarks listed above

Note: an attempted file-specific `check-nuitka-with-yamllint` invocation was rejected because that script does not take workflow files that way; the normal project yamllint command passed.

## PR Checklist

- [x] Correct base branch selected: `develop` branch.
- [x] Formatting: executed `./bin/autoformat-nuitka-source`.
- [x] Tests: focused checks listed above pass locally.
- [x] New Coverage: prepared-template validator added and wired into CI.
- [x] Documentation: no user-facing documentation change needed; this is an internal code-generation refactor.

## AI Generated Code Policy

- [x] Detection: This PR contains AI generated code.
  - [x] Issue First: Work was initiated from a maintainer-provided planning/request prompt for faster prepared template emission before implementation; no separate GitHub issue number was supplied.
  - [x] Documentation: Prompt summary: implement prepared Nuitka code templates that emit fragments directly into collectors, ignore Jinja2 for now, retain legacy parity through pre/post validation, add performance numbers, clean up duplicates/unneeded code, and prepare a PR following repository policy.
  - [x] Verification: The generated and edited code was manually reviewed and verified with the local checks listed above.
  - [x] Evidence: Validator, CI hook, compile smoke test, generated-code checks, lint/format checks, benchmark results, and real code-generation timings are included above.
