### PR TITLE
UI: Python flag values and verbosity levels for "trace_imports"

### DIFF
--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -73,6 +73,7 @@ from nuitka.options.Options import (
     getOutputDir,
     getPgoArgs,
     getPositionalArgs,
+    getPythonFlagTraceImportsValue,
     getPythonPgoInput,
     getShallFollowExtra,
     getShallFollowExtraFilePatterns,
@@ -834,7 +835,7 @@ def runSconsBackend():
         scons_options["python_sysflag_no_site"] = asBoolStr(True)
 
     if hasPythonFlagTraceImports():
-        scons_options["python_sysflag_verbose"] = asBoolStr(True)
+        scons_options["python_sysflag_verbose"] = str(getPythonFlagTraceImportsValue())
 
     if hasPythonFlagNoRandomization():
         scons_options["python_sysflag_no_randomization"] = asBoolStr(True)

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -105,7 +105,7 @@ python_sysflag_bytes_warning = getArgumentBool("python_sysflag_bytes_warning", F
 # python_sysflag_no_site
 python_sysflag_no_site = getArgumentBool("python_sysflag_no_site", False)
 # python_sysflag_verbose
-python_sysflag_verbose = getArgumentBool("python_sysflag_verbose", False)
+python_sysflag_verbose = getArgumentInt("python_sysflag_verbose", 0)
 # python_sysflag_unicode
 python_sysflag_unicode = getArgumentBool("python_sysflag_unicode", False)
 # python_sysflag_utf8
@@ -446,7 +446,7 @@ def createBuildDefinitionsFile():
 
     env.build_definitions["SYSFLAG_NO_SITE"] = 1 if python_sysflag_no_site else 0
 
-    env.build_definitions["SYSFLAG_VERBOSE"] = 1 if python_sysflag_verbose else 0
+    env.build_definitions["SYSFLAG_VERBOSE"] = python_sysflag_verbose
 
     env.build_definitions["SYSFLAG_UTF8"] = 1 if python_sysflag_utf8 else 0
 

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -187,9 +187,11 @@ enforces a specific mode. These are options that also exist to standard
 Python executable. Currently supported: "-S" (alias "no_site"),
 "static_hashes" (do not use hash randomization), "no_warnings" (do not
 give Python run time warnings), "-O" (alias "no_asserts"), "no_docstrings"
-(do not use doc strings), "-u" (alias "unbuffered"), "isolated" (do not
-load outside code), "-P" (alias "safe_path", do not used current directory
-in module search) and "-m" (package mode, compile as "package.__main__").
+(do not use doc strings), "-u" (alias "unbuffered"), "-v" (alias
+"trace_imports", trace imports, repeat as "-vv" for more verbosity, or give
+the level directly with "trace_imports=2"), "isolated" (do not load outside
+code), "-P" (alias "safe_path", do not used current directory in module
+search) and "-m" (package mode, compile as "package.__main__").
 Default empty.""",
 )
 

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -2823,53 +2823,89 @@ def shallMacOSProhibitMultipleInstances():
 _python_flags = None
 
 
+def _splitPythonFlagValue(part):
+    """Split a python flag into its name and its value if any was given.
+
+    Values are given with "=" separator, e.g. "trace_imports=2", and the
+    value is *None* for flags given without one, where the flag specific
+    default is used, normally 1.
+    """
+
+    if "=" not in part:
+        return part, None
+
+    part, value = part.split("=", 1)
+
+    try:
+        value = int(value)
+    except ValueError:
+        return options_logger.sysexit(
+            "Python flag '%s' needs an integer value, not '%s'." % (part, value)
+        )
+
+    return part, value
+
+
 def _getPythonFlags():
-    """*list*, values of ``--python-flag``"""
+    """*dict*, values of ``--python-flag`` mapped to their integer values"""
     # There is many flags, pylint: disable=too-many-branches
 
     # singleton, pylint: disable=global-statement
     global _python_flags
 
     if _python_flags is None:
-        _python_flags = set()
+        _python_flags = {}
 
         for parts in options.python_flags:
             for part in parts.split(","):
+                part, value = _splitPythonFlagValue(part)
+
+                # Python allows repeating "-v" for more verbosity, e.g. "-vv",
+                # in which case the number of them is the value used.
+                if part.startswith("-v") and part.count("v") == len(part) - 1:
+                    if value is None:
+                        value = len(part) - 1
+
+                    part = "trace_imports"
+
+                if value is None:
+                    value = 1
+
                 if part in ("-S", "nosite", "no_site"):
-                    _python_flags.add("no_site")
+                    _python_flags["no_site"] = value
                 elif part in ("site",):
                     if "no_site" in _python_flags:
-                        _python_flags.remove("no_site")
+                        del _python_flags["no_site"]
                 elif part in (
                     "-R",
                     "static_hashes",
                     "norandomization",
                     "no_randomization",
                 ):
-                    _python_flags.add("no_randomization")
-                elif part in ("-v", "trace_imports", "trace_import"):
-                    _python_flags.add("trace_imports")
+                    _python_flags["no_randomization"] = value
+                elif part in ("trace_imports", "trace_import"):
+                    _python_flags["trace_imports"] = value
                 elif part in ("no_warnings", "nowarnings"):
-                    _python_flags.add("no_warnings")
+                    _python_flags["no_warnings"] = value
                 elif part in ("-O", "no_asserts", "noasserts"):
-                    _python_flags.add("no_asserts")
+                    _python_flags["no_asserts"] = value
                 elif part in ("no_docstrings", "nodocstrings"):
-                    _python_flags.add("no_docstrings")
+                    _python_flags["no_docstrings"] = value
                 elif part in ("-OO",):
-                    _python_flags.add("no_docstrings")
-                    _python_flags.add("no_asserts")
+                    _python_flags["no_docstrings"] = value
+                    _python_flags["no_asserts"] = value
                 elif part in ("no_annotations", "noannotations"):
-                    _python_flags.add("no_annotations")
+                    _python_flags["no_annotations"] = value
                 elif part in ("unbuffered", "-u"):
-                    _python_flags.add("unbuffered")
+                    _python_flags["unbuffered"] = value
                 elif part in ("-m", "package_mode"):
-                    _python_flags.add("package_mode")
+                    _python_flags["package_mode"] = value
                 elif part in ("-I", "isolated"):
-                    _python_flags.add("isolated")
+                    _python_flags["isolated"] = value
                 elif part in ("-B", "dont_write_bytecode", "dontwritebytecode"):
-                    _python_flags.add("dontwritebytecode")
+                    _python_flags["dontwritebytecode"] = value
                 elif part in ("-P", "safe_path"):
-                    _python_flags.add("safe_path")
+                    _python_flags["safe_path"] = value
                 else:
                     return options_logger.sysexit(
                         "Unsupported python flag '%s'." % part
@@ -2878,76 +2914,92 @@ def _getPythonFlags():
     return _python_flags
 
 
+def _getPythonFlagValue(flag_name):
+    """*int*, value of the given python flag, 0 if it was not given"""
+
+    return _getPythonFlags().get(flag_name, 0)
+
+
 def hasPythonFlagNoSite():
     """*bool* = "no_site" in python flags given"""
 
-    return "no_site" in _getPythonFlags()
+    return _getPythonFlagValue("no_site") > 0
 
 
 def hasPythonFlagNoAnnotations():
     """*bool* = "no_annotations" in python flags given"""
 
-    return "no_annotations" in _getPythonFlags()
+    return _getPythonFlagValue("no_annotations") > 0
 
 
 def hasPythonFlagNoAsserts():
     """*bool* = "no_asserts" in python flags given"""
 
-    return "no_asserts" in _getPythonFlags()
+    return _getPythonFlagValue("no_asserts") > 0
 
 
 def hasPythonFlagNoDocStrings():
     """*bool* = "no_docstrings" in python flags given"""
 
-    return "no_docstrings" in _getPythonFlags()
+    return _getPythonFlagValue("no_docstrings") > 0
 
 
 def hasPythonFlagNoWarnings():
     """*bool* = "no_warnings" in python flags given"""
 
-    return "no_warnings" in _getPythonFlags()
+    return _getPythonFlagValue("no_warnings") > 0
 
 
 def hasPythonFlagIsolated():
     """*bool* = "isolated" in python flags given"""
 
-    return "isolated" in _getPythonFlags()
+    return _getPythonFlagValue("isolated") > 0
 
 
 def hasPythonFlagTraceImports():
     """*bool* = "trace_imports", "-v" in python flags given"""
 
-    return "trace_imports" in _getPythonFlags()
+    return _getPythonFlagValue("trace_imports") > 0
+
+
+def getPythonFlagTraceImportsValue():
+    """*int* = value of "trace_imports", "-v" python flag, 0 if not given
+
+    The value is the verbosity level, e.g. 2 for "-vv" like with standard
+    Python, or given directly with "trace_imports=2".
+    """
+
+    return _getPythonFlagValue("trace_imports")
 
 
 def hasPythonFlagNoRandomization():
     """*bool* = "no_randomization", "-R", "static_hashes" in python flags given"""
 
-    return "no_randomization" in _getPythonFlags()
+    return _getPythonFlagValue("no_randomization") > 0
 
 
 def hasPythonFlagNoBytecodeRuntimeCache():
     """*bool* = "dontwritebytecode", "-B" in python flags given"""
 
-    return "dontwritebytecode" in _getPythonFlags()
+    return _getPythonFlagValue("dontwritebytecode") > 0
 
 
 def hasPythonFlagNoCurrentDirectoryInPath():
     """*bool* = "safe_path", "-P" in python flags given"""
 
-    return "safe_path" in _getPythonFlags()
+    return _getPythonFlagValue("safe_path") > 0
 
 
 def hasPythonFlagUnbuffered():
     """*bool* = "unbuffered", "-u" in python flags given"""
 
-    return "unbuffered" in _getPythonFlags()
+    return _getPythonFlagValue("unbuffered") > 0
 
 
 def hasPythonFlagPackageMode():
     """*bool* = "package_mode", "-m" in python flags given"""
 
-    return "package_mode" in _getPythonFlags()
+    return _getPythonFlagValue("package_mode") > 0
 
 
 def shallNotUseDependsExeCachedResults():


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Makes `--python-flag` values carry an optional integer value, and uses that to support the repeated verbose forms (`-vv`, `-vvv`) with an actual verbosity level, rather than collapsing them onto a single boolean.

Following the review feedback, this no longer just silences the error:

* Flag values are now generic: `--python-flag=name=value`, e.g. `--python-flag=trace_imports=2`. A flag given without a value has the value `1`, a flag not given at all has the value `0`. `_getPythonFlags()` therefore returns a mapping of flag name to integer value, and `_getPythonFlagValue()` always returns an integer, so this can be reused for other flags that want levels.

* `-v` may be repeated like with the standard Python executable, and the number of `v` characters is the value, i.e. `-vv` is the same as `trace_imports=2`.

* `python_sysflag_verbose` became a number and is passed through as such, so `SYSFLAG_VERBOSE` and therefore `Py_VerboseFlag` receive the actual level. The Python importer, which is used for some things, honors the higher levels, so the behavior is now compatible with what standard Python does, and not just an accepted-and-ignored flag.

```
$ nuitka anyfile.py --python-flag=-vv     # sys.flags.verbose == 2
$ nuitka anyfile.py --python-flag=trace_imports=2  # same thing
```

Booleans helpers like `hasPythonFlagTraceImports()` remain, they are now `value > 0`, and `getPythonFlagTraceImportsValue()` gives the level.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #2159.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: `develop`.
- [x] **Formatting**: Ran `./bin/autoformat-nuitka-source` (no changes needed) and `./bin/check-nuitka-with-pylint` (clean).
- [x] **Tests**: Verified by compilation and by running the result, see evidence below.
- [ ] **New Coverage**: n/a.
- [x] **Documentation**: `--python-flag` help text now mentions `-v` / `trace_imports` and the value form.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: Issue #2159 already existed (labelled `help wanted`).
  - [x] **Documentation**: Prompts used (paraphrased):
    - "Look at open issues, check for easy code fixes, reproduce them and if possible fix them."
    - "Look for other issues you can easily fix; it shouldn't have been attempted already."
    - "Widen the search for something small and untaken."
    - "Look at the review comments on the PR and address them."
  - [x] **Verification**: Manually verified, see evidence.
  - [x] **Evidence**:

    Option parsing:

    ```
    -v                -> {'trace_imports': 1}
    -vv               -> {'trace_imports': 2}
    -vvv              -> {'trace_imports': 3}
    trace_imports     -> {'trace_imports': 1}
    trace_imports=2   -> {'trace_imports': 2}
    -vx               -> FATAL: Unsupported python flag '-vx'.
    trace_imports=x   -> FATAL: Python flag 'trace_imports' needs an integer value, not 'x'.
    ```

    Compiling `print(sys.flags.verbose)` with `--python-flag=-vv` gives `#define SYSFLAG_VERBOSE 2` in `build_definitions.h`, and the compiled binary prints `2`, with the import tracing of the Python importer at that level, matching uncompiled `python -vv`.
