### PR TITLE
Support annotationlib.ForwardRef constants on Python 3.14

### DIFF
--- a/nuitka/Serialization.py
+++ b/nuitka/Serialization.py
@@ -34,6 +34,11 @@ from nuitka.OutputDirectories import getSourceDirectoryPath
 from nuitka.PythonVersions import python_version
 from nuitka.utils.FileOperations import getNormalizedPathJoin, openPickleFile
 
+try:
+    import annotationlib
+except ImportError:
+    annotationlib = None
+
 
 class BuiltinAnonValue(object):
     """Used to pickle anonymous values."""
@@ -63,6 +68,15 @@ class BuiltinUnionTypeValue(object):
 
     def __init__(self, args):
         self.args = args
+
+
+class BuiltinForwardRefValue(object):
+    """For transporting annotationlib.ForwardRef values through pickler."""
+
+    def __init__(self, arg, module, is_class):
+        self.arg = arg
+        self.module = module
+        self.is_class = is_class
 
 
 class BuiltinSpecialValue(object):
@@ -106,6 +120,16 @@ def _pickleUnionType(pickler, value):
     pickler.save(BuiltinUnionTypeValue(args=value.__args__))
 
 
+def _pickleForwardRef(pickler, value):
+    pickler.save(
+        BuiltinForwardRefValue(
+            arg=value.__forward_arg__,
+            module=value.__forward_module__,
+            is_class=value.__forward_is_class__,
+        )
+    )
+
+
 class ConstantStreamWriter(object):
     """Write constants to a stream and return numbers for them."""
 
@@ -132,6 +156,9 @@ class ConstantStreamWriter(object):
 
         if python_version >= 0x3A0:
             self.pickle.dispatch[UnionType] = _pickleUnionType
+
+        if python_version >= 0x3E0 and annotationlib is not None:
+            self.pickle.dispatch[annotationlib.ForwardRef] = _pickleForwardRef
 
     def addConstantValue(self, constant_value):
         self.pickle.dump(constant_value)

--- a/nuitka/build/ConstantBlobFormat.py
+++ b/nuitka/build/ConstantBlobFormat.py
@@ -55,6 +55,7 @@ _tag_define_names = (
     ("blob_data", "NUITKA_CONSTANT_BLOB_TAG_BLOB_DATA"),
     ("generic_alias", "NUITKA_CONSTANT_BLOB_TAG_GENERIC_ALIAS"),
     ("union_type", "NUITKA_CONSTANT_BLOB_TAG_UNION_TYPE"),
+    ("forward_ref", "NUITKA_CONSTANT_BLOB_TAG_FORWARD_REF"),
     ("builtin_named", "NUITKA_CONSTANT_BLOB_TAG_BUILTIN_NAMED"),
     ("builtin_exception", "NUITKA_CONSTANT_BLOB_TAG_BUILTIN_EXCEPTION"),
     ("code_object", "NUITKA_CONSTANT_BLOB_TAG_CODE_OBJECT"),

--- a/nuitka/build/include/nuitka/constants_blob_spec.h
+++ b/nuitka/build/include/nuitka/constants_blob_spec.h
@@ -42,6 +42,7 @@
 #define NUITKA_CONSTANT_BLOB_TAG_BLOB_DATA 0x58                 /* 'X' */
 #define NUITKA_CONSTANT_BLOB_TAG_GENERIC_ALIAS 0x41             /* 'A' */
 #define NUITKA_CONSTANT_BLOB_TAG_UNION_TYPE 0x48                /* 'H' */
+#define NUITKA_CONSTANT_BLOB_TAG_FORWARD_REF 0x52               /* 'R' */
 #define NUITKA_CONSTANT_BLOB_TAG_BUILTIN_NAMED 0x4f             /* 'O' */
 #define NUITKA_CONSTANT_BLOB_TAG_BUILTIN_EXCEPTION 0x45         /* 'E' */
 #define NUITKA_CONSTANT_BLOB_TAG_CODE_OBJECT 0x43               /* 'C' */

--- a/nuitka/build/static_src/HelpersConstantsBlob.c
+++ b/nuitka/build/static_src/HelpersConstantsBlob.c
@@ -69,6 +69,23 @@ static PyObject *set_cache = NULL;
 
 static PyObject *frozenset_cache = NULL;
 
+#if PYTHON_VERSION >= 0x3e0
+static PyObject *annotationlib_forward_ref_type = NULL;
+
+static PyObject *getAnnotationlibForwardRefType(void) {
+    if (annotationlib_forward_ref_type == NULL) {
+        PyObject *annotationlib_module = PyImport_ImportModule("annotationlib");
+        CHECK_OBJECT(annotationlib_module);
+
+        annotationlib_forward_ref_type = PyObject_GetAttrString(annotationlib_module, "ForwardRef");
+        Py_DECREF(annotationlib_module);
+        CHECK_OBJECT(annotationlib_forward_ref_type);
+    }
+
+    return annotationlib_forward_ref_type;
+}
+#endif
+
 // Use our own non-random hash for some of the things to be fast. This is inspired
 // from the original Python2 hash func, but we are mostly using it on pointer values
 static Py_hash_t Nuitka_FastHashBytes(const void *value, Py_ssize_t size) {
@@ -1132,6 +1149,27 @@ static unsigned char const *_unpackBlobConstantObjectUnionType(PyThreadState *ts
 }
 #endif
 
+#if PYTHON_VERSION >= 0x3e0
+static unsigned char const *_unpackBlobConstantObjectForwardRef(PyThreadState *tstate, void **output,
+                                                                unsigned char const *data) {
+    PyObject *items[3];
+    data = _unpackBlobConstantsAt(tstate, items, data, 3);
+
+    PyObject *args = MAKE_TUPLE1(tstate, items[0]);
+    PyObject *kwargs = MAKE_DICT_EMPTY(tstate);
+
+    PyDict_SetItemString(kwargs, "module", items[1]);
+    PyDict_SetItemString(kwargs, "is_class", items[2]);
+
+    PyObject *forward_ref = PyObject_Call(getAnnotationlibForwardRefType(), args, kwargs);
+    Py_DECREF(args);
+    Py_DECREF(kwargs);
+
+    _finalizeUnpackedConstantObject(output, forward_ref);
+    return data;
+}
+#endif
+
 static unsigned char const *_unpackBlobConstantObjectCodeObject(PyThreadState *tstate, void **output,
                                                                 unsigned char const *data) {
     uint64_t flags = _unpackVariableLength(&data);
@@ -1431,6 +1469,12 @@ static unsigned char const *_unpackBlobConstant(PyThreadState *tstate, void **ou
 #if PYTHON_VERSION >= 0x3a0
     case NUITKA_CONSTANT_BLOB_TAG_UNION_TYPE: {
         data = _unpackBlobConstantObjectUnionType(tstate, output, data);
+        break;
+    }
+#endif
+#if PYTHON_VERSION >= 0x3e0
+    case NUITKA_CONSTANT_BLOB_TAG_FORWARD_REF: {
+        data = _unpackBlobConstantObjectForwardRef(tstate, output, data);
         break;
     }
 #endif

--- a/nuitka/build/static_src/HelpersDeepcopy.c
+++ b/nuitka/build/static_src/HelpersDeepcopy.c
@@ -125,6 +125,10 @@ typedef struct {
 PyTypeObject *Nuitka_PyUnion_Type;
 #endif
 
+#if PYTHON_VERSION >= 0x3e0
+PyTypeObject *Nuitka_PyForwardRef_Type;
+#endif
+
 static PyObject *_makeDeepCopyFunctionCapsule(copy_func func) { return Nuitka_CapsuleNew((void *)func); }
 
 static void _initDeepCopy(PyThreadState *tstate) {
@@ -161,6 +165,19 @@ static void _initDeepCopy(PyThreadState *tstate) {
         Py_DECREF(args_tuple);
     }
 
+#endif
+
+#if PYTHON_VERSION >= 0x3e0
+    {
+        PyObject *annotationlib_module = PyImport_ImportModule("annotationlib");
+        CHECK_OBJECT(annotationlib_module);
+
+        Nuitka_PyForwardRef_Type = (PyTypeObject *)PyObject_GetAttrString(annotationlib_module, "ForwardRef");
+        Py_DECREF(annotationlib_module);
+        CHECK_OBJECT(Nuitka_PyForwardRef_Type);
+
+        PyDict_SetItem(_deep_copy_dispatch, (PyObject *)Nuitka_PyForwardRef_Type, _deep_noop);
+    }
 #endif
 
 #if PYTHON_VERSION < 0x300
@@ -459,6 +476,27 @@ Py_hash_t DEEP_HASH(PyThreadState *tstate, PyObject *value) {
 
         result ^= DEEP_HASH(tstate, args);
         Py_DECREF(args);
+
+        return result;
+#endif
+#if PYTHON_VERSION >= 0x3e0
+    } else if (Py_TYPE(value) == Nuitka_PyForwardRef_Type) {
+        Py_hash_t result = DEEP_HASH_INIT(tstate, value);
+
+        PyObject *arg = PyObject_GetAttrString(value, "__forward_arg__");
+        CHECK_OBJECT(arg);
+        result ^= DEEP_HASH(tstate, arg);
+        Py_DECREF(arg);
+
+        PyObject *module = PyObject_GetAttrString(value, "__forward_module__");
+        CHECK_OBJECT(module);
+        result ^= DEEP_HASH(tstate, module);
+        Py_DECREF(module);
+
+        PyObject *is_class = PyObject_GetAttrString(value, "__forward_is_class__");
+        CHECK_OBJECT(is_class);
+        result ^= DEEP_HASH(tstate, is_class);
+        Py_DECREF(is_class);
 
         return result;
 #endif

--- a/nuitka/code_generation/Namify.py
+++ b/nuitka/code_generation/Namify.py
@@ -17,9 +17,15 @@ from types import BuiltinFunctionType
 from nuitka.__past__ import GenericAlias, UnionType, long, md5, unicode, xrange
 from nuitka.Builtins import builtin_anon_values, builtin_named_values_list
 from nuitka.nodes.CodeObjectSpecs import CodeObjectSpec
+from nuitka.PythonVersions import python_version
 from nuitka.Tracing import general
 
 from .SpecialConstantData import BlobData
+
+try:
+    import annotationlib
+except ImportError:
+    annotationlib = None
 
 
 class ExceptionCannotNamify(Exception):
@@ -174,6 +180,12 @@ def namifyConstant(constant):
         )
     elif constant_type is UnionType:
         return "uniontype_%s" % namifyConstant(constant.__args__)
+    elif python_version >= 0x3E0 and annotationlib is not None and constant_type is annotationlib.ForwardRef:
+        return "forwardref_%s_%s_%s" % (
+            namifyConstant(constant.__forward_arg__),
+            namifyConstant(constant.__forward_module__),
+            namifyConstant(constant.__forward_is_class__),
+        )
     elif constant is sys.version_info:
         return "sys_version_info"
     elif constant_type is BlobData:

--- a/nuitka/code_generation/Namify.py
+++ b/nuitka/code_generation/Namify.py
@@ -180,7 +180,11 @@ def namifyConstant(constant):
         )
     elif constant_type is UnionType:
         return "uniontype_%s" % namifyConstant(constant.__args__)
-    elif python_version >= 0x3E0 and annotationlib is not None and constant_type is annotationlib.ForwardRef:
+    elif (
+        python_version >= 0x3E0
+        and annotationlib is not None
+        and constant_type is annotationlib.ForwardRef
+    ):
         return "forwardref_%s_%s_%s" % (
             namifyConstant(constant.__forward_arg__),
             namifyConstant(constant.__forward_module__),

--- a/nuitka/tools/data_composer/DataComposer.py
+++ b/nuitka/tools/data_composer/DataComposer.py
@@ -22,6 +22,7 @@ from nuitka.nodes.CodeObjectSpecs import CodeObjectSpec
 from nuitka.PythonVersions import python_version
 from nuitka.Serialization import (
     BuiltinAnonValue,
+    BuiltinForwardRefValue,
     BuiltinGenericAliasValue,
     BuiltinSpecialValue,
     BuiltinUnionTypeValue,
@@ -334,6 +335,12 @@ def _writeConstantValue(output, constant_value, blob_spec):
         output.write(blob_spec.tag_union_type)
         _last_written = None
         _writeConstantValue(output, constant_value.args, blob_spec)
+    elif constant_type is BuiltinForwardRefValue:
+        output.write(blob_spec.tag_forward_ref)
+        _last_written = None
+        _writeConstantValue(output, constant_value.arg, blob_spec)
+        _writeConstantValue(output, constant_value.module, blob_spec)
+        _writeConstantValue(output, constant_value.is_class, blob_spec)
     elif constant_value in builtin_named_values:
         output.write(blob_spec.tag_builtin_named)
         output.write(builtin_named_values[constant_value].encode("utf8"))

--- a/tests/basics/CallableForwardRefAliasTest314.py
+++ b/tests/basics/CallableForwardRefAliasTest314.py
@@ -1,0 +1,47 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Test Callable aliases that embed annotationlib.ForwardRef values."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+class CMapDecoder:
+    pass
+
+
+CMapResourceResolver = Callable[
+    [str], bytes | bytearray | memoryview | "CMapDecoder" | None
+]
+
+print("Alias:", CMapResourceResolver)
+
+union_value = CMapResourceResolver.__args__[1]
+print("Union:", union_value)
+
+forward_ref = union_value.__args__[3]
+print(
+    "ForwardRef:",
+    (
+        forward_ref.__forward_arg__,
+        forward_ref.__forward_module__,
+        forward_ref.__forward_is_class__,
+    ),
+)
+
+#     Python tests originally created or extracted from other peoples work. The
+#     parts were too small to be protected.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR teaches Nuitka's constant serialization and blob-loading machinery how to handle Python 3.14 `annotationlib.ForwardRef` objects.

The motivating case is a `Callable[...]` alias under `from __future__ import annotations` whose return annotation contains a union with a forward reference, for example:

```python
from __future__ import annotations

from collections.abc import Callable


class CMapDecoder:
    pass


CMapResourceResolver = Callable[
    [str], bytes | bytearray | memoryview | "CMapDecoder" | None
]
```

Before this change, Nuitka crashed while serializing constants because `annotationlib.ForwardRef.__getstate__()` includes a code object on Python 3.14, which is not pickleable in the current constant pipeline.

This PR adds:

- custom serialization support for `annotationlib.ForwardRef`
- constant blob encoding/decoding support for reconstructed `ForwardRef` values
- deep-copy/deep-hash handling for the reconstructed runtime type
- a regression test for the reported reproducer
- a follow-up cleanup so `ForwardRef` values can also be namified without warnings

## 🧐 Why was it initiated? Any relevant Issues?

This was initiated from the crash reported in:

- Fixes https://github.com/Nuitka/Nuitka/issues/3965

That issue includes the original minimal reproducer and the crash details.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: I have created an issue explaining the problem *before* using AI to generate a fix, ensuring the direction is correct.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective.

### Manual verification and test evidence

I verified the fix manually with the original reproducer and the added regression case.

Direct Python reproducer still behaves normally:

```sh
uv run python repros/nuitka_callable_forwardref_py314.py
```

Nuitka previously crashed on this command, and now compiles and runs it successfully:

```sh
uv run nuitka --run repros/nuitka_callable_forwardref_py314.py
```

Added regression test:

```sh
uv run python tests/basics/CallableForwardRefAliasTest314.py
uv run nuitka --run tests/basics/CallableForwardRefAliasTest314.py
```

Observed compiled output for the regression case:

```txt
Alias: collections.abc.Callable[[str], bytes | bytearray | memoryview | ForwardRef('CMapDecoder') | None]
Union: bytes | bytearray | memoryview | ForwardRef('CMapDecoder') | None
ForwardRef: ('CMapDecoder', None, False)
```

### Commit structure

This PR is split into two commits:

- `85ae46b10` `Support annotationlib.ForwardRef constants`
- `7281b7329` `Namify ForwardRef constants`

______________________________________________________________________

## Summary by Sourcery

Handle Python 3.14 annotationlib.ForwardRef objects as serializable constants and ensure they can be loaded, copied, hashed, and namified correctly.

Bug Fixes:
- Prevent crashes when serializing constants that include annotationlib.ForwardRef values on Python 3.14.

Enhancements:
- Extend constant blob format, serialization, and namification support to cover ForwardRef-based annotation values on Python 3.14.

Tests:
- Add a regression test for Callable aliases embedding annotationlib.ForwardRef values on Python 3.14.