### PR TITLE
Quality: Faster duplicate parameter detection in ParameterSpec

### DIFF
--- a/nuitka/specs/ParameterSpecs.py
+++ b/nuitka/specs/ParameterSpecs.py
@@ -149,10 +149,14 @@ class ParameterSpec(object):
     def checkParametersValid(self):
         arg_names = self.getParameterNames()
 
-        # Check for duplicate arguments, could happen.
+        # Check for duplicate arguments, could happen. Track seen names in a set
+        # for a single pass, rather than re-scanning the whole list per name,
+        # and report the first repeated name, which matches CPython's own error.
+        seen_arg_names = set()
         for arg_name in arg_names:
-            if arg_names.count(arg_name) != 1:
+            if arg_name in seen_arg_names:
                 return "duplicate argument '%s' in function definition" % arg_name
+            seen_arg_names.add(arg_name)
 
         return None
 


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Replaces the quadratic duplicate-argument check in `ParameterSpec.checkParametersValid()` with a single linear pass.

The old code called `arg_names.count(arg_name)` for every parameter name, re-scanning the whole parameter list once per parameter (`O(n²)`). It now tracks already-seen names in a `set()` and reports on the first repeat (`O(n)`).

```diff
-        # Check for duplicate arguments, could happen.
-        for arg_name in arg_names:
-            if arg_names.count(arg_name) != 1:
-                return "duplicate argument '%s' in function definition" % arg_name
+        # Check for duplicate arguments, could happen. Track seen names in a set
+        # for a single pass, rather than re-scanning the whole list per name,
+        # and report the first repeated name, which matches CPython's own error.
+        seen_arg_names = set()
+        for arg_name in arg_names:
+            if arg_name in seen_arg_names:
+                return "duplicate argument '%s' in function definition" % arg_name
+            seen_arg_names.add(arg_name)
```

Kept Python 2.6-compatible (`set()`, no comprehensions/literals).

**Behavior note:** for the (source-unreachable) case of two *distinct* duplicated names, e.g. `def f(a, b, b, a)`, the old code reported `'a'`; this reports `'b'`, which is exactly what CPython's own parser reports. All cases reachable from valid Python source are unchanged (CPython rejects the first duplicate before Nuitka ever builds the spec).

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3940.

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [x] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: `develop`.
- [x] **Formatting**: Ran `./bin/autoformat-nuitka-source` (no changes needed) and `./bin/check-nuitka-with-pylint` (clean).
- [x] **Tests**: Verified via reproducer (see evidence). Compilation still works. No dedicated regression test added — this code path is defensive (valid Python source cannot reach it, CPython rejects duplicate args at parse time).
- [ ] **New Coverage**: n/a — see above.
- [ ] **Documentation**: n/a.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: Issue #3940 already existed and specifies the intended direction ("single pass with a `set()`-based membership check").
  - [x] **Documentation**: Prompts used (paraphrased):
    - "Look at open issues, check for easy code fixes, reproduce them and if possible fix them."
    - "Install black, make sure it passes black too."
    - "Commit this, open PR if you are certain it fixes the issue."
  - [x] **Verification**: Manually verified. The change is a straightforward `O(n²)`→`O(n)` rewrite; I confirmed the emitted error string is byte-identical and that the reported duplicate name now matches CPython's parser.
  - [x] **Evidence**:

    Correctness (current `count` impl vs new `set` impl), reported duplicate name:

    ```
    ('a', 'b', 'c')       -> None            (same)
    ('a', 'a')            -> 'a'             (same)
    ('a', 'b', 'a')       -> 'a'             (same)
    ('a', 'b', 'b', 'a')  -> old 'a' / new 'b'   (new matches CPython)
    ()                    -> None            (same)
    ```

    CPython reference for the differing case:

    ```
    def f(a,b,b,a): pass  -> SyntaxError: duplicate argument 'b' in function definition
    ```

    Performance (no-duplicate worst case, 200 iterations):

    ```
    n=100    count=0.0116s  set=0.0007s   16x
    n=500    count=0.2752s  set=0.0032s   87x
    n=2000   count=4.4523s  set=0.0221s  201x
    ```

## Summary by Sourcery

Optimize duplicate parameter detection in ParameterSpec to run in linear time and align the reported duplicate name with CPython’s behavior.

Enhancements:
- Replace quadratic duplicate-argument validation with a single-pass set-based check in ParameterSpec.
- Adjust duplicate-argument reporting to return the first repeated parameter name, matching CPython’s parser semantics.