### PR TITLE
Quality: Avoid recursion in tree visiting for deep node trees

### DIFF
--- a/nuitka/tree/Operations.py
+++ b/nuitka/tree/Operations.py
@@ -10,15 +10,29 @@ You can visit a scope, a tree (module), or every scope of a tree (module).
 
 
 def visitTree(tree, visitor):
-    visitor.onEnterNode(tree)
+    # Iterative pre-/post-order traversal using an explicit stack, so that very
+    # deeply nested node trees do not exceed the Python recursion limit, which
+    # the previous per-node recursion did.
+    stack = [(tree, False)]
 
-    for visitable in tree.getVisitableNodes():
-        if visitable is None:
-            raise AssertionError("'None' child encountered", tree, tree.source_ref)
+    while stack:
+        node, children_visited = stack.pop()
 
-        visitTree(visitable, visitor)
+        if children_visited:
+            visitor.onLeaveNode(node)
+            continue
 
-    visitor.onLeaveNode(tree)
+        visitor.onEnterNode(node)
+
+        # Revisit this node for the leave call once its children are done, then
+        # push the children in reverse, so they are visited left to right.
+        stack.append((node, True))
+
+        for visitable in reversed(node.getVisitableNodes()):
+            if visitable is None:
+                raise AssertionError("'None' child encountered", node, node.source_ref)
+
+            stack.append((visitable, False))
 
 
 class VisitorNoopMixin(object):


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Rewrites `visitTree()` in `nuitka/tree/Operations.py` from per-node recursion to an iterative traversal using an explicit stack, so deep node trees can no longer exceed the Python recursion limit.

```diff
-def visitTree(tree, visitor):
-    visitor.onEnterNode(tree)
-
-    for visitable in tree.getVisitableNodes():
-        if visitable is None:
-            raise AssertionError("'None' child encountered", tree, tree.source_ref)
-
-        visitTree(visitable, visitor)
-
-    visitor.onLeaveNode(tree)
+def visitTree(tree, visitor):
+    stack = [(tree, False)]
+
+    while stack:
+        node, children_visited = stack.pop()
+
+        if children_visited:
+            visitor.onLeaveNode(node)
+            continue
+
+        visitor.onEnterNode(node)
+        stack.append((node, True))
+
+        for visitable in reversed(node.getVisitableNodes()):
+            if visitable is None:
+                raise AssertionError("'None' child encountered", node, node.source_ref)
+            stack.append((visitable, False))
```

Semantics preserved: pre-order `onEnterNode` / post-order `onLeaveNode`, left-to-right child order, and the `None`-child assertion (with the same parent context in the message). Python 2.6-compatible (no comprehensions/literals). Used by finalization, variable closure and function inlining.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3934 ("prevent RecursionError on deep trees").

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: `develop`.
- [x] **Formatting**: Ran `./bin/autoformat-nuitka-source` (no changes needed) and `./bin/check-nuitka-with-pylint` (clean).
- [x] **Tests**: Existing compilation still works (compiled and ran a nested-closure module through `bin/nuitka --module`, output matches CPython). Behaviour verified equivalent to the old recursion (see evidence).
- [ ] **New Coverage**: No committed unit test — Nuitka has no unit-test harness for this internal traversal helper; reproduction provided below as evidence instead.
- [ ] **Documentation**: n/a.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: Issue #3934 already existed and names the target file/behaviour.
  - [x] **Documentation**: Prompts used (paraphrased):
    - "Look at open issues, check for easy code fixes, reproduce them and if possible fix them."
    - "Commit this, open PR if you are certain it fixes the issue."
    - "If #3934 can be reproduced and you are certain this has fixed it, make a PR."
  - [x] **Verification**: Manually verified. Confirmed enter/leave order, child order and the `None`-child guard are unchanged.
  - [x] **Evidence**:

    **1. Reproduction with real Nuitka nodes** — a depth-6000 chain of real `ExpressionOperationNot` nodes wrapping a constant leaf, at the default recursion limit (1000):

    ```
    recursion limit: 1000 depth: 6000
    OLD recursive visitTree: RecursionError  <-- bug reproduced
    NEW visitTree: enters=6001 leaves=6001 expected=6001  OK
    ```

    **2. Equivalence** — over 500 randomly-shaped trees, the old recursive and new iterative implementations produce byte-identical `(enter/leave, node)` sequences; the `None`-child `AssertionError` is still raised.

    **3. End-to-end** — `bin/nuitka --module` on a nested-closure module (exercises `visitTree` via variable closure + finalization) compiles and the resulting extension runs, matching CPython output.

    > **Note on source-level reproduction:** a purely source-driven crash is not reachable, because `buildParseTree` in `nuitka/tree/Building.py` catches the AST-building `RecursionError` first and raises `CodeTooComplexCode`. The deep-tree condition this fixes arises from internally constructed/transformed trees, hence the real-node reproduction above.

## Summary by Sourcery

Replace recursive tree traversal with an iterative stack-based implementation to prevent recursion errors on very deep node trees.

Bug Fixes:
- Prevent RecursionError when visiting deeply nested node trees by avoiding per-node recursion in visitTree().

Enhancements:
- Preserve pre-/post-order visiting semantics and child ordering while using an explicit stack-based traversal in visitTree().