### PR TITLE
UI: Avoid false missing-file warning for --include-data-files-external

### DIFF
--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -282,7 +282,7 @@ def packDistFolderToOnefileBootstrap(onefile_output_filename, dist_dir, start_bi
     if has_payload:
         expected_files = []
         for data_file in getIncludedDataFiles():
-            if "copy" in data_file.tags:
+            if "copy" in data_file.tags and "external" not in data_file.tags:
                 expected_files.append(data_file.dest_path)
 
         for entry_point in getStandaloneEntryPoints():


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

When building the onefile `expected_files` list used to validate the distribution folder before payload compression, skip data files tagged `external`.

`--include-data-files-external` keeps the `copy` tag but places those files outside `dist` (via `getOutputPath`). Including them in `expected_files` caused a false warning that the distribution folder was missing them.

## 🧐 Why was it initiated? Any relevant Issues?

Onefile builds with `--include-data-files-external` emit a misleading warning:

    Nuitka-Onefile:WARNING: Distribution folder is missing expected file 'test.txt'. This might cause issues.

### MRE

    touch test.py
    touch test.txt
    python -m nuitka test.py --onefile --include-data-files=./test.txt=test.txt --include-data-files-external=test.txt --output-dir=test --jobs=2

Before: warning above.

After: no such warning; external data still correctly stays outside the onefile payload.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## Summary by Sourcery

Bug Fixes:
- Prevent false missing-file warnings in onefile builds when using externally placed data files via --include-data-files-external.