### PR TITLE
Plugins: Split comma-separated --noinclude-qt-plugins like --include-qt-plugins

### DIFF
--- a/nuitka/options/CommandLineOptionsTools.py
+++ b/nuitka/options/CommandLineOptionsTools.py
@@ -9,6 +9,7 @@ from optparse import (
     AmbiguousOptionError,
     BadOptionError,
     IndentedHelpFormatter,
+    Option,
     OptionGroup,
     OptionParser,
 )
@@ -17,6 +18,43 @@ from nuitka.Tracing import formatTerminalLink
 
 # For re-export only:
 from optparse import SUPPRESS_HELP  # isort:skip pylint: disable=unused-import
+
+
+def _splitShellPattern(value):
+    """Split a comma-separated value, keeping shell patterns intact."""
+    return value.split(",") if "{" not in value else [value]
+
+
+class OurOption(Option):
+    TYPES = Option.TYPES + ("append_comma", "append_shell_pattern")
+    TYPE_CHECKER = dict(Option.TYPE_CHECKER)
+    TYPE_CHECKER["append_comma"] = lambda self, opt, value: value
+    TYPE_CHECKER["append_shell_pattern"] = lambda self, opt, value: value
+
+    ACTIONS = Option.ACTIONS + ("append_comma", "append_shell_pattern")
+    STORE_ACTIONS = Option.STORE_ACTIONS + ("append_comma", "append_shell_pattern")
+    TYPED_ACTIONS = Option.TYPED_ACTIONS + ("append_comma", "append_shell_pattern")
+    ALWAYS_TYPED_ACTIONS = Option.ALWAYS_TYPED_ACTIONS + (
+        "append_comma",
+        "append_shell_pattern",
+    )
+
+    def __init__(self, *args, **kwargs):
+        if (
+            kwargs.get("action") in ("append_comma", "append_shell_pattern")
+            and "type" not in kwargs
+        ):
+            kwargs["type"] = kwargs["action"]
+
+        Option.__init__(self, *args, **kwargs)
+
+    def take_action(self, action, dest, opt, value, values, parser):
+        if action == "append_comma":
+            values.ensure_value(dest, []).extend(value.split(","))
+        elif action == "append_shell_pattern":
+            values.ensure_value(dest, []).extend(_splitShellPattern(value))
+        else:
+            Option.take_action(self, action, dest, opt, value, values, parser)
 
 
 class OurOptionGroup(OptionGroup):
@@ -260,7 +298,10 @@ def makeOptionsParser(usage, epilog):
         kwargs["width"] = 10000
 
     return OurOptionParser(
-        usage=usage, epilog=epilog, formatter=OurHelpFormatter(**kwargs)
+        usage=usage,
+        epilog=epilog,
+        option_class=OurOption,
+        formatter=OurHelpFormatter(**kwargs),
     )
 
 

--- a/nuitka/plugins/standard/PySidePyQtPlugin.py
+++ b/nuitka/plugins/standard/PySidePyQtPlugin.py
@@ -111,13 +111,8 @@ class NuitkaPluginQtBindingsPluginBase(NuitkaPluginBase):
 
         sensible_qt_plugins = self._getSensiblePlugins()
 
-        self.include_qt_plugins = OrderedSet(
-            sum([value.split(",") for value in self.include_qt_plugins], [])
-        )
-
-        self.noinclude_qt_plugins = OrderedSet(
-            sum([value.split(",") for value in self.noinclude_qt_plugins], [])
-        )
+        self.include_qt_plugins = OrderedSet(self.include_qt_plugins)
+        self.noinclude_qt_plugins = OrderedSet(self.noinclude_qt_plugins)
 
         # Useless, but nice for old option usage, where expanding it meant to repeat it.
         if "sensible" in self.include_qt_plugins:
@@ -167,7 +162,7 @@ newer, or downgrade to patchelf 0.9.""" % (patchelf_version, self.binding_name))
     def addPluginCommandLineOptions(cls, group):
         group.add_option(
             "--include-qt-plugins",
-            action="append",
+            action="append_comma",
             dest="include_qt_plugins",
             default=[],
             help="""\
@@ -179,7 +174,7 @@ not exist, a list of all available will be given.""",
 
         group.add_option(
             "--noinclude-qt-plugins",
-            action="append",
+            action="append_comma",
             dest="noinclude_qt_plugins",
             default=[],
             help="""\

--- a/nuitka/plugins/standard/PySidePyQtPlugin.py
+++ b/nuitka/plugins/standard/PySidePyQtPlugin.py
@@ -115,6 +115,10 @@ class NuitkaPluginQtBindingsPluginBase(NuitkaPluginBase):
             sum([value.split(",") for value in self.include_qt_plugins], [])
         )
 
+        self.noinclude_qt_plugins = OrderedSet(
+            sum([value.split(",") for value in self.noinclude_qt_plugins], [])
+        )
+
         # Useless, but nice for old option usage, where expanding it meant to repeat it.
         if "sensible" in self.include_qt_plugins:
             self.include_qt_plugins.remove("sensible")


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Make `--noinclude-qt-plugins` accept comma-separated plugin family names the same way `--include-qt-plugins` already does.

Previously only `--include-qt-plugins=a,b,c` was split into individual families. A single `--noinclude-qt-plugins=a,b,c` was treated as one literal name `"a,b,c"`, so `discard()` never matched and the plugins stayed selected (e.g. default sensible `mediaservice` kept pulling in `Qt5Multimedia.dll` via `dsengine.dll`).

## 🧐 Why was it initiated? Any relevant Issues?

Observed when packaging a PyQt5 app with:

```
--noinclude-qt-plugins=mediaservice,printsupport,...
```

Nuitka report still showed:

```
qt5multimedia.dll ... reason="Used by 'PyQt5\qt-plugins\mediaservice\dsengine.dll'"
```

Root cause: `include_qt_plugins` values were `split(",")`, but `noinclude_qt_plugins` were not. Workaround was repeating `--noinclude-qt-plugins=` once per family; this PR makes the documented comma form work.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## Summary by Sourcery

Bug Fixes:
- Ensure --noinclude-qt-plugins correctly respects comma-separated plugin family names instead of treating them as a single literal value.