### PR TITLE
Plugins: Add option to exclude PIL image formats (#3894)

### DIFF
--- a/nuitka/plugins/standard/AntiBloatPlugin.py
+++ b/nuitka/plugins/standard/AntiBloatPlugin.py
@@ -51,6 +51,7 @@ class NuitkaPluginAntiBloat(NuitkaYamlPluginBase):
         noinclude_dask_mode,
         noinclude_numba_mode,
         noinclude_default_mode,
+        noinclude_pil_image_formats,
         custom_choices,
         show_changes,
     ):
@@ -240,6 +241,27 @@ instead of '--noinclude-custom-mode=%s'""" % (module_name, custom_choice))
             if mode == "allow":
                 self.control_tags["use_%s" % module_name] = True
 
+        # Image format plugins of PIL/Pillow to exclude from being followed,
+        # given as their format plugin base names without the "ImagePlugin"
+        # suffix and lower cased, e.g. "avif". Consumed by the "PIL.Image"
+        # variable config in the standard package configuration.
+        if noinclude_pil_image_formats:
+            self.pil_excluded_image_formats = tuple(
+                sorted(
+                    set(
+                        image_format.strip().lstrip(".").lower()
+                        for image_format in noinclude_pil_image_formats.split(",")
+                        if image_format.strip()
+                    )
+                )
+            )
+        else:
+            self.pil_excluded_image_formats = ()
+
+        self.control_tags["pil_excluded_image_formats"] = (
+            self.pil_excluded_image_formats
+        )
+
         self.handled_module_namespaces = {}
 
         for handled_module_name, (
@@ -273,7 +295,9 @@ instead of '--noinclude-custom-mode=%s'""" % (module_name, custom_choice))
         self.context_codes = {}
 
         # Precompute this for getCacheContributionValues to avoid sorting each time
-        self.handled_modules_hash = str(tuple(sorted(self.handled_modules.items())))
+        self.handled_modules_hash = str(
+            tuple(sorted(self.handled_modules.items()))
+        ) + str(self.pil_excluded_image_formats)
 
     def getEvaluationConditionControlTags(self):
         return self.control_tags
@@ -399,6 +423,20 @@ can be used to turn all of these on.""",
 What to do if a specific import is encountered. Format is module name,
 which can and should be a top level package and then one choice, "error",
 "warning", "nofollow", e.g. PyQt5:error.""",
+        )
+
+        group.add_option(
+            "--noinclude-pil-image-formats",
+            action="store",
+            dest="noinclude_pil_image_formats",
+            metavar="FORMATS",
+            default=None,
+            help="""\
+Comma separated list of PIL/Pillow image format plugins to not include. Use
+this to avoid unused image formats, whose support can be several MB in size,
+most notably 'avif'. Names are the format plugin base names, lower cased and
+without the "ImagePlugin" suffix, e.g. 'avif', 'webp', 'jpeg2k'. By default
+nothing is excluded and all available image formats are supported.""",
         )
 
     def _getContextCode(self, module_name, anti_bloat_config):

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -4479,12 +4479,17 @@
     - depends:
         - 'PIL._tkinter_finder'
 
-- module-name: 'PIL.Image' # checksum: fc233aba
+- module-name: 'PIL.Image' # checksum: 4117535f
+  constants:
+    declarations:
+      # Bridge the anti-bloat control tag (evaluated in Nuitka) into the
+      # runtime variable below (evaluated in the target Python).
+      'pil_excluded_image_formats': '(pil_excluded_image_formats)'
   variables:
     setup_code:
       - 'import PIL.Image'
     declarations:
-      'pil_image_plugins': 'tuple("PIL." + plugin for plugin in PIL.Image._plugins)'
+      'pil_image_plugins': 'tuple("PIL." + plugin for plugin in PIL.Image._plugins if plugin.replace("ImagePlugin", "").lower() not in pil_excluded_image_formats)'
   anti-bloat:
     - description: 'avoid Qt dependency'
       no-auto-follow:


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Adds a new anti-bloat option `--noinclude-pil-image-formats` that prevents selected
PIL/Pillow image format plugins from being followed.

Names are the format plugin base names, lower cased and without the `ImagePlugin`
suffix, and are comma separated, e.g.:

```
--noinclude-pil-image-formats=avif
--noinclude-pil-image-formats=avif,webp,jpeg2k
```

Mechanism:

- The option is parsed in the always-enabled `anti-bloat` plugin into the control tag
  `pil_excluded_image_formats`.
- The `PIL.Image` package configuration bridges that control tag (evaluated in Nuitka)
  into its existing runtime `pil_image_plugins` variable (evaluated in the target
  Python) via a `constants` declaration, and filters the automatically detected
  `PIL.Image._plugins` list by it.

Default behavior is unchanged: with no option given the control tag is an empty tuple,
so nothing is excluded and all available image formats are supported exactly as before.

## 🧐 Why was it initiated? Any relevant Issues?

Fixes the size regression reported in #3894.

Since Pillow 11.3.0, AVIF support (`PIL.AvifImagePlugin` → `PIL._avif`) is bundled in the
wheels. Its extension module is very large (7.5&nbsp;MB on `cp314-win_amd64`, codecs
statically linked), and Nuitka follows every entry of `PIL.Image._plugins`
unconditionally, so it was pulled in even when the program never uses AVIF. This option
gives users a way to drop such unused formats.

A deny-list was chosen over an allow-list on purpose: PIL format plugins have hard
inter-imports (e.g. `MpoImagePlugin` does `from . import JpegImagePlugin`), so a naive
allow-list could break at runtime, whereas dropping a specific unused format is safe.

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 🧹 Refactoring
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: `develop`.
- [x] **Formatting**: executed `./bin/autoformat-nuitka-source` (no changes needed) and
  `python -m nuitka.tools.quality.yamllint --update-checksum` for the YAML config.
- [ ] **Tests**: Verified manually via standalone builds (see Evidence) and
  `check-nuitka-with-pylint`; the full test suite was not run locally, leaving that to CI.
- [ ] **New Coverage**: No automated test added; verification was done via manual
  standalone build comparison (Evidence below). Happy to add a test if you can point me
  at the preferred place for anti-bloat option coverage.
- [ ] **Documentation**: The option is self-documented via its `--help` text.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: Issue #3894 pre-existed and identified the root cause and the
    desired direction (a way to select PIL image formats).
  - [x] **Documentation**: Prompts used (paraphrased, in order):
    1. "Take a look at issue #3894." → analyze the issue and root cause.
    2. "Dig deeper." → confirm the offending module (`_avif`), the Pillow version that
       introduced it, sizes of all format plugins, and the inclusion mechanism.
    3. "Go ahead and implement it." → add an option to exclude PIL image formats,
       basing the work on the `factory` branch and reusing the anti-bloat control-tag
       plumbing; default must stay backward compatible.
    4. "Make a PR, but make sure this wasn't PR'd already." → verify no existing
       PR/factory commit already does this, then open against `develop`.
  - [x] **Verification**: Manually reviewed and understood; the deny-list vs allow-list
    trade-off and the Nuitka-side/target-Python evaluation split were deliberate.
  - [x] **Evidence**: Standalone build of a minimal `from PIL import Image, ImageDraw`
    program (Pillow 12.2.0, Python 3.14, Windows), before vs. after the option:

    | build | `AvifImagePlugin` in report | `_avif.pyd` in dist | dist size |
    |-------|:---:|:---:|:---:|
    | default (no option) | yes | yes | 40 MB |
    | `--noinclude-pil-image-formats=avif` | no | no | **32 MB** |

    An 8&nbsp;MB reduction, with all other formats still present. The default build is
    byte-for-byte the same set of 47 followed plugins as before this change.

## Summary by Sourcery

Add a configurable anti-bloat option to exclude specific PIL/Pillow image format plugins from being included in builds and wire it through the PIL.Image package configuration.

New Features:
- Introduce the --noinclude-pil-image-formats option to omit selected PIL/Pillow image format plugins from inclusion.
- Propagate excluded PIL image formats into the PIL.Image plugin list via a new pil_excluded_image_formats control tag and constant.

Enhancements:
- Include excluded PIL image formats in the anti-bloat plugin cache contribution hash to ensure correct cache invalidation.