### PR TITLE
Plugins: pywebview: add missing win32 platform, fix bugs in onModuleEncounter

### DIFF
--- a/nuitka/plugins/standard/PywebViewPlugin.py
+++ b/nuitka/plugins/standard/PywebViewPlugin.py
@@ -37,26 +37,27 @@ class NuitkaPluginPywebview(NuitkaPluginBase):
         # Make sure webview platforms are included as needed.
         if module_name.isBelowNamespace("webview.platforms"):
             if isWin32Windows():
-                # spell-checker: ignore winforms,edgechromium,edgehtml
+                # spell-checker: ignore winforms,edgechromium,edgehtml,win32
                 result = module_name in (
                     "webview.platforms.winforms",
                     "webview.platforms.edgechromium",
                     "webview.platforms.edgehtml",
                     "webview.platforms.mshtml",
                     "webview.platforms.cef",
+                    "webview.platforms.win32",
                 )
                 reason = "Platforms package of webview used on '%s'." % getOS()
             elif isMacOS():
                 result = module_name == "webview.platforms.cocoa"
                 reason = "Platforms package of webview used on '%s'." % getOS()
             elif getActiveQtPlugin() is not None:
-                result = module_name = "webview.platforms.qt"
+                result = module_name == "webview.platforms.qt"
                 reason = (
                     "Platforms package of webview used due to '%s' plugin being active."
                     % getActiveQtPlugin()
                 )
             else:
-                result = module_name = "webview.platforms.gtk"
+                result = module_name == "webview.platforms.gtk"
                 reason = (
                     "Platforms package of webview used on '%s' without Qt plugin enabled."
                     % getOS()


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Two fixes in `nuitka/plugins/standard/PywebViewPlugin.py`:

1. **Add `webview.platforms.win32` to the Windows platform allowlist.** pywebview 6.x introduced `webview/platforms/win32.py` as a new module, imported by `winforms.py` via `from webview.platforms import win32`. The plugin's hardcoded allowlist in `onModuleEncounter` did not include this module, so Nuitka returned `False` for it, causing `ImportError: cannot import name 'win32'` at runtime on Windows.

2. **Fix `=` vs `==` bugs in Qt and GTK branches.** Lines 53 and 59 used `result = module_name = "webview.platforms.qt"` and `result = module_name = "webview.platforms.gtk"`. These are chained assignments, not comparisons, inadvertently mutating `module_name`. Changed to `result = module_name == "webview.platforms.qt"` and `result = module_name == "webview.platforms.gtk"` to perform the intended equality check.

## 🧐 Why was it initiated?

When building a pywebview 6.2.1 application with Nuitka standalone mode on Windows 11, the compiled executable crashes at startup:

```
ImportError: cannot import name 'win32' from 'webview.platforms'
```

The root cause is that `webview.platforms.win32` was added in pywebview 6.x but the Nuitka pywebview plugin's allowlist was never updated to include it. The `onModuleEncounter` method returns `False` for any unlisted module, actively excluding it during compilation.

Before this fix, users had to work around the bug by adding `--disable-plugin=pywebview --include-module=webview.platforms.win32` to their build command.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Update the pywebview plugin to correctly include the appropriate platform modules and fix conditional logic for platform selection.

Bug Fixes:
- Allow inclusion of the new webview.platforms.win32 module on Windows to prevent ImportError at runtime.
- Correct equality checks for selecting Qt and GTK webview platform modules so module names are not inadvertently overwritten.