### PR TITLE
Fix: only defer outer-iterator await for async-for genexprs

### DIFF
--- a/nuitka/tree/ReformulationContractionExpressions.py
+++ b/nuitka/tree/ReformulationContractionExpressions.py
@@ -463,10 +463,11 @@ def _buildContractionBodyNode(
         if qual is node.generators[0]:
             iterator_ref = makeVariableRefNode(variable=iter_tmp, source_ref=source_ref)
 
-            if for_asyncgen and python_version >= 0x370:
-                iterator_ref = ExpressionYieldFromAwaitable(
-                    expression=iterator_ref, source_ref=source_ref
-                )
+            if getattr(qual, "is_async", 0):
+                if for_asyncgen and python_version >= 0x370:
+                    iterator_ref = ExpressionYieldFromAwaitable(
+                        expression=iterator_ref, source_ref=source_ref
+                    )
 
             tmp_iter_variable = None
 

--- a/tests/basics/AsyncGenexprAwaitTest37.py
+++ b/tests/basics/AsyncGenexprAwaitTest37.py
@@ -1,0 +1,52 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Async genexpr: sync-for with await vs async-for.
+
+* Sync ``for`` plus ``await`` in the element must not treat the outer
+  list iterator as awaitable (would surface as Task got bad yield).
+* ``async for`` genexpr must still work when created in a normal ``def``,
+  where getting the async iterator is deferred until the asyncgen runs
+  (cannot await at construction time in a sync function).
+"""
+
+import asyncio
+
+
+async def val(x):
+    return x
+
+
+async def arange(n):
+    for i in range(n):
+        yield i
+
+
+def make_arange(n):
+    return (i async for i in arange(n))
+
+
+async def main():
+    agen = (await val(x) for x in [1])
+    print(await agen.__anext__())
+
+    agen2 = make_arange(3)
+    print(await agen2.__anext__())
+
+
+asyncio.run(main())
+
+#     Python tests originally created or extracted from other peoples work. The
+#     parts were too small to be protected.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Restrict deferred `await` of the outermost iterator in async generator expressions to clauses that are actually `async for`.
In `_buildContractionBodyNode`, Python 3.7+ previously did `YieldFromAwaitable` on the outer iterator for **every** async genexpr (`for_asyncgen`). That is only correct when the outermost clause is `async for` (aiter must be awaited after construction, including when the genexpr is created in a sync `def`).

For sync `for` genexprs that are async only because of an inner `await` (in the element or `if`), the outer value is a normal iterator (e.g. `list_iterator`). Awaiting / yield-from'ing it leaked the element into the driving `Task` and raised:
```text
RuntimeError: Task got bad yield: 1
```

The guard is now also `getattr(qual, "is_async", 0)`, matching the intent of 70549ba and the existing `_makeIteratorCreation` path.

Adds `tests/basics/AsyncGenexprAwaitTest37.py` covering:
- sync `for` + `await` driven via `__anext__` (must not bad-yield)
- `async for` genexpr created in a normal `def` (deferred aiter await must still work)

## 🧐 Why was it initiated? Any relevant Issues?

Fixes #3973

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
      [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
      - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: I have created an issue explaining the problem *before* using AI to
        generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Fix handling of async generator expressions so that deferred awaiting of the outer iterator only occurs for truly async-for comprehensions, and add coverage for these async genexpr behaviors.

Bug Fixes:
- Prevent async generator expressions with a synchronous outer for and inner await from incorrectly treating the outer iterator as an awaitable, avoiding bad Task yields.
- Correct error message construction in YAML scalar node handling to avoid reliance on deprecated ruamel.yaml internals.

Enhancements:
- Align async generator expression iterator handling with existing iterator creation logic by guarding await behavior on the generator qualifier's async flag.

Tests:
- Add an async genexpr test verifying correct behavior for sync-for with inner await and async-for genexprs created in a synchronous function.