### PR TITLE
Experimental: Opt-in module frontend cache and backend object reuse for incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ doxygen-*
 Nuitka-*
 nuitka/tools/podman/containers/requirements-devel.txt
 nuitka/build/inline_copy/downloads
+
+# Local experimental MCC benches / format venv (not for PRs)
+tests/scratch/
+.venv-format/

--- a/nuitka/CacheCleanup.py
+++ b/nuitka/CacheCleanup.py
@@ -37,6 +37,7 @@ def cleanCaches():
     _cleanCacheDirectory("clcache", "clcache")
     _cleanCacheDirectory("zig", "zig")
     _cleanCacheDirectory("bytecode", "module-cache")
+    _cleanCacheDirectory("module-frontend", "module-frontend")
     _cleanCacheDirectory("dll-dependencies", "library_dependencies")
 
 

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -31,6 +31,13 @@ from nuitka.code_generation.CodeGeneration import (
     generateHelpersCode,
     generateModuleCode,
 )
+from nuitka.ModuleFrontendCaching import (
+    flushModuleFrontendCacheIndex,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipStats,
+    storeModuleFrontendCache,
+    tryRestoreModuleFrontendCache,
+)
 from nuitka.code_generation.ConstantCodes import (
     addDistributionMetadataValue,
     getDistributionMetadataValues,
@@ -104,6 +111,7 @@ from nuitka.options.Options import (
     isPythonPgoErrorExitStrict,
     isRemoveBuildDir,
     isRuntimeProfile,
+    shallKeepBackendObjects,
     isShowInclusion,
     isShowMemory,
     isShowProgress,
@@ -191,7 +199,7 @@ from nuitka.utils.MemoryUsage import reportMemoryUsage, showMemoryTrace
 from nuitka.utils.ModuleNames import ModuleName
 from nuitka.utils.ReExecute import callExecProcess, reExecuteNuitka
 from nuitka.utils.StaticLibraries import getSystemStaticLibPythonPath
-from nuitka.utils.Timing import withProfiling
+from nuitka.utils.Timing import TimerReport, withProfiling
 from nuitka.utils.Utils import getArchitecture, isMacOS, isWin32Windows
 from nuitka.Version import getCommercialVersion, getNuitkaVersion
 from nuitka.VersionCheck import checkNuitkaUpdate
@@ -201,6 +209,7 @@ from .build.SconsInterface import (
     asBoolStr,
     cleanSconsDirectory,
     getCommonSconsOptions,
+    removeOrphanBackendSources,
     runScons,
 )
 from .code_generation import LoaderCodes, Reports
@@ -246,17 +255,25 @@ def _createMainModule():
 
     onBeforeCodeParsing()
 
-    # First, build the raw node tree from the source code.
-    if isMultidistMode():
-        assert not shallMakeModule()
+    from nuitka.options.Options import shallUseModuleFrontendCache
 
-        main_module = buildMainModuleTree(
-            source_code=createMultidistMainSourceCode(),
-        )
-    else:
-        main_module = buildMainModuleTree(
-            source_code=None,
-        )
+    # First, build the raw node tree from the source code.
+    with TimerReport(
+        "Module frontend phase: tree finished in %.2f seconds.",
+        logger=general,
+        decider=shallUseModuleFrontendCache(),
+        min_report_time=0.01,
+    ):
+        if isMultidistMode():
+            assert not shallMakeModule()
+
+            main_module = buildMainModuleTree(
+                source_code=createMultidistMainSourceCode(),
+            )
+        else:
+            main_module = buildMainModuleTree(
+                source_code=None,
+            )
 
     OutputDirectories.setMainModule(main_module)
 
@@ -295,12 +312,20 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
             OutputDirectories.initStandaloneDirectory(logger=general)
 
     # Delete result file, to avoid confusion with previous build and to
-    # avoid locking issues after the build.
-    _deleteResultFile(OutputDirectories.getResultFullpath(onefile=False, real=True))
+    # avoid locking issues after the build. With ``--keep-backend-objects``
+    # preserve the previous binary so a durable sconsign can skip re-link
+    # when objects and constant blobs are unchanged.
+    if not shallKeepBackendObjects():
+        _deleteResultFile(
+            OutputDirectories.getResultFullpath(onefile=False, real=True)
+        )
+
+        if isOnefileMode():
+            _deleteResultFile(
+                OutputDirectories.getResultFullpath(onefile=True, real=True)
+            )
 
     if isOnefileMode():
-        _deleteResultFile(OutputDirectories.getResultFullpath(onefile=True, real=True))
-
         # Also make sure we inform the user in case the compression is not possible.
         getCompressorPython()
 
@@ -351,7 +376,15 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
     # TODO: The passed filename is really something that should come from
     # a command line option, it's a filename for the graph, which might not
     # need a default at all.
-    optimizeModules(main_module.getOutputFilename())
+    from nuitka.options.Options import shallUseModuleFrontendCache
+
+    with TimerReport(
+        "Module frontend phase: optimize finished in %.2f seconds.",
+        logger=general,
+        decider=shallUseModuleFrontendCache(),
+        min_report_time=0.01,
+    ):
+        optimizeModules(main_module.getOutputFilename())
 
     # Freezer may have concerns for some modules.
     if isStandaloneMode():
@@ -565,20 +598,34 @@ def makeSourceDirectory():
     )
 
     # Generate code for compiled modules, this can be slow, so do it separately
-    # with a progress bar.
+    # with a progress bar. Optionally restore from module-frontend cache first.
     for current_module in compiled_modules:
         module_name = current_module.getFullName()
         c_filename = module_filenames[current_module]
+        data_filename = changeFilenameExtension(
+            os.path.basename(c_filename), ".const"
+        )
+        const_filename = getNormalizedPathJoin(
+            source_dir,
+            data_filename,
+        )
 
         reportProgressBar(
             item=module_name,
         )
 
+        restored = tryRestoreModuleFrontendCache(
+            module=current_module,
+            c_filename=c_filename,
+            const_filename=const_filename,
+        )
+
+        if restored:
+            continue
+
         source_code = generateModuleCode(
             module=current_module,
-            data_filename=changeFilenameExtension(
-                os.path.basename(c_filename), ".const"
-            ),
+            data_filename=data_filename,
         )
 
         writeSourceCode(
@@ -588,7 +635,60 @@ def makeSourceDirectory():
             assume_yes_for_downloads=assumeYesForDownloads(),
         )
 
+        storeModuleFrontendCache(
+            module=current_module,
+            c_filename=c_filename,
+            const_filename=const_filename,
+        )
+
+    # Drop stale module.*.c from previous inclusion sets when reusing the
+    # build directory for object-level incremental compiles.
+    if shallKeepBackendObjects():
+        removeOrphanBackendSources(
+            source_dir=source_dir,
+            kept_filenames=module_filenames.values(),
+        )
+
     closeProgressBar()
+
+    # Persist L1/L2 process index after this compile's stores.
+    flushModuleFrontendCacheIndex()
+
+    module_frontend_stats = getModuleFrontendCacheStats()
+    if (
+        module_frontend_stats.get("hit")
+        or module_frontend_stats.get("store")
+        or module_frontend_stats.get("stub")
+    ):
+        general.info(
+            "Module frontend cache: %d hit(s), %d miss(es), %d store(s), %d bypass(es), %d invalid, %d stub(s)."
+            % (
+                module_frontend_stats.get("hit", 0),
+                module_frontend_stats.get("miss", 0),
+                module_frontend_stats.get("store", 0),
+                module_frontend_stats.get("bypass", 0),
+                module_frontend_stats.get("invalid", 0),
+                module_frontend_stats.get("stub", 0),
+            )
+        )
+
+    optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+    if (
+        optimize_skip_stats.get("skip")
+        or optimize_skip_stats.get("probe_miss")
+        or optimize_skip_stats.get("stub")
+    ):
+        general.info(
+            "Module frontend optimize-skip: %d skip(s), %d stub(s), %d full, %d probe-miss, %d probe-invalid, %d probe-bypass."
+            % (
+                optimize_skip_stats.get("skip", 0),
+                optimize_skip_stats.get("stub", 0),
+                optimize_skip_stats.get("full", 0),
+                optimize_skip_stats.get("probe_miss", 0),
+                optimize_skip_stats.get("probe_invalid", 0),
+                optimize_skip_stats.get("probe_bypass", 0),
+            )
+        )
 
     (
         helper_decl_code,
@@ -1057,7 +1157,10 @@ import sys; sys.path.insert(0, %(output_dir)r)
 
 
 def compileTree():
+    from nuitka.options.Options import shallUseModuleFrontendCache
+
     source_dir = OutputDirectories.getSourceDirectoryPath(onefile=False, create=False)
+    report_mcc_phases = shallUseModuleFrontendCache()
 
     general.info("Completed Python level compilation and optimization.")
 
@@ -1074,12 +1177,18 @@ def compileTree():
         )
 
         # Now build the target language code for the whole tree.
-        with withProfiling(
-            name="code-generation",
-            logger=code_generation_logger,
-            enabled=isCompileTimeProfile(),
+        with TimerReport(
+            "Module frontend phase: codegen finished in %.2f seconds.",
+            logger=general,
+            decider=report_mcc_phases,
+            min_report_time=0.01,
         ):
-            module_filenames = makeSourceDirectory()
+            with withProfiling(
+                name="code-generation",
+                logger=code_generation_logger,
+                enabled=isCompileTimeProfile(),
+            ):
+                module_filenames = makeSourceDirectory()
 
         bytecode_accessor = ConstantAccessor(
             data_filename="__bytecode.const", top_level_name="bytecode_data"
@@ -1127,7 +1236,13 @@ def compileTree():
 
     general.info("Running data composer tool for optimal constant value handling.")
 
-    runDataComposer(source_dir)  # TODO: This should be a hook too
+    with TimerReport(
+        "Module frontend phase: data-composer finished in %.2f seconds.",
+        logger=general,
+        decider=report_mcc_phases,
+        min_report_time=0.01,
+    ):
+        runDataComposer(source_dir)  # TODO: This should be a hook too
 
     writeExtraCodeFiles(onefile=False)
 
@@ -1138,7 +1253,13 @@ def compileTree():
     general.info("Running C compilation via Scons.")
 
     # Run the Scons to build things.
-    result, scons_options = runSconsBackend()
+    with TimerReport(
+        "Module frontend phase: scons/backend finished in %.2f seconds.",
+        logger=general,
+        decider=report_mcc_phases,
+        min_report_time=0.01,
+    ):
+        result, scons_options = runSconsBackend()
 
     if result:
         readSconsObjectSizes(

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -31,13 +31,6 @@ from nuitka.code_generation.CodeGeneration import (
     generateHelpersCode,
     generateModuleCode,
 )
-from nuitka.ModuleFrontendCaching import (
-    flushModuleFrontendCacheIndex,
-    getModuleFrontendCacheStats,
-    getModuleFrontendOptimizeSkipStats,
-    storeModuleFrontendCache,
-    tryRestoreModuleFrontendCache,
-)
 from nuitka.code_generation.ConstantCodes import (
     addDistributionMetadataValue,
     getDistributionMetadataValues,
@@ -70,6 +63,13 @@ from nuitka.importing.Recursion import (
     scanPluginSinglePath,
 )
 from nuitka.installer.Installer import createInstallerDispatch
+from nuitka.ModuleFrontendCaching import (
+    flushModuleFrontendCacheIndex,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipStats,
+    storeModuleFrontendCache,
+    tryRestoreModuleFrontendCache,
+)
 from nuitka.optimizations.ValueTraces import setupValueTraceFromOptions
 from nuitka.options.Options import (
     assumeYesForDownloads,
@@ -111,7 +111,6 @@ from nuitka.options.Options import (
     isPythonPgoErrorExitStrict,
     isRemoveBuildDir,
     isRuntimeProfile,
-    shallKeepBackendObjects,
     isShowInclusion,
     isShowMemory,
     isShowProgress,
@@ -121,6 +120,7 @@ from nuitka.options.Options import (
     shallCreatePythonPgoInput,
     shallCreateScriptFileForExecution,
     shallExecuteImmediately,
+    shallKeepBackendObjects,
     shallMakeModule,
     shallMakePackage,
     shallNotDoExecCCompilerCall,
@@ -316,9 +316,7 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
     # preserve the previous binary so a durable sconsign can skip re-link
     # when objects and constant blobs are unchanged.
     if not shallKeepBackendObjects():
-        _deleteResultFile(
-            OutputDirectories.getResultFullpath(onefile=False, real=True)
-        )
+        _deleteResultFile(OutputDirectories.getResultFullpath(onefile=False, real=True))
 
         if isOnefileMode():
             _deleteResultFile(
@@ -602,9 +600,7 @@ def makeSourceDirectory():
     for current_module in compiled_modules:
         module_name = current_module.getFullName()
         c_filename = module_filenames[current_module]
-        data_filename = changeFilenameExtension(
-            os.path.basename(c_filename), ".const"
-        )
+        data_filename = changeFilenameExtension(os.path.basename(c_filename), ".const")
         const_filename = getNormalizedPathJoin(
             source_dir,
             data_filename,

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -128,6 +128,7 @@ from nuitka.options.Options import (
     shallRunInDebugger,
     shallTraceExecution,
     shallTreatUninstalledPython,
+    shallUseModuleFrontendCache,
     shallUsePythonDebug,
     shallUseStaticLibPython,
 )
@@ -251,11 +252,9 @@ def _createMainModule():
     directory paths.
 
     """
-    # Many cases and details to deal with, pylint: disable=too-many-branches
+    # Many cases and details to deal with, pylint: disable=too-many-branches,too-many-statements
 
     onBeforeCodeParsing()
-
-    from nuitka.options.Options import shallUseModuleFrontendCache
 
     # First, build the raw node tree from the source code.
     with TimerReport(
@@ -374,7 +373,6 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
     # TODO: The passed filename is really something that should come from
     # a command line option, it's a filename for the graph, which might not
     # need a default at all.
-    from nuitka.options.Options import shallUseModuleFrontendCache
 
     with TimerReport(
         "Module frontend phase: optimize finished in %.2f seconds.",
@@ -530,7 +528,7 @@ def pickSourceFilenames(source_dir, modules):
 def makeSourceDirectory():
     """Get the full list of modules imported, create code for all of them."""
     # We deal with a lot of details here, but rather one by one, and split makes
-    # no sense, pylint: disable=too-many-branches
+    # no sense, pylint: disable=too-many-branches,too-many-locals
 
     # assert main_module in ModuleRegistry.getDoneModules()
 
@@ -675,7 +673,9 @@ def makeSourceDirectory():
         or optimize_skip_stats.get("stub")
     ):
         general.info(
-            "Module frontend optimize-skip: %d skip(s), %d stub(s), %d full, %d probe-miss, %d probe-invalid, %d probe-bypass."
+            """\
+Module frontend optimize-skip: %d skip(s), %d stub(s), %d full, %d probe-miss, %d probe-invalid, %d probe-bypass.\
+"""
             % (
                 optimize_skip_stats.get("skip", 0),
                 optimize_skip_stats.get("stub", 0),
@@ -1153,7 +1153,6 @@ import sys; sys.path.insert(0, %(output_dir)r)
 
 
 def compileTree():
-    from nuitka.options.Options import shallUseModuleFrontendCache
 
     source_dir = OutputDirectories.getSourceDirectoryPath(onefile=False, create=False)
     report_mcc_phases = shallUseModuleFrontendCache()

--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -28,6 +28,13 @@ from nuitka.code_generation.CodeGeneration import (
     generateHelpersCode,
     generateModuleCode,
 )
+from nuitka.ModuleFrontendCaching import (
+    flushModuleFrontendCacheIndex,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipStats,
+    storeModuleFrontendCache,
+    tryRestoreModuleFrontendCache,
+)
 from nuitka.code_generation.ConstantCodes import (
     addDistributionMetadataValue,
     getDistributionMetadataValues,
@@ -99,6 +106,7 @@ from nuitka.options.Options import (
     isOnefileMode,
     isRemoveBuildDir,
     isRuntimeProfile,
+    shallKeepBackendObjects,
     isShowInclusion,
     isShowMemory,
     isShowProgress,
@@ -186,7 +194,7 @@ from nuitka.utils.MemoryUsage import reportMemoryUsage, showMemoryTrace
 from nuitka.utils.ModuleNames import ModuleName
 from nuitka.utils.ReExecute import callExecProcess, reExecuteNuitka
 from nuitka.utils.StaticLibraries import getSystemStaticLibPythonPath
-from nuitka.utils.Timing import withProfiling
+from nuitka.utils.Timing import TimerReport, withProfiling
 from nuitka.utils.Utils import getArchitecture, isMacOS, isWin32Windows
 from nuitka.Version import getCommercialVersion, getNuitkaVersion
 from nuitka.VersionCheck import checkNuitkaUpdate
@@ -196,6 +204,7 @@ from .build.SconsInterface import (
     asBoolStr,
     cleanSconsDirectory,
     getCommonSconsOptions,
+    removeOrphanBackendSources,
     runScons,
 )
 from .code_generation import LoaderCodes, Reports
@@ -241,17 +250,25 @@ def _createMainModule():
 
     onBeforeCodeParsing()
 
-    # First, build the raw node tree from the source code.
-    if isMultidistMode():
-        assert not shallMakeModule()
+    from nuitka.options.Options import shallUseModuleFrontendCache
 
-        main_module = buildMainModuleTree(
-            source_code=createMultidistMainSourceCode(),
-        )
-    else:
-        main_module = buildMainModuleTree(
-            source_code=None,
-        )
+    # First, build the raw node tree from the source code.
+    with TimerReport(
+        "Module frontend phase: tree finished in %.2f seconds.",
+        logger=general,
+        decider=shallUseModuleFrontendCache(),
+        min_report_time=0.01,
+    ):
+        if isMultidistMode():
+            assert not shallMakeModule()
+
+            main_module = buildMainModuleTree(
+                source_code=createMultidistMainSourceCode(),
+            )
+        else:
+            main_module = buildMainModuleTree(
+                source_code=None,
+            )
 
     OutputDirectories.setMainModule(main_module)
 
@@ -290,12 +307,20 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
             OutputDirectories.initStandaloneDirectory(logger=general)
 
     # Delete result file, to avoid confusion with previous build and to
-    # avoid locking issues after the build.
-    _deleteResultFile(OutputDirectories.getResultFullpath(onefile=False, real=True))
+    # avoid locking issues after the build. With ``--keep-backend-objects``
+    # preserve the previous binary so a durable sconsign can skip re-link
+    # when objects and constant blobs are unchanged.
+    if not shallKeepBackendObjects():
+        _deleteResultFile(
+            OutputDirectories.getResultFullpath(onefile=False, real=True)
+        )
+
+        if isOnefileMode():
+            _deleteResultFile(
+                OutputDirectories.getResultFullpath(onefile=True, real=True)
+            )
 
     if isOnefileMode():
-        _deleteResultFile(OutputDirectories.getResultFullpath(onefile=True, real=True))
-
         # Also make sure we inform the user in case the compression is not possible.
         getCompressorPython()
 
@@ -346,7 +371,15 @@ use the correct name instead.""" % (distribution_name, real_distribution_name))
     # TODO: The passed filename is really something that should come from
     # a command line option, it's a filename for the graph, which might not
     # need a default at all.
-    optimizeModules(main_module.getOutputFilename())
+    from nuitka.options.Options import shallUseModuleFrontendCache
+
+    with TimerReport(
+        "Module frontend phase: optimize finished in %.2f seconds.",
+        logger=general,
+        decider=shallUseModuleFrontendCache(),
+        min_report_time=0.01,
+    ):
+        optimizeModules(main_module.getOutputFilename())
 
     # Freezer may have concerns for some modules.
     if isStandaloneMode():
@@ -560,20 +593,34 @@ def makeSourceDirectory():
     )
 
     # Generate code for compiled modules, this can be slow, so do it separately
-    # with a progress bar.
+    # with a progress bar. Optionally restore from module-frontend cache first.
     for current_module in compiled_modules:
         module_name = current_module.getFullName()
         c_filename = module_filenames[current_module]
+        data_filename = changeFilenameExtension(
+            os.path.basename(c_filename), ".const"
+        )
+        const_filename = getNormalizedPathJoin(
+            source_dir,
+            data_filename,
+        )
 
         reportProgressBar(
             item=module_name,
         )
 
+        restored = tryRestoreModuleFrontendCache(
+            module=current_module,
+            c_filename=c_filename,
+            const_filename=const_filename,
+        )
+
+        if restored:
+            continue
+
         source_code = generateModuleCode(
             module=current_module,
-            data_filename=changeFilenameExtension(
-                os.path.basename(c_filename), ".const"
-            ),
+            data_filename=data_filename,
         )
 
         writeSourceCode(
@@ -583,7 +630,60 @@ def makeSourceDirectory():
             assume_yes_for_downloads=assumeYesForDownloads(),
         )
 
+        storeModuleFrontendCache(
+            module=current_module,
+            c_filename=c_filename,
+            const_filename=const_filename,
+        )
+
+    # Drop stale module.*.c from previous inclusion sets when reusing the
+    # build directory for object-level incremental compiles.
+    if shallKeepBackendObjects():
+        removeOrphanBackendSources(
+            source_dir=source_dir,
+            kept_filenames=module_filenames.values(),
+        )
+
     closeProgressBar()
+
+    # Persist L1/L2 process index after this compile's stores.
+    flushModuleFrontendCacheIndex()
+
+    module_frontend_stats = getModuleFrontendCacheStats()
+    if (
+        module_frontend_stats.get("hit")
+        or module_frontend_stats.get("store")
+        or module_frontend_stats.get("stub")
+    ):
+        general.info(
+            "Module frontend cache: %d hit(s), %d miss(es), %d store(s), %d bypass(es), %d invalid, %d stub(s)."
+            % (
+                module_frontend_stats.get("hit", 0),
+                module_frontend_stats.get("miss", 0),
+                module_frontend_stats.get("store", 0),
+                module_frontend_stats.get("bypass", 0),
+                module_frontend_stats.get("invalid", 0),
+                module_frontend_stats.get("stub", 0),
+            )
+        )
+
+    optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+    if (
+        optimize_skip_stats.get("skip")
+        or optimize_skip_stats.get("probe_miss")
+        or optimize_skip_stats.get("stub")
+    ):
+        general.info(
+            "Module frontend optimize-skip: %d skip(s), %d stub(s), %d full, %d probe-miss, %d probe-invalid, %d probe-bypass."
+            % (
+                optimize_skip_stats.get("skip", 0),
+                optimize_skip_stats.get("stub", 0),
+                optimize_skip_stats.get("full", 0),
+                optimize_skip_stats.get("probe_miss", 0),
+                optimize_skip_stats.get("probe_invalid", 0),
+                optimize_skip_stats.get("probe_bypass", 0),
+            )
+        )
 
     (
         helper_decl_code,
@@ -1013,7 +1113,10 @@ import sys; sys.path.insert(0, %(output_dir)r)
 
 
 def compileTree():
+    from nuitka.options.Options import shallUseModuleFrontendCache
+
     source_dir = OutputDirectories.getSourceDirectoryPath(onefile=False, create=False)
+    report_mcc_phases = shallUseModuleFrontendCache()
 
     general.info("Completed Python level compilation and optimization.")
 
@@ -1030,12 +1133,18 @@ def compileTree():
         )
 
         # Now build the target language code for the whole tree.
-        with withProfiling(
-            name="code-generation",
-            logger=code_generation_logger,
-            enabled=isCompileTimeProfile(),
+        with TimerReport(
+            "Module frontend phase: codegen finished in %.2f seconds.",
+            logger=general,
+            decider=report_mcc_phases,
+            min_report_time=0.01,
         ):
-            module_filenames = makeSourceDirectory()
+            with withProfiling(
+                name="code-generation",
+                logger=code_generation_logger,
+                enabled=isCompileTimeProfile(),
+            ):
+                module_filenames = makeSourceDirectory()
 
         bytecode_accessor = ConstantAccessor(
             data_filename="__bytecode.const", top_level_name="bytecode_data"
@@ -1083,7 +1192,13 @@ def compileTree():
 
     general.info("Running data composer tool for optimal constant value handling.")
 
-    runDataComposer(source_dir)  # TODO: This should be a hook too
+    with TimerReport(
+        "Module frontend phase: data-composer finished in %.2f seconds.",
+        logger=general,
+        decider=report_mcc_phases,
+        min_report_time=0.01,
+    ):
+        runDataComposer(source_dir)  # TODO: This should be a hook too
 
     writeExtraCodeFiles(onefile=False)
 
@@ -1094,7 +1209,13 @@ def compileTree():
     general.info("Running C compilation via Scons.")
 
     # Run the Scons to build things.
-    result, scons_options = runSconsBackend()
+    with TimerReport(
+        "Module frontend phase: scons/backend finished in %.2f seconds.",
+        logger=general,
+        decider=report_mcc_phases,
+        min_report_time=0.01,
+    ):
+        result, scons_options = runSconsBackend()
 
     if result:
         readSconsObjectSizes(

--- a/nuitka/ModuleFrontendCaching.py
+++ b/nuitka/ModuleFrontendCaching.py
@@ -232,8 +232,8 @@ def resetModuleFrontendCacheStats():
     _module_cache_keys.clear()
     _failed_internal_helpers.clear()
 
-    global _index_by_module, _index_context_hash, _index_dirty
-    global _internal_helper_factories
+    global _index_by_module, _index_context_hash, _index_dirty  # pylint: disable=global-statement
+    global _internal_helper_factories  # pylint: disable=global-statement
     _index_by_module = None
     _index_context_hash = None
     _index_dirty = False
@@ -346,7 +346,7 @@ def _indexPath():
 
 def _ensureIndexLoaded():
     """Load the process index for the current shared context if needed."""
-    global _index_by_module, _index_context_hash
+    global _index_by_module, _index_context_hash  # pylint: disable=global-statement
 
     context_hash = _getSharedContextHash()
     if _index_by_module is not None and _index_context_hash == context_hash:
@@ -381,7 +381,7 @@ def _updateIndexEntry(module_name_str, entry):
         module_name_str: Module full name as string.
         entry: Serializable index entry dict.
     """
-    global _index_dirty
+    global _index_dirty  # pylint: disable=global-statement
 
     _ensureIndexLoaded()
     _index_by_module[module_name_str] = entry
@@ -390,7 +390,7 @@ def _updateIndexEntry(module_name_str, entry):
 
 def flushModuleFrontendCacheIndex():
     """Persist the in-memory module-frontend index if dirty."""
-    global _index_dirty
+    global _index_dirty  # pylint: disable=global-statement
 
     if not _index_dirty or _index_by_module is None:
         return
@@ -612,6 +612,7 @@ def _eligibilityReasonFromParts(module_name, is_top, is_main, source_code, mode)
         source_code: Source text or empty.
         mode: Compilation mode string.
     """
+    # Module name is kept for call site symmetry, pylint: disable=unused-argument
     if is_main or is_top:
         return "main-or-top"
     if mode != "compiled":
@@ -711,6 +712,7 @@ def _loadValidatedMetaForName(module_name, cache_key, expected_module_name):
     Returns:
         tuple: (meta_dict, paths_dict) or (None, reason_str)
     """
+    # Many validation paths, pylint: disable=too-many-return-statements,unused-argument
     paths = _cachePaths(cache_key=cache_key)
 
     if not (
@@ -788,7 +790,6 @@ def _scanModuleCArtifacts(module_c_path):
     for match in _re_call_args.finditer(text):
         # Bare WITH_ARGS{n} only; KW_SPLIT/VECTORCALL suffixes also match
         # the prefix pattern but are owned by mixed-call tracking.
-        start = match.start()
         end = match.end()
         suffix = text[end : end + 16]
         if suffix.startswith("_KW_SPLIT") or suffix.startswith("_VECTORCALL"):
@@ -960,6 +961,7 @@ def _registerHelpersFromMetaOrC(meta, module_c_path, paths):
         paths: Cache path dict for optional meta upgrade, or None to skip
             upgrade writes.
     """
+    # Many helper kinds to register, pylint: disable=too-many-branches,too-many-locals
     if _metaHasCompleteCallHelperInfo(meta=meta):
         _applyCallHelpersToCodegen(
             arities=meta.get("quick_call_arities"),
@@ -1069,7 +1071,8 @@ def _getInternalHelperFactories():
         'helper_function_<short_name>'. Values are the '@once_decorator'
         singleton factories that attach the body to the root module.
     """
-    global _internal_helper_factories
+    # Many helpers, pylint: disable=too-many-locals
+    global _internal_helper_factories  # pylint: disable=global-statement
 
     if _internal_helper_factories is not None:
         return _internal_helper_factories
@@ -1319,6 +1322,7 @@ def reconcileCrossModuleFunctionUses():
         cached meta, and missing root internal helpers are materialized from
         the known factory registry first.
     """
+    # Complex reconciliation, pylint: disable=too-many-branches,too-many-locals,too-many-statements
     from nuitka import ModuleRegistry
     from nuitka.optimizations.TraceCollections import withChangeIndicationsTo
     from nuitka.tree.Operations import visitTree
@@ -1444,6 +1448,7 @@ def reconcileCrossModuleFunctionUses():
 
     def _ignoreSignal(tags, source_ref, message):
         # Reconcile runs after optimize passes; change tracking is not needed.
+        # pylint: disable=unused-argument
         pass
 
     with withChangeIndicationsTo(signal_change=_ignoreSignal):
@@ -1470,6 +1475,7 @@ def tryProbeAndPrepareOptimizeSkip(module):
     Returns:
         bool: True if local 'computeModule' loop may be skipped.
     """
+    # Many exit conditions, pylint: disable=too-many-return-statements
     module_name = module.getFullName()
     module_name_str = module_name.asString()
 
@@ -1568,6 +1574,7 @@ def tryBuildCachedFrontendModule(
     Returns:
         module instance or None
     """
+    # Many build steps, pylint: disable=too-many-locals,unused-argument
     if not _isStubEnabled():
         return None
 
@@ -1681,6 +1688,7 @@ def tryRestoreModuleFrontendCache(module, c_filename, const_filename):
     Returns:
         bool: True if restored successfully.
     """
+    # Many restore paths, pylint: disable=too-many-return-statements
     if not _isFeatureEnabled():
         return False
 
@@ -1780,6 +1788,7 @@ def storeModuleFrontendCache(module, c_filename, const_filename):
         c_filename: Path of the generated module C file.
         const_filename: Path of the generated module const blob.
     """
+    # Many store steps, pylint: disable=too-many-locals,too-many-return-statements,too-many-statements
     if not _isFeatureEnabled():
         return False
 

--- a/nuitka/ModuleFrontendCaching.py
+++ b/nuitka/ModuleFrontendCaching.py
@@ -1,0 +1,1920 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Optional module frontend cache for compiled Python modules.
+
+Caches generated module C sources and matching '.const' payloads so that
+repeated compilations of unchanged non-main modules can skip C source
+generation. Higher experimental levels also skip local optimize work and,
+eventually, AST construction:
+
+- '--enable-module-frontend-cache': L0 restore/store of module C/.const
+- '--experimental=module-frontend-skip-optimize': L1/L2 skip computeModule
+  with used-modules replay, process index, and global import verification
+- '--experimental=module-frontend-stub': L3 no-AST stub modules that only
+  register dependency edges and restore cached C
+
+This feature is opt-in and must not change behavior when disabled.
+"""
+
+import os
+import re
+import sys
+
+from nuitka.importing.Importing import locateModule, makeModuleUsageAttempt
+from nuitka.options.Options import (
+    getCompilationMode,
+    getFileReferenceMode,
+    isExperimental,
+    isStandaloneMode,
+    shallDisableCacheUsage,
+    shallMakeModule,
+)
+from nuitka.plugins.Hooks import getPluginsCacheContributionValues
+from nuitka.Tracing import cache_logger
+from nuitka.utils.AppDirs import getCacheDir
+from nuitka.utils.FileOperations import (
+    copyFile,
+    copyFileIfChanged,
+    getNormalizedPathJoin,
+    makePath,
+    replaceFileAtomic,
+)
+from nuitka.utils.Hashing import Hash, getStringHash
+from nuitka.utils.Json import loadJsonFromFilename, writeJsonToFilename
+from nuitka.utils.ModuleNames import ModuleName
+from nuitka.Version import version_string
+
+# Bump when meta schema or key ingredients change.
+# v2: source+context key, used_modules in meta
+# v3: index, helper arities, external symbol refs, stub support
+# Note: call-helper replay for POS_ARGS/KW_SPLIT/VECTORCALL is fixed in
+# _registerHelpersFromMetaOrC via C scan and is additive in meta; do not bump
+# solely for that or warm cache keys will all miss.
+_cache_format_version = 3
+
+_CACHE_BASENAME = "module-frontend"
+
+# Codegen path result -> count
+_stats = {
+    "hit": 0,
+    "miss": 0,
+    "store": 0,
+    "bypass": 0,
+    "invalid": 0,
+    "stub": 0,
+}
+
+# Optimize-skip path result -> count
+_optimize_stats = {
+    "skip": 0,
+    "full": 0,
+    "probe_miss": 0,
+    "probe_bypass": 0,
+    "probe_invalid": 0,
+    "feature_off": 0,
+    "stub": 0,
+}
+
+# module_name(str) -> dict(result=, reason=) for codegen
+_module_results = {}
+
+# module_name(str) -> dict(result=, reason=) for optimize skip
+_optimize_module_results = {}
+
+# module_name(str) set: modules whose computeModule was skipped this run
+_optimize_skipped_modules = set()
+
+# module_name(str) set: modules built as L3 stubs (no AST)
+_stub_modules = set()
+
+# L1: memo of optimize-skip decisions for this process
+# module_name(str) -> bool
+_skip_decision_memo = {}
+
+# L1: shared locate cache used during import verification
+# module_name(str) -> (module_kind, finding)
+_locate_cache = {}
+
+# Side data for modules (they use __slots__, cannot attach attrs).
+# module_name(str) -> meta dict / paths dict / cache_key
+_module_meta = {}
+_module_paths = {}
+_module_cache_keys = {}
+
+# L1: in-memory context index: module_name -> entry dict
+_index_by_module = None
+_index_context_hash = None
+_index_dirty = False
+
+# Short helper name -> factory callable. Built lazily once per process.
+_internal_helper_factories = None
+
+# Short names that could not be materialized during reconcile (hard error later).
+_failed_internal_helpers = set()
+
+# Regex helpers for scanning generated C.
+# Order matters for ARGS*: match longer suffixes before bare WITH_ARGS{n}.
+_re_call_args_kw_split = re.compile(r"\bCALL_FUNCTION_WITH_ARGS(\d+)_KW_SPLIT\b")
+_re_call_args_vectorcall = re.compile(r"\bCALL_FUNCTION_WITH_ARGS(\d+)_VECTORCALL\b")
+_re_call_args = re.compile(r"\bCALL_FUNCTION_WITH_ARGS(\d+)\b")
+_re_call_pos_args_kw_split = re.compile(
+    r"\bCALL_FUNCTION_WITH_POS_ARGS(\d+)_KW_SPLIT\b"
+)
+_re_call_pos_args = re.compile(r"\bCALL_FUNCTION_WITH_POS_ARGS(\d+)\b")
+_re_call_no_args_kw_split = re.compile(r"\bCALL_FUNCTION_WITH_NO_ARGS_KW_SPLIT\b")
+_re_instance_call_args = re.compile(r"\bCALL_METHOD_WITH_ARGS(\d+)\b")
+_re_external_impl = re.compile(
+    r"\b(_?impl_([A-Za-z0-9_]+?)\$\$\$(?:function|helper_function|class|generator|coroutine|asyncgen)_[A-Za-z0-9_]+)\b"
+)
+
+
+def getModuleFrontendCacheDir(create=True):
+    """Return the module-frontend cache root directory.
+
+    Args:
+        create: If True, create the directory when missing.
+
+    Returns:
+        str: Absolute cache directory path.
+    """
+    return getCacheDir(_CACHE_BASENAME, create=create)
+
+
+def getModuleFrontendCacheStats():
+    """Return a copy of codegen-path cache counters."""
+    return dict(_stats)
+
+
+def getModuleFrontendCacheModuleResults():
+    """Return per-module codegen cache results for this process."""
+    return dict(_module_results)
+
+
+def getModuleFrontendOptimizeSkipStats():
+    """Return a copy of optimize-skip path counters."""
+    return dict(_optimize_stats)
+
+
+def getModuleFrontendOptimizeSkipModuleResults():
+    """Return per-module optimize-skip results for this process."""
+    return dict(_optimize_module_results)
+
+
+def wasModuleOptimizeSkipped(module):
+    """Return whether local optimize was skipped for 'module' this run.
+
+    Args:
+        module: Compiled module node.
+    """
+    return module.getFullName().asString() in _optimize_skipped_modules
+
+
+def isModuleFrontendStub(module):
+    """Return whether 'module' was built as an L3 no-AST stub.
+
+    Args:
+        module: Compiled module node.
+    """
+    return module.getFullName().asString() in _stub_modules
+
+
+def markModuleFrontendStub(module):
+    """Record 'module' as an L3 stub and mark it optimize-skipped.
+
+    Args:
+        module: Compiled module node.
+    """
+    _stub_modules.add(module.getFullName().asString())
+    # Stubs always count as optimize-skipped for store guards.
+    _optimize_skipped_modules.add(module.getFullName().asString())
+
+
+def _setModuleCacheData(module_name_str, meta, paths, cache_key):
+    """Attach cache side data for a module name.
+
+    Args:
+        module_name_str: Module full name as string.
+        meta: Validated meta dict.
+        paths: Cache path dict for this entry.
+        cache_key: Opaque cache key string.
+    """
+    _module_meta[module_name_str] = meta
+    _module_paths[module_name_str] = paths
+    if cache_key is not None:
+        _module_cache_keys[module_name_str] = cache_key
+
+
+def _getModuleMeta(module):
+    """Return attached meta for 'module', or None."""
+    return _module_meta.get(module.getFullName().asString())
+
+
+def _getModulePaths(module):
+    """Return attached cache paths for 'module', or None."""
+    return _module_paths.get(module.getFullName().asString())
+
+
+def resetModuleFrontendCacheStats():
+    """Clear process-local MCC stats, memos, and side tables."""
+    for key in _stats:
+        _stats[key] = 0
+    for key in _optimize_stats:
+        _optimize_stats[key] = 0
+    _module_results.clear()
+    _optimize_module_results.clear()
+    _optimize_skipped_modules.clear()
+    _stub_modules.clear()
+    _skip_decision_memo.clear()
+    _locate_cache.clear()
+    _module_meta.clear()
+    _module_paths.clear()
+    _module_cache_keys.clear()
+    _failed_internal_helpers.clear()
+
+    global _index_by_module, _index_context_hash, _index_dirty
+    global _internal_helper_factories
+    _index_by_module = None
+    _index_context_hash = None
+    _index_dirty = False
+    _internal_helper_factories = None
+
+
+def _record(module_name, result, reason):
+    """Record a codegen-path cache outcome.
+
+    Args:
+        module_name: ModuleName instance.
+        result: Outcome key such as 'hit' or 'miss'.
+        reason: Short reason string.
+    """
+    _stats[result] = _stats.get(result, 0) + 1
+    _module_results[module_name.asString()] = {
+        "result": result,
+        "reason": reason,
+    }
+
+
+def _recordOptimize(module_name, result, reason):
+    """Record an optimize-skip path outcome.
+
+    Args:
+        module_name: ModuleName instance.
+        result: Outcome key such as 'skip' or 'probe_miss'.
+        reason: Short reason string.
+    """
+    _optimize_stats[result] = _optimize_stats.get(result, 0) + 1
+    _optimize_module_results[module_name.asString()] = {
+        "result": result,
+        "reason": reason,
+    }
+
+
+def _isFeatureEnabled():
+    """Return whether the module-frontend cache feature is active."""
+    from nuitka.options.Options import shallUseModuleFrontendCache
+
+    if not shallUseModuleFrontendCache():
+        return False
+
+    # Honors both "module-frontend" and "all".
+    if shallDisableCacheUsage(_CACHE_BASENAME):
+        return False
+
+    return True
+
+
+def _isSkipOptimizeEnabled():
+    """Return whether skip-optimize or stub experimental mode is active."""
+    return _isFeatureEnabled() and (
+        isExperimental("module-frontend-skip-optimize")
+        or isExperimental("module-frontend-stub")
+    )
+
+
+def _isStubEnabled():
+    """Return whether L3 stub experimental mode is active."""
+    return _isFeatureEnabled() and isExperimental("module-frontend-stub")
+
+
+def _getContextHash(module_name):
+    """Hash of toolchain / options / plugins that affect module frontend output.
+
+    Args:
+        module_name: ModuleName used for plugin cache contributions.
+    """
+    hash_value = Hash()
+
+    hash_value.updateFromValues(
+        version_string,
+        sys.version,
+        str(sys.version_info),
+        getCompilationMode(),
+        "standalone" if isStandaloneMode() else "not-standalone",
+        "module-mode" if shallMakeModule() else "not-module-mode",
+        getFileReferenceMode() or "",
+    )
+
+    hash_value.updateFromValues(*getPluginsCacheContributionValues(module_name))
+
+    return hash_value.asHexDigest()
+
+
+def _getSharedContextHash():
+    """Context hash without per-module plugin contribution (for index file)."""
+    hash_value = Hash()
+    hash_value.updateFromValues(
+        version_string,
+        sys.version,
+        str(sys.version_info),
+        getCompilationMode(),
+        "standalone" if isStandaloneMode() else "not-standalone",
+        "module-mode" if shallMakeModule() else "not-module-mode",
+        getFileReferenceMode() or "",
+        _cache_format_version,
+    )
+    return hash_value.asHexDigest()
+
+
+def _indexPath():
+    """Return the on-disk path of the context-specific MCC index."""
+    return getNormalizedPathJoin(
+        getModuleFrontendCacheDir(create=True),
+        "index-%s.json" % _getSharedContextHash(),
+    )
+
+
+def _ensureIndexLoaded():
+    """Load the process index for the current shared context if needed."""
+    global _index_by_module, _index_context_hash
+
+    context_hash = _getSharedContextHash()
+    if _index_by_module is not None and _index_context_hash == context_hash:
+        return
+
+    _index_context_hash = context_hash
+    _index_by_module = {}
+
+    path = _indexPath()
+    if not os.path.isfile(path):
+        return
+
+    data = loadJsonFromFilename(filename=path)
+    if data is None:
+        return
+
+    if data.get("file_format_version") != _cache_format_version:
+        return
+
+    if data.get("context_hash") != context_hash:
+        return
+
+    modules = data.get("modules") or {}
+    if type(modules) is dict:
+        _index_by_module = modules
+
+
+def _updateIndexEntry(module_name_str, entry):
+    """Update the in-memory index entry and mark the index dirty.
+
+    Args:
+        module_name_str: Module full name as string.
+        entry: Serializable index entry dict.
+    """
+    global _index_dirty
+
+    _ensureIndexLoaded()
+    _index_by_module[module_name_str] = entry
+    _index_dirty = True
+
+
+def flushModuleFrontendCacheIndex():
+    """Persist the in-memory module-frontend index if dirty."""
+    global _index_dirty
+
+    if not _index_dirty or _index_by_module is None:
+        return
+
+    path = _indexPath()
+    tmp = path + ".tmp"
+    data = {
+        "file_format_version": _cache_format_version,
+        "context_hash": _getSharedContextHash(),
+        "modules": _index_by_module,
+    }
+
+    try:
+        writeJsonToFilename(filename=tmp, contents=data)
+        replaceFileAtomic(source_path=tmp, dest_path=path)
+        _index_dirty = False
+    except (OSError, IOError) as e:
+        cache_logger.warning("Failed to write module frontend index: %s" % e)
+
+
+def _serializeUsedModules(module):
+    """Return a stable list describing modules this module decided to use.
+
+    Args:
+        module: Compiled module node after usage collection.
+    """
+    result = []
+
+    for used_module in module.getUsedModules():
+        result.append(
+            {
+                "module_name": used_module.module_name.asString(),
+                "finding": used_module.finding,
+                "module_kind": used_module.module_kind,
+                "reason": used_module.reason,
+                "source_ref_line": used_module.source_ref.getLineNumber(),
+                "level": used_module.level,
+            }
+        )
+
+    # Deterministic order for hashing / stable meta.
+    result.sort(
+        key=lambda item: (
+            item["module_name"],
+            item["finding"] or "",
+            item["module_kind"] or "",
+            item["reason"] or "",
+            item["source_ref_line"],
+            item.get("level") or 0,
+        )
+    )
+    return result
+
+
+def _locateModuleCached(module_name):
+    """Locate a module with process-local caching.
+
+    Args:
+        module_name: ModuleName to resolve.
+
+    Returns:
+        tuple: (module_kind, finding, filename)
+    """
+    key = module_name.asString()
+    if key in _locate_cache:
+        return _locate_cache[key]
+
+    _name, _filename, module_kind, finding = locateModule(
+        module_name=module_name,
+        parent_package=None,
+        level=0,
+    )
+    result = (module_kind, finding, _filename)
+    _locate_cache[key] = result
+    return result
+
+
+def _verifyUsedModulesStillValid(used_modules_data):
+    """Re-locate imports; return True only if resolution is unchanged.
+
+    Notes:
+        Used-module entries may have been discovered as relative imports. The
+        stored module name is already the resolved absolute name, so re-check
+        with absolute lookup (level=0). Attribute imports stored as not-found
+        are kept for completeness but must not fail verification.
+    """
+    seen = set()
+
+    for item in used_modules_data:
+        used_module_name = ModuleName(item["module_name"])
+        key = used_module_name.asString()
+
+        # Duplicates are common (parent path edges); verify once per name.
+        if key in seen:
+            continue
+        seen.add(key)
+
+        # Attribute imports (e.g. "from fastapi import FastAPI") are recorded as
+        # not-found / module_kind=None usage attempts.
+        if item["finding"] in (None, "not-found") or item["module_kind"] is None:
+            continue
+
+        module_kind, finding, _filename = _locateModuleCached(
+            module_name=used_module_name
+        )
+
+        # A previously resolvable import disappearing is a real miss.
+        if finding in (None, "not-found") or module_kind is None:
+            return False
+
+        if module_kind != item["module_kind"]:
+            return False
+
+    return True
+
+
+def _rebuildUsedModuleAttempts(module, used_modules_data):
+    """Rebuild ModuleUsageAttempt objects from cached meta and re-locate files."""
+    result = []
+    source_ref = module.source_ref
+
+    for item in used_modules_data:
+        used_module_name = ModuleName(item["module_name"])
+        finding = item["finding"]
+        module_kind = item["module_kind"]
+
+        filename = None
+        if finding not in (None, "not-found") and module_kind is not None:
+            located_kind, located_finding, located_filename = _locateModuleCached(
+                used_module_name
+            )
+            if located_finding in (None, "not-found") or located_kind is None:
+                # Keep not-found shape; considerUsedModules will skip filename=None.
+                finding = "not-found"
+                module_kind = None
+                filename = None
+            else:
+                finding = located_finding
+                module_kind = located_kind
+                filename = located_filename
+
+        line_number = item.get("source_ref_line") or 1
+        attempt_ref = source_ref.atLineNumber(line_number)
+
+        result.append(
+            makeModuleUsageAttempt(
+                module_name=used_module_name,
+                filename=filename,
+                module_kind=module_kind,
+                finding=finding,
+                level=item.get("level") or 0,
+                source_ref=attempt_ref,
+                reason=item.get("reason") or "import",
+            )
+        )
+
+    return result
+
+
+def _getModuleSourceForCacheKey(module):
+    """Return source text for keying, or None if the module cannot be keyed safely.
+
+    Notes:
+        Some synthetic modules still look like compiled modules but do not have a
+        readable on-disk source (e.g. generated helper modules). Those must bypass
+        the frontend cache rather than crash while hashing.
+    """
+    # Prefer already-captured source if present on the node.
+    source_code = getattr(module, "source_code", None)
+    if source_code is not None:
+        return source_code
+
+    try:
+        source_filename = module.getCompileTimeFilename()
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+    if not source_filename or not os.path.isfile(source_filename):
+        return None
+
+    try:
+        return module.getSourceCode()
+    except (OSError, IOError, ValueError):
+        return None
+
+
+def _eligibilityReason(module):
+    """Return None if eligible for MCC, else a short reason string.
+
+    Args:
+        module: Compiled module node.
+    """
+    if not module.isCompiledPythonModule():
+        return "not-compiled-python"
+
+    if module.isMainModule() or module.isTopModule():
+        return "main-or-top"
+
+    if module.getCompilationMode() != "compiled":
+        return "mode-%s" % module.getCompilationMode()
+
+    # Note: modules with cross-used functions are still eligible. Cached C already
+    # contains the needed cross-module decls from a prior full codegen. Skipping
+    # them was the main reason expensive library modules never entered the cache.
+
+    if not _getModuleSourceForCacheKey(module=module):
+        return "no-source"
+
+    return None
+
+
+def _eligibilityReasonFromParts(module_name, is_top, is_main, source_code, mode):
+    """Return eligibility failure reason from parts, or None if eligible.
+
+    Args:
+        module_name: ModuleName (unused, for symmetry/debug).
+        is_top: Whether the module is a top module.
+        is_main: Whether the module is the main module.
+        source_code: Source text or empty.
+        mode: Compilation mode string.
+    """
+    if is_main or is_top:
+        return "main-or-top"
+    if mode != "compiled":
+        return "mode-%s" % mode
+    if not source_code:
+        return "no-source"
+    return None
+
+
+def makeModuleFrontendCacheKey(module):
+    """Return cache key for a module based on source+context only.
+
+    Args:
+        module: Compiled module node.
+
+    Returns:
+        str or None: Opaque cache key, or None if ineligible.
+    """
+    if _eligibilityReason(module=module) is not None:
+        return None
+
+    module_name = module.getFullName()
+    source_code = _getModuleSourceForCacheKey(module=module)
+
+    return _makeCacheKeyFromSource(
+        module_name=module_name,
+        source_code=source_code,
+        reason=module.reason or "",
+    )
+
+
+def _makeCacheKeyFromSource(module_name, source_code, reason):
+    """Build an opaque cache key from source and compilation context.
+
+    Args:
+        module_name: ModuleName of the module.
+        source_code: Full source text used for the key hash.
+        reason: Module inclusion reason string.
+
+    Returns:
+        str: Cache key basename for the module entry.
+    """
+    key_hash = Hash()
+    key_hash.updateFromValues(
+        _cache_format_version,
+        module_name.asString(),
+        getStringHash(source_code),
+        _getContextHash(module_name=module_name),
+        reason or "",
+    )
+    return module_name.asLegalFilename() + "@" + key_hash.asHexDigest()
+
+
+def _cachePaths(cache_key):
+    """Return the on-disk path layout for a cache key.
+
+    Args:
+        cache_key: Opaque cache key string.
+
+    Returns:
+        dict: Paths for dir/meta/module_c/module_const.
+    """
+    cache_dir = getNormalizedPathJoin(getModuleFrontendCacheDir(create=True), cache_key)
+    return {
+        "dir": cache_dir,
+        "meta": getNormalizedPathJoin(cache_dir, "meta.json"),
+        "module_c": getNormalizedPathJoin(cache_dir, "module.c"),
+        "module_const": getNormalizedPathJoin(cache_dir, "module.const"),
+    }
+
+
+def _loadValidatedMeta(module, cache_key):
+    """Load meta.json and validate format/name/key/hashes/imports.
+
+    Args:
+        module: Compiled module node being validated.
+        cache_key: Opaque cache key string.
+
+    Returns:
+        tuple(meta_dict, paths_dict) or (None, reason_str)
+    """
+    return _loadValidatedMetaForName(
+        module_name=module.getFullName(),
+        cache_key=cache_key,
+        expected_module_name=module.getFullName().asString(),
+    )
+
+
+def _loadValidatedMetaForName(module_name, cache_key, expected_module_name):
+    """Load and validate meta for a module name and cache key.
+
+    Args:
+        module_name: ModuleName used for context-sensitive checks.
+        cache_key: Opaque cache key string.
+        expected_module_name: Expected 'module_name' field in meta.
+
+    Returns:
+        tuple: (meta_dict, paths_dict) or (None, reason_str)
+    """
+    paths = _cachePaths(cache_key=cache_key)
+
+    if not (
+        os.path.isfile(paths["meta"])
+        and os.path.isfile(paths["module_c"])
+        and os.path.isfile(paths["module_const"])
+    ):
+        return None, "not-present"
+
+    meta = loadJsonFromFilename(filename=paths["meta"])
+    if meta is None:
+        return None, "meta-unreadable"
+
+    # Accept current format; older entries will rebuild on store.
+    if meta.get("file_format_version") not in (2, 3, _cache_format_version):
+        return None, "format-version"
+
+    if meta.get("module_name") != expected_module_name:
+        return None, "module-name"
+
+    if meta.get("cache_key") != cache_key:
+        return None, "key-mismatch"
+
+    c_hash = Hash()
+    c_hash.updateFromFile(paths["module_c"])
+    if meta.get("c_hash") != c_hash.asHexDigest():
+        return None, "c-hash"
+
+    const_hash = Hash()
+    const_hash.updateFromFile(paths["module_const"])
+    if meta.get("const_hash") != const_hash.asHexDigest():
+        return None, "const-hash"
+
+    used_modules_data = meta.get("used_modules") or []
+    if not _verifyUsedModulesStillValid(used_modules_data=used_modules_data):
+        return None, "imports-changed"
+
+    return meta, paths
+
+
+def _scanModuleCArtifacts(module_c_path):
+    """Extract helper arities and external impl symbol refs from module C.
+
+    Notes:
+        Call helper families map to CallCodes tracking sets:
+
+        - 'CALL_FUNCTION_WITH_ARGS{n}' -> quick_calls_used
+        - 'CALL_METHOD_WITH_ARGS{n}' -> quick_instance_calls_used
+        - 'CALL_FUNCTION_WITH_POS_ARGS{n}' -> quick_tuple_calls_used
+        - 'CALL_FUNCTION_WITH_ARGS{n}_KW_SPLIT' -> mixed (n, False, True)
+        - 'CALL_FUNCTION_WITH_POS_ARGS{n}_KW_SPLIT' -> mixed (n, True, True)
+        - 'CALL_FUNCTION_WITH_ARGS{n}_VECTORCALL' -> mixed (n, False, False)
+        - 'CALL_FUNCTION_WITH_NO_ARGS_KW_SPLIT' -> mixed (0, False, True)
+
+    Args:
+        module_c_path: Path to module C source to scan.
+
+    Returns:
+        dict: Helper arity lists, mixed calls, and external impl symbols.
+    """
+    empty = {
+        "quick_call_arities": [],
+        "quick_instance_call_arities": [],
+        "quick_tuple_call_arities": [],
+        "quick_mixed_calls": [],
+        "external_impl_symbols": [],
+    }
+    try:
+        with open(module_c_path, "rb") as module_c_file:
+            text = module_c_file.read().decode("latin1", "replace")
+    except (OSError, IOError):
+        return empty
+
+    quick_calls = set()
+    for match in _re_call_args.finditer(text):
+        # Bare WITH_ARGS{n} only; KW_SPLIT/VECTORCALL suffixes also match
+        # the prefix pattern but are owned by mixed-call tracking.
+        start = match.start()
+        end = match.end()
+        suffix = text[end : end + 16]
+        if suffix.startswith("_KW_SPLIT") or suffix.startswith("_VECTORCALL"):
+            continue
+        quick_calls.add(int(match.group(1)))
+
+    instance_calls = set()
+    for match in _re_instance_call_args.finditer(text):
+        instance_calls.add(int(match.group(1)))
+
+    tuple_calls = set()
+    for match in _re_call_pos_args.finditer(text):
+        end = match.end()
+        suffix = text[end : end + 16]
+        if suffix.startswith("_KW_SPLIT"):
+            continue
+        tuple_calls.add(int(match.group(1)))
+
+    # (args_count, has_tuple_arg, has_dict_values) for getCallsCode()
+    mixed_calls = set()
+    for match in _re_call_args_kw_split.finditer(text):
+        mixed_calls.add((int(match.group(1)), False, True))
+    for match in _re_call_pos_args_kw_split.finditer(text):
+        mixed_calls.add((int(match.group(1)), True, True))
+    for match in _re_call_args_vectorcall.finditer(text):
+        mixed_calls.add((int(match.group(1)), False, False))
+    if _re_call_no_args_kw_split.search(text):
+        # Template: args_count==0 and has_dict_values (tuple flag unused).
+        mixed_calls.add((0, False, True))
+
+    external = set()
+    for match in _re_external_impl.finditer(text):
+        symbol = match.group(1)
+        owner_code = match.group(2)
+        # Drop self-module symbols later; store all for consumers to filter.
+        external.add((symbol, owner_code))
+
+    return {
+        "quick_call_arities": sorted(quick_calls),
+        "quick_instance_call_arities": sorted(instance_calls),
+        "quick_tuple_call_arities": sorted(tuple_calls),
+        "quick_mixed_calls": [
+            [args_count, has_tuple_arg, has_dict_values]
+            for (args_count, has_tuple_arg, has_dict_values) in sorted(mixed_calls)
+        ],
+        "external_impl_symbols": [
+            {"symbol": symbol, "owner_code_name": owner_code}
+            for (symbol, owner_code) in sorted(external)
+        ],
+    }
+
+
+def _metaHasCompleteCallHelperInfo(meta):
+    """Return whether meta alone can replay all call-helper families.
+
+    Notes:
+        Older v3 entries only stored bare WITH_ARGS / METHOD arities and must
+        still scan module C. Empty lists are valid (module needs no such
+        helpers); missing keys mean incomplete.
+
+    Args:
+        meta: Cache meta dict or None.
+
+    Returns:
+        bool: True if all four helper-family keys are present.
+    """
+    if meta is None:
+        return False
+
+    return (
+        meta.get("quick_call_arities") is not None
+        and meta.get("quick_instance_call_arities") is not None
+        and meta.get("quick_tuple_call_arities") is not None
+        and meta.get("quick_mixed_calls") is not None
+    )
+
+
+def _applyCallHelpersToCodegen(arities, instance_arities, tuple_arities, mixed_calls):
+    """Register high-arity call helpers into CallCodes tracking sets.
+
+    Args:
+        arities: Iterable of CALL_FUNCTION_WITH_ARGS arities.
+        instance_arities: Iterable of CALL_METHOD_WITH_ARGS arities.
+        tuple_arities: Iterable of CALL_FUNCTION_WITH_POS_ARGS arities.
+        mixed_calls: Iterable of [args_count, has_tuple_arg, has_dict_values]
+            or matching tuples for mixed/KW_SPLIT/VECTORCALL helpers.
+    """
+    from nuitka.code_generation.CallCodes import (
+        max_quick_call,
+        quick_calls_used,
+        quick_instance_calls_used,
+        quick_mixed_calls_used,
+        quick_tuple_calls_used,
+    )
+
+    for arity in arities or ():
+        arity = int(arity)
+        if arity > max_quick_call:
+            quick_calls_used.add(arity)
+
+    for arity in instance_arities or ():
+        arity = int(arity)
+        if arity > max_quick_call:
+            quick_instance_calls_used.add(arity)
+
+    for arity in tuple_arities or ():
+        arity = int(arity)
+        if arity > max_quick_call:
+            quick_tuple_calls_used.add(arity)
+
+    for item in mixed_calls or ():
+        args_count = int(item[0])
+        has_tuple_arg = bool(item[1])
+        has_dict_values = bool(item[2])
+        if args_count > max_quick_call:
+            quick_mixed_calls_used.add((args_count, has_tuple_arg, has_dict_values))
+
+
+def _upgradeMetaCallHelpers(meta, paths, scanned):
+    """Persist full helper families into meta after a C scan.
+
+    Notes:
+        Best-effort only: restore already succeeded. Uses atomic replace so a
+        crashed upgrade cannot leave a truncated meta.json. Lets the next warm
+        restore skip scanning this module's C.
+
+    Args:
+        meta: Mutable meta dict already used for this restore.
+        paths: Cache path dict that must include 'meta'.
+        scanned: Dict with the four helper-family lists to store.
+    """
+    if meta is None or paths is None:
+        return
+
+    meta_path = paths.get("meta")
+    if not meta_path:
+        return
+
+    meta["quick_call_arities"] = scanned["quick_call_arities"]
+    meta["quick_instance_call_arities"] = scanned["quick_instance_call_arities"]
+    meta["quick_tuple_call_arities"] = scanned["quick_tuple_call_arities"]
+    meta["quick_mixed_calls"] = scanned["quick_mixed_calls"]
+
+    tmp_meta = meta_path + ".tmp"
+    try:
+        writeJsonToFilename(filename=tmp_meta, contents=meta)
+        replaceFileAtomic(source_path=tmp_meta, dest_path=meta_path)
+    except (OSError, IOError):
+        # Restore already succeeded; upgrade is only a speed optimization.
+        try:
+            if os.path.isfile(tmp_meta):
+                os.unlink(tmp_meta)
+        except (OSError, IOError):
+            pass
+
+
+def _registerHelpersFromMetaOrC(meta, module_c_path, paths):
+    """Replay high-arity call helper needs into codegen globals.
+
+    Notes:
+        Prefer complete meta (all four helper families) so warm restores do not
+        re-read and regex-scan every cached 'module.c'. Incomplete or missing
+        meta still scans C and best-effort upgrades meta so POS_ARGS / KW_SPLIT
+        / VECTORCALL helpers are never dropped from '__helpers.c'.
+
+    Args:
+        meta: Cache meta dict, or None to force a C scan.
+        module_c_path: Path to cached or restored module C source.
+        paths: Cache path dict for optional meta upgrade, or None to skip
+            upgrade writes.
+    """
+    if _metaHasCompleteCallHelperInfo(meta=meta):
+        _applyCallHelpersToCodegen(
+            arities=meta.get("quick_call_arities"),
+            instance_arities=meta.get("quick_instance_call_arities"),
+            tuple_arities=meta.get("quick_tuple_call_arities"),
+            mixed_calls=meta.get("quick_mixed_calls"),
+        )
+        return
+
+    scanned = _scanModuleCArtifacts(module_c_path=module_c_path)
+
+    # Union partial meta + scan so incomplete meta cannot under-declare.
+    arity_set = set()
+    for arity in scanned["quick_call_arities"] or ():
+        arity_set.add(int(arity))
+    instance_set = set()
+    for arity in scanned["quick_instance_call_arities"] or ():
+        instance_set.add(int(arity))
+    tuple_set = set()
+    for arity in scanned["quick_tuple_call_arities"] or ():
+        tuple_set.add(int(arity))
+    mixed_list = list(scanned["quick_mixed_calls"] or ())
+
+    if meta is not None:
+        for arity in meta.get("quick_call_arities") or ():
+            arity_set.add(int(arity))
+        for arity in meta.get("quick_instance_call_arities") or ():
+            instance_set.add(int(arity))
+        if meta.get("quick_tuple_call_arities") is not None:
+            for arity in meta.get("quick_tuple_call_arities") or ():
+                tuple_set.add(int(arity))
+        for item in meta.get("quick_mixed_calls") or ():
+            mixed_list.append(item)
+
+    # Dedup mixed while preserving list form for apply/upgrade.
+    mixed_set = set()
+    mixed_normalized = []
+    for item in mixed_list:
+        key = (int(item[0]), bool(item[1]), bool(item[2]))
+        if key not in mixed_set:
+            mixed_set.add(key)
+            mixed_normalized.append([key[0], key[1], key[2]])
+
+    arities = sorted(arity_set)
+    instance_arities = sorted(instance_set)
+    tuple_arities = sorted(tuple_set)
+    mixed_for_meta = sorted(
+        mixed_normalized, key=lambda item: (item[0], item[1], item[2])
+    )
+
+    _applyCallHelpersToCodegen(
+        arities=arities,
+        instance_arities=instance_arities,
+        tuple_arities=tuple_arities,
+        mixed_calls=mixed_for_meta,
+    )
+
+    # Make the next hit cheap if we had to scan.
+    if meta is not None:
+        scanned_for_meta = {
+            "quick_call_arities": arities,
+            "quick_instance_call_arities": instance_arities,
+            "quick_tuple_call_arities": tuple_arities,
+            "quick_mixed_calls": mixed_for_meta,
+        }
+        _upgradeMetaCallHelpers(meta=meta, paths=paths, scanned=scanned_for_meta)
+
+
+def _registerHelpersFromCachedModuleC(module_c_path):
+    """Register helpers by scanning module C when no meta is available.
+
+    Args:
+        module_c_path: Path to module C source to scan.
+    """
+    _registerHelpersFromMetaOrC(meta=None, module_c_path=module_c_path, paths=None)
+
+
+def _prepareUsageTraceCollection(module, used_modules_data):
+    """Attach a usage-only trace collection replayed from cached meta.
+
+    Args:
+        module: Compiled module node.
+        used_modules_data: Serialized used-module list from meta.
+
+    Returns:
+        list: Rebuilt module usage attempts.
+    """
+    from nuitka.optimizations.TraceCollections import TraceCollectionModule
+
+    module.trace_collection = TraceCollectionModule(
+        module=module,
+        very_trusted_module_variables={},
+        old_collection=None,
+    )
+    attempts = _rebuildUsedModuleAttempts(
+        module=module, used_modules_data=used_modules_data
+    )
+    module.trace_collection.onModuleUsageAttempts(attempts)
+    return attempts
+
+
+def _getInternalHelperFactories():
+    """Return the registry of root-module internal helper factories.
+
+    Notes:
+        Keys are the Python helper short names used in generated C as
+        'helper_function_<short_name>'. Values are the '@once_decorator'
+        singleton factories that attach the body to the root module.
+    """
+    global _internal_helper_factories
+
+    if _internal_helper_factories is not None:
+        return _internal_helper_factories
+
+    factories = {}
+
+    # Import lazily so tree modules load after options are ready.
+    from nuitka.tree.ComplexCallHelperFunctions import (
+        getCallableNameDescBody,
+        getFunctionCallHelperDictionaryUnpacking,
+        getFunctionCallHelperKeywordsStarDict,
+        getFunctionCallHelperKeywordsStarList,
+        getFunctionCallHelperKeywordsStarListStarDict,
+        getFunctionCallHelperPosKeywordsStarDict,
+        getFunctionCallHelperPosKeywordsStarList,
+        getFunctionCallHelperPosKeywordsStarListStarDict,
+        getFunctionCallHelperPosStarDict,
+        getFunctionCallHelperPosStarList,
+        getFunctionCallHelperPosStarListStarDict,
+        getFunctionCallHelperStarDict,
+        getFunctionCallHelperStarList,
+        getFunctionCallHelperStarListStarDict,
+    )
+    from nuitka.tree.ReformulationClasses3 import (
+        getClassBasesMroConversionHelper,
+        getClassSelectMetaClassHelper,
+    )
+    from nuitka.tree.ReformulationDictionaryCreation import (
+        _getDictUnpackingHelper,
+    )
+    from nuitka.tree.ReformulationSequenceCreation import (
+        getListUnpackingHelper,
+        getSetUnpackingHelper,
+    )
+
+    factories.update(
+        {
+            "_mro_entries_conversion": getClassBasesMroConversionHelper,
+            "_select_metaclass": getClassSelectMetaClassHelper,
+            "_unpack_dict": _getDictUnpackingHelper,
+            "_unpack_list": getListUnpackingHelper,
+            "_unpack_set": getSetUnpackingHelper,
+            "get_callable_name_desc": getCallableNameDescBody,
+            "complex_call_helper_star_list": getFunctionCallHelperStarList,
+            "complex_call_helper_keywords_star_list": getFunctionCallHelperKeywordsStarList,
+            "complex_call_helper_pos_star_list": getFunctionCallHelperPosStarList,
+            "complex_call_helper_pos_keywords_star_list": getFunctionCallHelperPosKeywordsStarList,
+            "complex_call_helper_star_dict": getFunctionCallHelperStarDict,
+            "complex_call_helper_pos_star_dict": getFunctionCallHelperPosStarDict,
+            "complex_call_helper_keywords_star_dict": getFunctionCallHelperKeywordsStarDict,
+            "complex_call_helper_pos_keywords_star_dict": getFunctionCallHelperPosKeywordsStarDict,
+            "complex_call_helper_star_list_star_dict": getFunctionCallHelperStarListStarDict,
+            "complex_call_helper_pos_star_list_star_dict": getFunctionCallHelperPosStarListStarDict,
+            "complex_call_helper_keywords_star_list_star_dict": getFunctionCallHelperKeywordsStarListStarDict,
+            "complex_call_helper_pos_keywords_star_list_star_dict": getFunctionCallHelperPosKeywordsStarListStarDict,
+            "complex_call_helper_dict_unpacking_checks": getFunctionCallHelperDictionaryUnpacking,
+        }
+    )
+
+    _internal_helper_factories = factories
+    return factories
+
+
+def _helperShortNameFromCodeName(function_code_name):
+    """Convert 'helper_function_<name>' code name to short helper name.
+
+    Args:
+        function_code_name: Full function code name string.
+
+    Returns:
+        str or None: Short helper name, or None if not a helper code name.
+    """
+    if not function_code_name.startswith("helper_function_"):
+        return None
+
+    return function_code_name[len("helper_function_") :]
+
+
+def _findFunctionBodyByCodeName(owner_module, function_code_name):
+    """Locate a function body on owner by exact or suffix code-name match.
+
+    Args:
+        owner_module: Module that may own the function body.
+        function_code_name: Exact or suffix code name to match.
+
+    Returns:
+        function body node or None
+    """
+    function_body = owner_module.getFunctionFromCodeName(function_code_name)
+    if function_body is not None:
+        return function_body
+
+    for candidate_function in owner_module.subnode_functions:
+        candidate_name = candidate_function.getCodeName()
+        if (
+            candidate_name == function_code_name
+            or candidate_name.endswith(function_code_name)
+            or function_code_name.endswith(candidate_name)
+        ):
+            return candidate_function
+
+    return None
+
+
+def _materializeInternalHelper(owner_module, helper_code_name):
+    """Create a known internal helper on the root module if missing.
+
+    Notes:
+        Helpers such as '_mro_entries_conversion' live on the root/top module
+        (code name '__main__') but are only constructed when some module's
+        reformulation references them. L3 stubs never reformulate, so cached C
+        may still reference helpers that were never built in this run.
+
+        Factories are '@once_decorator' singletons and attach via
+        'addFunction' on the root module. Unknown short names are recorded
+        and later force a hard failure instead of an undefined-symbol link error.
+    """
+    short_name = _helperShortNameFromCodeName(function_code_name=helper_code_name)
+    if short_name is None:
+        return None
+
+    # Already present under the Python helper name?
+    for candidate_function in owner_module.subnode_functions:
+        if candidate_function.getFunctionName() == short_name:
+            return candidate_function
+
+    factory = _getInternalHelperFactories().get(short_name)
+    if factory is None:
+        _failed_internal_helpers.add(short_name)
+        cache_logger.warning(
+            "Module frontend cache cannot materialize unknown internal helper "
+            "'%s' on '%s'; disable stub/skip or report missing factory."
+            % (short_name, owner_module.getFullName().asString())
+        )
+        return None
+
+    helper_body = factory()
+    return helper_body
+
+
+def _collectNeededInternalHelperShortNames():
+    """Collect root-module helper short names referenced by cached modules.
+
+    Returns:
+        set: Short helper names that must exist on the root module.
+    """
+    needed = set()
+
+    for meta in _module_meta.values():
+        if not meta:
+            continue
+
+        # Explicit list written at store time (preferred).
+        for short_name in meta.get("internal_helpers_needed") or ():
+            needed.add(short_name)
+
+        # Fallback: derive from external symbol table.
+        self_code = meta.get("module_code_name")
+        for item in meta.get("external_impl_symbols") or ():
+            owner_code_name = item.get("owner_code_name")
+            symbol = item.get("symbol") or ""
+            if owner_code_name in (None, self_code):
+                continue
+
+            # Root helpers always use code name owner '__main__' (and rarely
+            # other top modules). Materialize only helper_function_* symbols.
+            if "$$$helper_function_" not in symbol:
+                continue
+
+            short_name = symbol.rsplit("helper_function_", 1)[-1]
+            if short_name:
+                needed.add(short_name)
+
+    return needed
+
+
+def _materializeAllNeededInternalHelpers():
+    """Ensure every cached external root helper exists before codegen.
+
+    Notes:
+        Uses the factory registry and marks helpers used/cross-used on the
+        root module so later pruning keeps them.
+    """
+    from nuitka import ModuleRegistry
+
+    needed = _collectNeededInternalHelperShortNames()
+    if not needed:
+        return
+
+    # Internal helpers attach to the root/top module.
+    owner_module = ModuleRegistry.getRootTopModule()
+    if owner_module is None or not owner_module.isCompiledPythonModule():
+        return
+
+    for short_name in sorted(needed):
+        helper_code_name = "helper_function_" + short_name
+        if (
+            _findFunctionBodyByCodeName(
+                owner_module=owner_module, function_code_name=helper_code_name
+            )
+            is not None
+        ):
+            continue
+
+        helper_body = _materializeInternalHelper(
+            owner_module=owner_module,
+            helper_code_name=helper_code_name,
+        )
+        if helper_body is None:
+            continue
+
+        owner_module.addUsedFunction(helper_body)
+        helper_body.markAsCrossModuleUsed()
+        helper_body.markAsDirectlyCalled()
+
+
+def checkModuleFrontendHelperMaterialization():
+    """Abort if stub/skip needed an internal helper we cannot build.
+
+    Notes:
+        Turns unresolved root helpers into a hard frontend error instead of
+        an undefined-symbol link failure later.
+    """
+    if not _failed_internal_helpers:
+        return
+
+    names = ", ".join(sorted(_failed_internal_helpers))
+    cache_logger.sysexit(
+        "Error, module frontend cache could not materialize internal helper(s): "
+        "%s. Recompile without '--experimental=module-frontend-stub' / "
+        "'module-frontend-skip-optimize', or extend the helper factory registry."
+        % names
+    )
+
+
+def reconcileCrossModuleFunctionUses():
+    """Mark functions used via ExpressionFunctionRef across modules.
+
+    Notes:
+        Full optimize walks these refs while computing modules. Skip-optimize
+        modules never do that, so owner modules (often '__main__' helpers)
+        would not get 'addUsedFunction' and later pruning would drop the
+        definitions, causing link failures. Newly marked functions that never
+        ran 'computeFunctionRaw' also need a trace collection before codegen.
+
+        L3 stubs have no AST; their external symbol needs are reconciled from
+        cached meta, and missing root internal helpers are materialized from
+        the known factory registry first.
+    """
+    from nuitka import ModuleRegistry
+    from nuitka.optimizations.TraceCollections import withChangeIndicationsTo
+    from nuitka.tree.Operations import visitTree
+
+    # Materialize every root helper referenced by cached C before walking trees
+    # or pruning unused functions.
+    _materializeAllNeededInternalHelpers()
+
+    # Collect first so tree mutation during computeFunctionRaw cannot disturb
+    # visitTree.
+    discovered = []
+
+    class _FunctionRefCollectVisitor(object):
+        def __init__(self, consumer_module):
+            self.consumer_module = consumer_module
+
+        def onEnterNode(self, node):
+            if node.isExpressionFunctionRef():
+                discovered.append((self.consumer_module, node.getFunctionBody()))
+
+        def onLeaveNode(self, node):
+            pass
+
+    # Code name -> compiled module for O(1) owner lookup from meta symbols.
+    modules_by_code_name = {}
+    for module in ModuleRegistry.getDoneModules():
+        if module.isCompiledPythonModule():
+            modules_by_code_name[module.getCodeName()] = module
+
+    for module in ModuleRegistry.getDoneModules():
+        if not module.isCompiledPythonModule():
+            continue
+
+        # Stubs have no function-ref nodes worth walking.
+        if isModuleFrontendStub(module=module):
+            continue
+
+        visitTree(tree=module, visitor=_FunctionRefCollectVisitor(module))
+
+    pending_compute = []
+    seen_bodies = set()
+
+    def _markUsed(consumer_module, owner_module, function_body):
+        owner_module.addUsedFunction(function_body)
+
+        if owner_module is not consumer_module:
+            function_body.markAsCrossModuleUsed()
+            function_body.markAsDirectlyCalled()
+            consumer_module.addCrossUsedFunction(function_body)
+
+        if (
+            function_body not in seen_bodies
+            and getattr(function_body, "trace_collection", None) is None
+        ):
+            seen_bodies.add(function_body)
+            pending_compute.append((owner_module, function_body))
+
+    for consumer_module, function_body in discovered:
+        owner_module = function_body.getParentModule()
+        _markUsed(
+            consumer_module=consumer_module,
+            owner_module=owner_module,
+            function_body=function_body,
+        )
+
+    # External impl symbols from cached stub/skip modules.
+    for module in ModuleRegistry.getDoneModules():
+        if not module.isCompiledPythonModule():
+            continue
+
+        meta = _getModuleMeta(module=module)
+        if not meta:
+            continue
+
+        self_code_name = module.getCodeName()
+        for item in meta.get("external_impl_symbols") or ():
+            owner_code_name = item.get("owner_code_name")
+            symbol = item.get("symbol")
+            if not owner_code_name or not symbol:
+                continue
+
+            # Skip symbols that belong to the consumer itself.
+            if owner_code_name == self_code_name:
+                continue
+
+            owner_module = modules_by_code_name.get(owner_code_name)
+            if owner_module is None:
+                continue
+
+            # Stub owners already restore complete C that contains their helpers.
+            if isModuleFrontendStub(module=owner_module):
+                continue
+
+            # Symbol form: impl_<owner>$$$helper_function_<name> or function_
+            parts = symbol.split("$$$", 1)
+            if len(parts) != 2:
+                continue
+            function_code_name = parts[1]
+
+            function_body = _findFunctionBodyByCodeName(
+                owner_module=owner_module,
+                function_code_name=function_code_name,
+            )
+
+            # L3: consumer stubs never ran reformulation, so internal helpers on
+            # the root module may not exist yet.
+            if function_body is None and function_code_name.startswith(
+                "helper_function_"
+            ):
+                function_body = _materializeInternalHelper(
+                    owner_module=owner_module,
+                    helper_code_name=function_code_name,
+                )
+
+            if function_body is None:
+                continue
+
+            _markUsed(
+                consumer_module=module,
+                owner_module=owner_module,
+                function_body=function_body,
+            )
+
+    def _ignoreSignal(tags, source_ref, message):
+        # Reconcile runs after optimize passes; change tracking is not needed.
+        pass
+
+    with withChangeIndicationsTo(signal_change=_ignoreSignal):
+        for owner_module, function_body in pending_compute:
+            parent_collection = owner_module.trace_collection
+            if parent_collection is None:
+                continue
+
+            # Nested functions may appear while computing another body.
+            if getattr(function_body, "trace_collection", None) is None:
+                function_body.computeFunctionRaw(parent_collection)
+
+    checkModuleFrontendHelperMaterialization()
+
+
+def tryProbeAndPrepareOptimizeSkip(module):
+    """Probe frontend cache and prepare module to skip local optimize micro-passes.
+
+    Notes:
+        On success, injects cached used-module attempts into a fresh
+        'TraceCollectionModule' so 'considerUsedModules' still closes the
+        dependency graph. Does not skip dependency discovery.
+
+    Returns:
+        bool: True if local 'computeModule' loop may be skipped.
+    """
+    module_name = module.getFullName()
+    module_name_str = module_name.asString()
+
+    if not _isSkipOptimizeEnabled():
+        return False
+
+    # L1: memoize decision so later optimization passes do not re-probe.
+    if module_name_str in _skip_decision_memo:
+        return _skip_decision_memo[module_name_str]
+
+    # L3 stubs are always skipped.
+    if isModuleFrontendStub(module=module):
+        meta = _getModuleMeta(module=module)
+        used_modules_data = (meta or {}).get("used_modules") or []
+        if module.trace_collection is None:
+            _prepareUsageTraceCollection(
+                module=module, used_modules_data=used_modules_data
+            )
+        _optimize_skipped_modules.add(module_name_str)
+        _recordOptimize(module_name=module_name, result="stub", reason="stub-module")
+        _skip_decision_memo[module_name_str] = True
+        return True
+
+    reason = _eligibilityReason(module=module)
+    if reason is not None:
+        _recordOptimize(module_name=module_name, result="probe_bypass", reason=reason)
+        _skip_decision_memo[module_name_str] = False
+        return False
+
+    cache_key = makeModuleFrontendCacheKey(module=module)
+    if cache_key is None:
+        _recordOptimize(module_name=module_name, result="probe_bypass", reason="no-key")
+        _skip_decision_memo[module_name_str] = False
+        return False
+
+    meta, paths_or_reason = _loadValidatedMeta(module=module, cache_key=cache_key)
+    if meta is None:
+        reason = paths_or_reason
+        if reason == "not-present":
+            _recordOptimize(module_name=module_name, result="probe_miss", reason=reason)
+        else:
+            _recordOptimize(
+                module_name=module_name, result="probe_invalid", reason=reason
+            )
+            cache_logger.info(
+                "Module frontend optimize-skip invalid for '%s' (%s)."
+                % (module_name.asString(), reason)
+            )
+        _skip_decision_memo[module_name_str] = False
+        return False
+
+    used_modules_data = meta.get("used_modules") or []
+    _prepareUsageTraceCollection(module=module, used_modules_data=used_modules_data)
+
+    # Keep meta/paths for later external-symbol reconcile / helpers.
+    _setModuleCacheData(
+        module_name_str=module_name_str,
+        meta=meta,
+        paths=paths_or_reason,
+        cache_key=cache_key,
+    )
+
+    _optimize_skipped_modules.add(module_name_str)
+    _recordOptimize(module_name=module_name, result="skip", reason="probe-hit")
+    _skip_decision_memo[module_name_str] = True
+    cache_logger.info(
+        "Module frontend optimize-skip for '%s'." % module_name.asString()
+    )
+    return True
+
+
+def tryBuildCachedFrontendModule(
+    module_name,
+    module_filename,
+    reason,
+    source_code,
+    source_ref,
+    is_package,
+    is_top,
+    is_main,
+    mode,
+):
+    """L3: build a no-AST stub module when a validated frontend cache exists.
+
+    Args:
+        module_name: ModuleName of the module being built.
+        module_filename: Source filename for the module.
+        reason: Inclusion reason string.
+        source_code: Full module source text.
+        source_ref: Source reference for the module node.
+        is_package: Whether this is a package module.
+        is_top: Whether this is a top-level module.
+        is_main: Whether this is the main module.
+        mode: Compilation mode string.
+
+    Returns:
+        module instance or None
+    """
+    if not _isStubEnabled():
+        return None
+
+    if is_main or is_top:
+        return None
+
+    if mode != "compiled":
+        return None
+
+    if not source_code:
+        return None
+
+    cache_key = _makeCacheKeyFromSource(
+        module_name=module_name,
+        source_code=source_code,
+        reason=reason or "",
+    )
+
+    meta, paths_or_reason = _loadValidatedMetaForName(
+        module_name=module_name,
+        cache_key=cache_key,
+        expected_module_name=module_name.asString(),
+    )
+    if meta is None:
+        return None
+
+    paths = paths_or_reason
+
+    from nuitka.nodes.FutureSpecs import FutureSpec
+    from nuitka.nodes.ModuleNodes import (
+        CompiledPythonModule,
+        CompiledPythonPackage,
+    )
+
+    if is_package:
+        module = CompiledPythonPackage(
+            module_name=module_name,
+            reason=reason,
+            is_top=is_top,
+            mode=mode,
+            future_spec=FutureSpec(use_annotations=False),
+            source_ref=source_ref,
+        )
+    else:
+        module = CompiledPythonModule(
+            module_name=module_name,
+            reason=reason,
+            is_top=is_top,
+            mode=mode,
+            future_spec=FutureSpec(use_annotations=False),
+            source_ref=source_ref,
+        )
+
+    # Keep source for later keying / reports.
+    module.source_code = source_code
+    _setModuleCacheData(
+        module_name_str=module_name.asString(),
+        meta=meta,
+        paths=paths,
+        cache_key=cache_key,
+    )
+
+    # Empty body: no AST, no functions.
+    module.setChildBody(None)
+    module.setChildFunctions(())
+
+    used_modules_data = meta.get("used_modules") or []
+    _prepareUsageTraceCollection(module=module, used_modules_data=used_modules_data)
+
+    markModuleFrontendStub(module=module)
+    _stats["stub"] = _stats.get("stub", 0) + 1
+    _record(module_name=module_name, result="stub", reason="no-ast")
+
+    cache_logger.info(
+        "Module frontend stub (no AST) for '%s'." % module_name.asString()
+    )
+    return module
+
+
+def _restoreCachedArtifacts(source_c, source_const, c_filename, const_filename):
+    """Restore C/.const into the build tree, optionally preserving mtime.
+
+    Notes:
+        With '--keep-backend-objects', identical content keeps the existing
+        file mtime so Scons can reuse object files.
+
+    Args:
+        source_c: Cached module C path.
+        source_const: Cached module const path.
+        c_filename: Destination module C path in the build tree.
+        const_filename: Destination module const path in the build tree.
+    """
+    from nuitka.options.Options import shallKeepBackendObjects
+
+    if shallKeepBackendObjects():
+        copyFileIfChanged(source_path=source_c, dest_path=c_filename)
+        copyFileIfChanged(source_path=source_const, dest_path=const_filename)
+    else:
+        copyFile(source_path=source_c, dest_path=c_filename)
+        copyFile(source_path=source_const, dest_path=const_filename)
+
+
+def tryRestoreModuleFrontendCache(module, c_filename, const_filename):
+    """Try to restore generated C and const files for module.
+
+    Args:
+        module: Compiled module node to restore for.
+        c_filename: Destination path for module C.
+        const_filename: Destination path for module const blob.
+
+    Returns:
+        bool: True if restored successfully.
+    """
+    if not _isFeatureEnabled():
+        return False
+
+    module_name = module.getFullName()
+
+    # L3 stubs always restore from the paths captured at build time.
+    if isModuleFrontendStub(module=module):
+        paths = _getModulePaths(module=module)
+        meta = _getModuleMeta(module=module)
+        if paths is None or meta is None:
+            _record(
+                module_name=module_name, result="invalid", reason="stub-missing-paths"
+            )
+            return False
+
+        try:
+            _restoreCachedArtifacts(
+                source_c=paths["module_c"],
+                source_const=paths["module_const"],
+                c_filename=c_filename,
+                const_filename=const_filename,
+            )
+        except (OSError, IOError):
+            _record(module_name=module_name, result="invalid", reason="restore-io")
+            return False
+
+        _registerHelpersFromMetaOrC(
+            meta=meta, module_c_path=paths["module_c"], paths=paths
+        )
+        _record(module_name=module_name, result="hit", reason="stub-restored")
+        cache_logger.info(
+            "Module frontend cache hit (stub) for '%s'." % module_name.asString()
+        )
+        return True
+
+    reason = _eligibilityReason(module=module)
+    if reason is not None:
+        _record(module_name=module_name, result="bypass", reason=reason)
+        return False
+
+    cache_key = makeModuleFrontendCacheKey(module=module)
+    if cache_key is None:
+        _record(module_name=module_name, result="bypass", reason="no-key")
+        return False
+
+    meta, paths_or_reason = _loadValidatedMeta(module=module, cache_key=cache_key)
+    if meta is None:
+        reason = paths_or_reason
+        if reason == "not-present":
+            _record(module_name=module_name, result="miss", reason=reason)
+            cache_logger.info(
+                "Module frontend cache miss for '%s' (not present)."
+                % module_name.asString()
+            )
+        else:
+            _record(module_name=module_name, result="invalid", reason=reason)
+            cache_logger.info(
+                "Module frontend cache invalid for '%s' (%s)."
+                % (module_name.asString(), reason)
+            )
+        return False
+
+    paths = paths_or_reason
+
+    # Restore into build directory.
+    try:
+        _restoreCachedArtifacts(
+            source_c=paths["module_c"],
+            source_const=paths["module_const"],
+            c_filename=c_filename,
+            const_filename=const_filename,
+        )
+    except (OSError, IOError):
+        _record(module_name=module_name, result="invalid", reason="restore-io")
+        return False
+
+    # Ensure __helpers generation still emits high-arity calls used by this C.
+    _registerHelpersFromMetaOrC(meta=meta, module_c_path=paths["module_c"], paths=paths)
+
+    _setModuleCacheData(
+        module_name_str=module_name.asString(),
+        meta=meta,
+        paths=paths,
+        cache_key=cache_key,
+    )
+
+    _record(module_name=module_name, result="hit", reason="restored")
+    cache_logger.info("Module frontend cache hit for '%s'." % module_name.asString())
+    return True
+
+
+def storeModuleFrontendCache(module, c_filename, const_filename):
+    """Store generated C and const files for a module if eligible.
+
+    Args:
+        module: Compiled module node after successful codegen.
+        c_filename: Path of the generated module C file.
+        const_filename: Path of the generated module const blob.
+    """
+    if not _isFeatureEnabled():
+        return False
+
+    module_name = module.getFullName()
+
+    # Do not store C produced from an optimize-skipped tree unless we also
+    # restored (which would not call store). If generate ran after skip, the
+    # tree may be under-optimized - refuse to poison the cache.
+    if wasModuleOptimizeSkipped(module=module) or isModuleFrontendStub(module=module):
+        cache_logger.info(
+            "Module frontend cache store skipped for '%s' (optimize was skipped; "
+            "codegen should have restored)." % module_name.asString()
+        )
+        return False
+
+    reason = _eligibilityReason(module=module)
+    if reason is not None:
+        if module_name.asString() not in _module_results:
+            _record(module_name=module_name, result="bypass", reason=reason)
+        return False
+
+    cache_key = makeModuleFrontendCacheKey(module=module)
+    if cache_key is None:
+        if module_name.asString() not in _module_results:
+            _record(module_name=module_name, result="bypass", reason="no-key")
+        return False
+
+    used_modules_data = _serializeUsedModules(module=module)
+    paths = _cachePaths(cache_key=cache_key)
+    makePath(path=paths["dir"])
+
+    if not os.path.isfile(c_filename) or not os.path.isfile(const_filename):
+        return False
+
+    # Atomic write via temp files then replace.
+    tmp_c = paths["module_c"] + ".tmp"
+    tmp_const = paths["module_const"] + ".tmp"
+    tmp_meta = paths["meta"] + ".tmp"
+
+    try:
+        copyFile(source_path=c_filename, dest_path=tmp_c)
+        copyFile(source_path=const_filename, dest_path=tmp_const)
+
+        c_hash = Hash()
+        c_hash.updateFromFile(tmp_c)
+        const_hash = Hash()
+        const_hash.updateFromFile(tmp_const)
+
+        scanned = _scanModuleCArtifacts(module_c_path=tmp_c)
+
+        # Prefer explicit short names for root helpers this module's C needs.
+        self_code_name = module.getCodeName()
+        internal_helpers_needed = []
+        seen_helpers = set()
+        for item in scanned["external_impl_symbols"]:
+            owner_code_name = item.get("owner_code_name")
+            symbol = item.get("symbol") or ""
+            if owner_code_name == self_code_name:
+                continue
+            if "$$$helper_function_" not in symbol:
+                continue
+            short_name = symbol.rsplit("helper_function_", 1)[-1]
+            if short_name and short_name not in seen_helpers:
+                seen_helpers.add(short_name)
+                internal_helpers_needed.append(short_name)
+
+        meta = {
+            "file_format_version": _cache_format_version,
+            "module_name": module_name.asString(),
+            "cache_key": cache_key,
+            "nuitka_version": version_string,
+            "python_version": list(sys.version_info),
+            "compilation_mode": getCompilationMode(),
+            "c_hash": c_hash.asHexDigest(),
+            "const_hash": const_hash.asHexDigest(),
+            "used_modules": used_modules_data,
+            "had_cross_used": bool(module.getCrossUsedFunctions()),
+            "module_code_name": module.getCodeName(),
+            "quick_call_arities": scanned["quick_call_arities"],
+            "quick_instance_call_arities": scanned["quick_instance_call_arities"],
+            "quick_tuple_call_arities": scanned["quick_tuple_call_arities"],
+            "quick_mixed_calls": scanned["quick_mixed_calls"],
+            "external_impl_symbols": scanned["external_impl_symbols"],
+            "internal_helpers_needed": sorted(internal_helpers_needed),
+            "source_hash": getStringHash(
+                _getModuleSourceForCacheKey(module=module) or ""
+            ),
+        }
+
+        writeJsonToFilename(filename=tmp_meta, contents=meta)
+
+        replaceFileAtomic(source_path=tmp_c, dest_path=paths["module_c"])
+        replaceFileAtomic(source_path=tmp_const, dest_path=paths["module_const"])
+        replaceFileAtomic(source_path=tmp_meta, dest_path=paths["meta"])
+    except (OSError, IOError) as e:
+        cache_logger.warning(
+            "Failed to store module frontend cache for '%s': %s"
+            % (module_name.asString(), e)
+        )
+        return False
+
+    # L1/L2: update process index for faster future lookups.
+    _updateIndexEntry(
+        module_name_str=module_name.asString(),
+        entry={
+            "cache_key": cache_key,
+            "source_hash": meta["source_hash"],
+            "module_code_name": meta["module_code_name"],
+            "used_module_names": [
+                item["module_name"]
+                for item in used_modules_data
+                if item.get("module_kind") is not None
+            ],
+        },
+    )
+
+    _stats["store"] = _stats.get("store", 0) + 1
+    cache_logger.info("Module frontend cache store for '%s'." % module_name.asString())
+    return True
+
+
+#     Part of "Nuitka", an optimizing Python compiler that is compatible and
+#     integrates with CPython, but also works on its own.
+#
+#     Licensed under the GNU Affero General Public License, Version 3 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        https://www.gnu.org/licenses/agpl-3.0.txt
+#
+#     See also: "Nuitka Runtime Library Exception, Version 1.0" in file
+#     "LICENSE-RUNTIME.txt" for additional permissions granted under Section 7.
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/nuitka/Serialization.py
+++ b/nuitka/Serialization.py
@@ -3,6 +3,7 @@
 
 """Write and read constants data files and provide identifiers."""
 
+import os
 import pickle
 import sys
 
@@ -32,7 +33,12 @@ from nuitka.code_generation.SpecialConstantData import (
 from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.OutputDirectories import getSourceDirectoryPath
 from nuitka.PythonVersions import python_version
-from nuitka.utils.FileOperations import getNormalizedPathJoin, openPickleFile
+from nuitka.utils.FileOperations import (
+    deleteFile,
+    getNormalizedPathJoin,
+    openPickleFile,
+    putBinaryFileContents,
+)
 
 
 class BuiltinAnonValue(object):
@@ -111,13 +117,17 @@ class ConstantStreamWriter(object):
 
     def __init__(self, filename):
         self.count = 0
+        self._closed = False
 
-        filename = getNormalizedPathJoin(
+        self.filename = getNormalizedPathJoin(
             getSourceDirectoryPath(onefile=False, create=False),
             filename,
         )
 
-        self.file, self.pickle = openPickleFile(filename, "wb")
+        # Write through a temp path so close() can keep the final file's mtime
+        # when content is identical (keep-backend-objects / durable sconsign).
+        self._tmp_filename = self.filename + ".tmp"
+        self.file, self.pickle = openPickleFile(self._tmp_filename, "wb")
 
         self.pickle.dispatch[type] = _pickleAnonValues
         self.pickle.dispatch[type(Ellipsis)] = _pickleAnonValues
@@ -142,7 +152,28 @@ class ConstantStreamWriter(object):
         self.count += 1
 
     def close(self):
+        if self._closed:
+            return
+
+        self._closed = True
         self.file.close()
+
+        try:
+            with open(self._tmp_filename, "rb") as tmp_file:
+                new_data = tmp_file.read()
+
+            if os.path.isfile(self.filename):
+                try:
+                    if os.path.getsize(self.filename) == len(new_data):
+                        with open(self.filename, "rb") as old_file:
+                            if old_file.read() == new_data:
+                                return
+                except (OSError, IOError):
+                    pass
+
+            putBinaryFileContents(self.filename, new_data)
+        finally:
+            deleteFile(self._tmp_filename, must_exist=False)
 
 
 class ConstantStreamReader(object):

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -381,9 +381,9 @@ def discoverSourceFiles():
 
 source_files = discoverSourceFiles()
 
-# Remove the target file to avoid cases where it falsely doesn't get rebuild and
-# then lingers from previous builds, and also workaround for MinGW64 not
-# supporting unicode result paths for "-o" basename.
+# Prepare result path. Default mode deletes any previous binary so a false
+# up-to-date decision cannot leave a stale program; keep-backend-objects leaves
+# it in place for durable sconsign reuse. Also handles MinGW unicode "-o" paths.
 result_exe = makeResultPathFileSystemEncodable(env=env, result_exe=result_exe)
 
 if env.module_mode:
@@ -423,6 +423,20 @@ elif env.dll_mode:
 else:
     # For scons internal use, we use Python native paths as MSYS2 does wrong things otherwise.
     target = env.Program(os.path.normpath(result_exe), source_files)
+
+# Keep existing object files when doing object-level incremental builds. Without
+# this, Scons deletes targets before rebuilding and the spawn-time fresh-object
+# check never sees previous .o files.
+if getattr(env, "keep_backend_objects", False):
+    try:
+        from SCons.Script import Precious  # pylint: disable=import-error
+
+        for node in target:
+            Precious(node)
+            for child in node.children():
+                Precious(child)
+    except Exception:  # pylint: disable=broad-except
+        pass
 
 
 def createBuildDefinitionsFile():

--- a/nuitka/build/Backend.scons
+++ b/nuitka/build/Backend.scons
@@ -378,9 +378,9 @@ def discoverSourceFiles():
 
 source_files = discoverSourceFiles()
 
-# Remove the target file to avoid cases where it falsely doesn't get rebuild and
-# then lingers from previous builds, and also workaround for MinGW64 not
-# supporting unicode result paths for "-o" basename.
+# Prepare result path. Default mode deletes any previous binary so a false
+# up-to-date decision cannot leave a stale program; keep-backend-objects leaves
+# it in place for durable sconsign reuse. Also handles MinGW unicode "-o" paths.
 result_exe = makeResultPathFileSystemEncodable(env=env, result_exe=result_exe)
 
 if env.module_mode:
@@ -420,6 +420,20 @@ elif env.dll_mode:
 else:
     # For scons internal use, we use Python native paths as MSYS2 does wrong things otherwise.
     target = env.Program(os.path.normpath(result_exe), source_files)
+
+# Keep existing object files when doing object-level incremental builds. Without
+# this, Scons deletes targets before rebuilding and the spawn-time fresh-object
+# check never sees previous .o files.
+if getattr(env, "keep_backend_objects", False):
+    try:
+        from SCons.Script import Precious  # pylint: disable=import-error
+
+        for node in target:
+            Precious(node)
+            for child in node.children():
+                Precious(child)
+    except Exception:  # pylint: disable=broad-except
+        pass
 
 
 def createBuildDefinitionsFile():

--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -1217,6 +1217,7 @@ def createNuitkaSconsEnvironment(needs_source_dir=True):
     enableSconsProgressBar(progress_bar)
 
     disable_ccache = getArgumentBool("disable_ccache", False)
+    keep_backend_objects = getArgumentBool("keep_backend_objects", False)
 
     # Patch the compiler detection.
     Environment.Detect = getEnhancedToolDetect()
@@ -1280,6 +1281,7 @@ def createNuitkaSconsEnvironment(needs_source_dir=True):
     env.onefile_windows_static_runtime = onefile_windows_static_runtime
     env.cf_protection = cf_protection
     env.disable_ccache = disable_ccache
+    env.keep_backend_objects = keep_backend_objects
 
     if env.the_compiler is None or getExecutablePath(env.the_compiler, env=env) is None:
         raiseNoCompilerFoundErrorExit()

--- a/nuitka/build/SconsCompilerSettings.py
+++ b/nuitka/build/SconsCompilerSettings.py
@@ -1214,6 +1214,7 @@ def createNuitkaSconsEnvironment(needs_source_dir=True):
     enableSconsProgressBar(progress_bar)
 
     disable_ccache = getArgumentBool("disable_ccache", False)
+    keep_backend_objects = getArgumentBool("keep_backend_objects", False)
 
     # Patch the compiler detection.
     Environment.Detect = getEnhancedToolDetect()
@@ -1276,6 +1277,7 @@ def createNuitkaSconsEnvironment(needs_source_dir=True):
     env.onefile_windows_static_runtime = onefile_windows_static_runtime
     env.cf_protection = cf_protection
     env.disable_ccache = disable_ccache
+    env.keep_backend_objects = keep_backend_objects
 
     if env.the_compiler is None or getExecutablePath(env.the_compiler, env=env) is None:
         raiseNoCompilerFoundErrorExit()

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -50,6 +50,7 @@ from nuitka.options.Options import (
     shallCreateAppBundle,
     shallCreateDiffableCompilationReport,
     shallDisableCCacheUsage,
+    shallKeepBackendObjects,
     shallMakeDll,
     shallMakeExe,
     shallMakeModule,
@@ -202,14 +203,14 @@ def _getInlineSconsVersionForPythonVersion(python_version_info):
     if python_version_info < (2, 7):
         # Non-Windows, Python 2.6, mostly older RHEL
         return "scons-2.3.2"
-    elif os.name == "nt" and python_version_info >= (3, 7):
-        # Windows can use latest, supported MSVC 2026 this way
+    elif python_version_info >= (3, 7):
+        # Modern CPython needs modern Scons .sconsign support.
         return "scons-4.10.1"
     elif os.name == "nt" and python_version_info >= (3, 5):
         # Windows can use latest, supported MSVC 2022 this way
         return "scons-4.3.0"
     else:
-        # Everything else 2.7 or higher works with this.
+        # Python 2.7 and early 3.x
         return "scons-3.1.2"
 
 
@@ -665,31 +666,55 @@ def asBoolStr(value):
 
 
 def cleanSconsDirectory(source_dir):
-    """Clean scons build directory."""
+    """Clean scons build directory.
+
+    Notes:
+        With ``--keep-backend-objects``, previous C sources, headers, constants
+        and object files are preserved so content-stable rewrites can keep
+        mtimes and Scons can skip recompiling unchanged modules. Do not combine
+        with ``--remove-output`` if you want reuse across builds.
+    """
+
+    from nuitka.options.Options import shallKeepBackendObjects
+
+    keep_objects = shallKeepBackendObjects()
 
     # spell-checker: ignore gcda
-    extensions = (
-        ".bin",
-        ".c",
-        ".cpp",
+    extensions = [
         ".exp",
-        ".h",
         ".lib",
         ".manifest",
-        ".o",
-        ".obj",
-        ".os",
         ".rc",
         ".res",
         ".S",
-        ".txt",
         ".pickle",
-        ".const",
         ".gcda",
         ".pgd",
         ".pgc",
         ".json",
-    )
+    ]
+
+    # Full clean: wipe generated sources, objects and constant blobs so builds
+    # cannot pick up stale artifacts from a previous configuration.
+    #
+    # keep-backend-objects must preserve ".bin"/".txt" under blobs/ too: the
+    # data composer rewrites them every run, and content-stable mtimes are
+    # required for durable sconsign to skip re-link.
+    if not keep_objects:
+        extensions.extend(
+            [
+                ".bin",
+                ".txt",
+                ".c",
+                ".cpp",
+                ".h",
+                ".const",
+                ".o",
+                ".obj",
+                ".os",
+            ]
+        )
+    extensions = tuple(extensions)
 
     def check(path):
         if hasFilenameExtension(path, extensions):
@@ -716,6 +741,34 @@ def cleanSconsDirectory(source_dir):
         if os.path.exists(blobs_dir):
             for path, _filename in listDir(blobs_dir):
                 check(path)
+
+
+def removeOrphanBackendSources(source_dir, kept_filenames):
+    """Delete generated module C sources not part of the current compile set.
+
+    Notes:
+        Used with ``--keep-backend-objects`` so ``scanSourceDir`` does not pull
+        stale ``module.*.c`` from a previous inclusion set into the link.
+        Matching ``.const`` sidecars are removed with their orphan ``.c`` files.
+    """
+    if not os.path.isdir(source_dir):
+        return
+
+    kept = set(os.path.basename(path) for path in kept_filenames)
+
+    for path, filename in listDir(source_dir):
+        if not filename.startswith("module."):
+            continue
+
+        # Only consider C/C++ module units for orphan detection. Their .const
+        # sidecars are derived from the same basename.
+        if not hasFilenameExtension(filename, (".c", ".cpp")):
+            continue
+
+        if filename not in kept:
+            deleteFile(path, must_exist=False)
+            const_path = changeFilenameExtension(path, ".const")
+            deleteFile(const_path, must_exist=False)
 
 
 def getCommonSconsOptions():
@@ -792,6 +845,9 @@ def getCommonSconsOptions():
 
     if shallDisableCCacheUsage():
         scons_options["disable_ccache"] = asBoolStr(True)
+
+    if shallKeepBackendObjects():
+        scons_options["keep_backend_objects"] = asBoolStr(True)
 
     if isWin32Windows() and getWindowsConsoleMode() != "attach":
         scons_options["console_mode"] = getWindowsConsoleMode()

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -675,8 +675,6 @@ def cleanSconsDirectory(source_dir):
         with ``--remove-output`` if you want reuse across builds.
     """
 
-    from nuitka.options.Options import shallKeepBackendObjects
-
     keep_objects = shallKeepBackendObjects()
 
     # spell-checker: ignore gcda

--- a/nuitka/build/SconsInterface.py
+++ b/nuitka/build/SconsInterface.py
@@ -49,6 +49,7 @@ from nuitka.options.Options import (
     shallCreateAppBundle,
     shallCreateDiffableCompilationReport,
     shallDisableCCacheUsage,
+    shallKeepBackendObjects,
     shallMakeDll,
     shallMakeExe,
     shallMakeModule,
@@ -201,14 +202,14 @@ def _getInlineSconsVersionForPythonVersion(python_version_info):
     if python_version_info < (2, 7):
         # Non-Windows, Python 2.6, mostly older RHEL
         return "scons-2.3.2"
-    elif os.name == "nt" and python_version_info >= (3, 7):
-        # Windows can use latest, supported MSVC 2026 this way
+    elif python_version_info >= (3, 7):
+        # Modern CPython needs modern Scons .sconsign support.
         return "scons-4.10.1"
     elif os.name == "nt" and python_version_info >= (3, 5):
         # Windows can use latest, supported MSVC 2022 this way
         return "scons-4.3.0"
     else:
-        # Everything else 2.7 or higher works with this.
+        # Python 2.7 and early 3.x
         return "scons-3.1.2"
 
 
@@ -655,31 +656,55 @@ def asBoolStr(value):
 
 
 def cleanSconsDirectory(source_dir):
-    """Clean scons build directory."""
+    """Clean scons build directory.
+
+    Notes:
+        With ``--keep-backend-objects``, previous C sources, headers, constants
+        and object files are preserved so content-stable rewrites can keep
+        mtimes and Scons can skip recompiling unchanged modules. Do not combine
+        with ``--remove-output`` if you want reuse across builds.
+    """
+
+    from nuitka.options.Options import shallKeepBackendObjects
+
+    keep_objects = shallKeepBackendObjects()
 
     # spell-checker: ignore gcda
-    extensions = (
-        ".bin",
-        ".c",
-        ".cpp",
+    extensions = [
         ".exp",
-        ".h",
         ".lib",
         ".manifest",
-        ".o",
-        ".obj",
-        ".os",
         ".rc",
         ".res",
         ".S",
-        ".txt",
         ".pickle",
-        ".const",
         ".gcda",
         ".pgd",
         ".pgc",
         ".json",
-    )
+    ]
+
+    # Full clean: wipe generated sources, objects and constant blobs so builds
+    # cannot pick up stale artifacts from a previous configuration.
+    #
+    # keep-backend-objects must preserve ".bin"/".txt" under blobs/ too: the
+    # data composer rewrites them every run, and content-stable mtimes are
+    # required for durable sconsign to skip re-link.
+    if not keep_objects:
+        extensions.extend(
+            [
+                ".bin",
+                ".txt",
+                ".c",
+                ".cpp",
+                ".h",
+                ".const",
+                ".o",
+                ".obj",
+                ".os",
+            ]
+        )
+    extensions = tuple(extensions)
 
     def check(path):
         if hasFilenameExtension(path, extensions):
@@ -706,6 +731,34 @@ def cleanSconsDirectory(source_dir):
         if os.path.exists(blobs_dir):
             for path, _filename in listDir(blobs_dir):
                 check(path)
+
+
+def removeOrphanBackendSources(source_dir, kept_filenames):
+    """Delete generated module C sources not part of the current compile set.
+
+    Notes:
+        Used with ``--keep-backend-objects`` so ``scanSourceDir`` does not pull
+        stale ``module.*.c`` from a previous inclusion set into the link.
+        Matching ``.const`` sidecars are removed with their orphan ``.c`` files.
+    """
+    if not os.path.isdir(source_dir):
+        return
+
+    kept = set(os.path.basename(path) for path in kept_filenames)
+
+    for path, filename in listDir(source_dir):
+        if not filename.startswith("module."):
+            continue
+
+        # Only consider C/C++ module units for orphan detection. Their .const
+        # sidecars are derived from the same basename.
+        if not hasFilenameExtension(filename, (".c", ".cpp")):
+            continue
+
+        if filename not in kept:
+            deleteFile(path, must_exist=False)
+            const_path = changeFilenameExtension(path, ".const")
+            deleteFile(const_path, must_exist=False)
 
 
 def getCommonSconsOptions():
@@ -782,6 +835,9 @@ def getCommonSconsOptions():
 
     if shallDisableCCacheUsage():
         scons_options["disable_ccache"] = asBoolStr(True)
+
+    if shallKeepBackendObjects():
+        scons_options["keep_backend_objects"] = asBoolStr(True)
 
     if isWin32Windows() and getWindowsConsoleMode() != "attach":
         scons_options["console_mode"] = getWindowsConsoleMode()

--- a/nuitka/build/SconsProgress.py
+++ b/nuitka/build/SconsProgress.py
@@ -7,6 +7,8 @@ This does only the interfacing with tracing and collection of information.
 
 """
 
+import time
+
 from nuitka.Progress import (
     closeProgressBar,
     enableProgressBar,
@@ -28,25 +30,130 @@ _total = None
 _current = 0
 _stage = None
 
+# Backend phase timing (wall clock + summed process deltas).
+_phase_wall_start = None
+_compile_finished_wall = None
+_link_finished_wall = None
+_compile_process_time = 0.0
+_link_process_time = 0.0
+_compile_jobs = 0
+_link_jobs = 0
+_phase_report_emitted = False
+
 
 def setSconsProgressBarTotal(name, total):
     # keep track of how many files there are to know when link comes, pylint: disable=global-statement
-    global _total, _stage
+    global _total, _stage, _phase_wall_start, _compile_finished_wall
+    global _link_finished_wall, _compile_process_time, _link_process_time
+    global _compile_jobs, _link_jobs, _phase_report_emitted, _current
+
     _total = total
     _stage = name
+    _current = 0
+    _phase_wall_start = time.time()
+    _compile_finished_wall = None
+    _link_finished_wall = None
+    _compile_process_time = 0.0
+    _link_process_time = 0.0
+    _compile_jobs = 0
+    _link_jobs = 0
+    _phase_report_emitted = False
 
     setupProgressBar(stage="%s C" % name, unit="file", total=total)
+
+    # Scons runs targets after the .scons script body; emit phase stats on exit.
+    import atexit
+
+    atexit.register(noteSconsBackendFinished)
+
+
+def recordSconsSpawnTiming(is_link, process_delta):
+    """Record one compiler/linker spawn duration for phase breakdown."""
+    # pylint: disable=global-statement
+    global _compile_process_time, _link_process_time, _compile_jobs, _link_jobs
+
+    if process_delta is None:
+        process_delta = 0.0
+
+    if is_link:
+        _link_process_time += process_delta
+        _link_jobs += 1
+    else:
+        _compile_process_time += process_delta
+        _compile_jobs += 1
+
+
+def getSconsBackendPhaseStats():
+    """Return compile/link phase timing collected for the current scons run."""
+    compile_wall = None
+    link_wall = None
+    total_wall = None
+
+    if _phase_wall_start is not None:
+        end_wall = _link_finished_wall or _compile_finished_wall or time.time()
+        total_wall = end_wall - _phase_wall_start
+
+        if _compile_finished_wall is not None:
+            compile_wall = _compile_finished_wall - _phase_wall_start
+            if _link_finished_wall is not None:
+                link_wall = _link_finished_wall - _compile_finished_wall
+        elif _link_finished_wall is not None:
+            # Link-only style runs (or no compile updates).
+            link_wall = _link_finished_wall - _phase_wall_start
+
+    return {
+        "compile_jobs": _compile_jobs,
+        "link_jobs": _link_jobs,
+        "compile_process_time": _compile_process_time,
+        "link_process_time": _link_process_time,
+        "compile_wall": compile_wall,
+        "link_wall": link_wall,
+        "total_wall": total_wall,
+    }
+
+
+def reportSconsBackendPhaseTiming():
+    """Log compile vs link timing once at the end of the backend."""
+    # pylint: disable=global-statement
+    global _phase_report_emitted
+
+    if _phase_report_emitted:
+        return
+
+    stats = getSconsBackendPhaseStats()
+    if stats["total_wall"] is None:
+        return
+
+    _phase_report_emitted = True
+
+    compile_wall = stats["compile_wall"]
+    link_wall = stats["link_wall"]
+
+    scons_logger.info(
+        "Backend phase timing: compile wall %.2fs (process-sum %.2fs, %d job(s)), "
+        "link wall %.2fs (process-sum %.2fs, %d job(s)), total wall %.2fs."
+        % (
+            compile_wall if compile_wall is not None else 0.0,
+            stats["compile_process_time"],
+            stats["compile_jobs"],
+            link_wall if link_wall is not None else 0.0,
+            stats["link_process_time"],
+            stats["link_jobs"],
+            stats["total_wall"],
+        )
+    )
 
 
 def updateSconsProgressBar():
     # Check if link is next, pylint: disable=global-statement
-    global _current
+    global _current, _compile_finished_wall
     _current += 1
 
     reportProgressBar(item=None, update=True)
 
     if _current == _total:
         closeSconsProgressBar()
+        _compile_finished_wall = time.time()
 
         message = "%s C linking" % _stage
 
@@ -63,6 +170,21 @@ def updateSconsProgressBar():
 
 def closeSconsProgressBar():
     closeProgressBar()
+
+
+def noteSconsBackendFinished():
+    """Mark backend finished and emit phase timing."""
+    # pylint: disable=global-statement
+    global _link_finished_wall, _compile_finished_wall
+
+    if _link_finished_wall is None:
+        _link_finished_wall = time.time()
+
+    # If we never reached compile completion (e.g. total==0), still close.
+    if _compile_finished_wall is None and _phase_wall_start is not None:
+        _compile_finished_wall = _phase_wall_start
+
+    reportSconsBackendPhaseTiming()
 
 
 def reportSlowCompilation(env, cmd, delta_time):

--- a/nuitka/build/SconsSpawn.py
+++ b/nuitka/build/SconsSpawn.py
@@ -21,6 +21,7 @@ from nuitka.utils.Timing import TimerReport
 from .SconsCaching import runClCache
 from .SconsProgress import (
     closeSconsProgressBar,
+    recordSconsSpawnTiming,
     reportSlowCompilation,
     updateSconsProgressBar,
 )
@@ -459,13 +460,65 @@ def _runSpawnMonitored(env, args, os_env):
 
         spawn_result = thread.getSpawnResult()
 
+        try:
+            wall_delta = thread.timer_report.getTimer().getDelta()
+        except Exception:  # pylint: disable=broad-except
+            wall_delta = 0.0
+
         if spawn_result.exit_code == 0 and spawn_result.exception is None:
             updateSconsProgressBar()
 
-        return spawn_result
+        return spawn_result, wall_delta
 
     finally:
         _threads.remove(thread)
+
+
+def _findCompileOutputPath(args):
+    """Return the ``-o`` object path from a compile command, if present."""
+    for index, arg in enumerate(args):
+        if arg == "-o" and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith("-o") and len(arg) > 2:
+            return arg[2:]
+
+    return None
+
+
+def _canSkipFreshObjectCompile(source_filename, args):
+    """True when object is newer/equal than its C source under keep-objects.
+
+    Notes:
+        Safety net when Scons still schedules a compile despite a durable
+        sconsign (e.g. partial signature miss). Preferred path is Scons itself
+        deciding up-to-date via the signature DB written when
+        ``--keep-backend-objects`` is enabled.
+    """
+    if source_filename is None or not os.path.isfile(source_filename):
+        return False
+
+    output_path = _findCompileOutputPath(args)
+    if output_path is None:
+        return False
+
+    # Resolve relative to current working directory (scons source_dir).
+    if not os.path.isabs(output_path):
+        output_path = os.path.join(os.getcwd(), output_path)
+    if not os.path.isabs(source_filename):
+        source_filename = os.path.join(os.getcwd(), source_filename)
+
+    if not os.path.isfile(output_path):
+        return False
+
+    # Only skip plain object products, never the final binary link step.
+    output_ext = getFilenameExtension(output_path)
+    if output_ext not in (".o", ".obj", ".os"):
+        return False
+
+    try:
+        return os.path.getmtime(output_path) >= os.path.getmtime(source_filename)
+    except (OSError, IOError):
+        return False
 
 
 def _getWrappedSpawnFunction(env):
@@ -487,13 +540,26 @@ def _getWrappedSpawnFunction(env):
                 source_filename = arg
                 break
 
+        # Object-level incremental: skip compile spawn when the object is still
+        # fresh vs its C source. Requires ``--keep-backend-objects`` (objects
+        # survive cleans, sources keep stable mtimes) and Precious targets so
+        # Scons does not delete objects before the spawn.
+        if _canSkipFreshObjectCompile(source_filename, args):
+            recordSconsSpawnTiming(is_link=False, process_delta=0.0)
+            updateSconsProgressBar()
+            return 0
+
         # Avoid using ccache on binary constants blob, not useful and not working
         # with old ccache.
         if source_filename is not None and source_name.startswith("__constants_data"):
             os_env = dict(os_env)
             os_env["CCACHE_DISABLE"] = "1"
 
-        spawn_result = _runSpawnMonitored(env, args, os_env)
+        spawn_result, wall_delta = _runSpawnMonitored(env, args, os_env)
+
+        recordSconsSpawnTiming(
+            is_link=source_filename is None, process_delta=wall_delta or 0.0
+        )
 
         if spawn_result.exception:
             closeSconsProgressBar()

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -50,18 +50,24 @@ def initScons(arguments):
     os.environ["LC_ALL"] = "C"
     os.environ["VSLANG"] = "1033"
 
-    def no_sync(self):
-        # That's a noop, pylint: disable=unused-argument
-        pass
+    # Historically Nuitka suppressed writing the SCons signature database:
+    # default builds wipe objects, so sconsign cannot help and only adds I/O.
+    # With ``--keep-backend-objects`` we deliberately keep C/objects and need a
+    # durable sconsign so the next process can mark targets up-to-date without
+    # re-spawning the compiler (and without relying only on spawn-time mtime
+    # heuristics). spell-checker: ignore dblite sconsign
+    if not getArgumentBool("keep_backend_objects", False):
 
-    # Avoid scons writing the scons database at all, we don't care for it,
-    # spell-checker: ignore dblite
-    import SCons.dblite  # pylint: disable=I0021,import-error
+        def no_sync(self):
+            # That's a noop, pylint: disable=unused-argument
+            pass
 
-    try:
-        SCons.dblite.dblite.sync = no_sync
-    except AttributeError:
-        SCons.dblite._Dblite.sync = no_sync  # pylint: disable=protected-access
+        import SCons.dblite  # pylint: disable=I0021,import-error
+
+        try:
+            SCons.dblite.dblite.sync = no_sync
+        except AttributeError:
+            SCons.dblite._Dblite.sync = no_sync  # pylint: disable=protected-access
 
     # We use threads during build, so keep locks if necessary for progress bar
     # updates.
@@ -95,6 +101,17 @@ def setupScons(env, source_dir):
     )
 
     env.SConsignFile(sconsign_filename)
+
+    # Keep-objects mode: use content-aware decisions backed by a real sconsign
+    # write (see 'initScons'). Prefer MD5-timestamp so unchanged files with
+    # preserved mtimes are cheap, while content changes still rebuild.
+    if getArgumentBool("keep_backend_objects", False):
+        for decider_name in ("MD5-timestamp", "content-timestamp", "MD5"):
+            try:
+                env.Decider(decider_name)
+                break
+            except Exception:  # pylint: disable=broad-except
+                continue
 
 
 def getArgumentRequired(name):
@@ -1187,23 +1204,33 @@ def createDefinitionsFile(source_dir, filename, definitions):
 
     build_definitions_filename = getNormalizedPathJoin(source_dir, filename)
 
-    with openTextFile(build_definitions_filename, "w", encoding="utf8") as f:
-        for key, value in sorted(definitions.items()):
-            if key == "_NUITKA_BUILD_DEFINITIONS_CATALOG":
-                continue
+    lines = []
+    for key, value in sorted(definitions.items()):
+        if key == "_NUITKA_BUILD_DEFINITIONS_CATALOG":
+            continue
 
-            if type(value) is int or key.endswith(("_BOOL", "_INT")):
-                if type(value) is bool:
-                    value = int(value)
-                f.write("#define %s %s\n" % (key, value))
-            elif key.endswith("_WIDE_STRING") or (
-                key.endswith("_FILENAME") and isWin32Windows()
-            ):
-                assert type(value) in (str, unicode), value
-                f.write("#define %s L%s\n" % (key, makeCLiteral(value)))
-            else:
-                assert type(value) in (str, unicode), value
-                f.write("#define %s %s\n" % (key, makeCLiteral(value)))
+        if type(value) is int or key.endswith(("_BOOL", "_INT")):
+            if type(value) is bool:
+                value = int(value)
+            lines.append("#define %s %s\n" % (key, value))
+        elif key.endswith("_WIDE_STRING") or (
+            key.endswith("_FILENAME") and isWin32Windows()
+        ):
+            assert type(value) in (str, unicode), value
+            lines.append("#define %s L%s\n" % (key, makeCLiteral(value)))
+        else:
+            assert type(value) in (str, unicode), value
+            lines.append("#define %s %s\n" % (key, makeCLiteral(value)))
+
+    contents = "".join(lines)
+
+    # Preserve mtime when definitions are unchanged so object-level incremental
+    # builds are not forced to recompile every translation unit.
+    from nuitka.utils.FileOperations import writeTextFileIfChanged
+
+    writeTextFileIfChanged(
+        filename=build_definitions_filename, contents=contents, encoding="utf8"
+    )
 
 
 def getMsvcVersionString(env):
@@ -1368,7 +1395,14 @@ c) Using "--zig" forces Nuitka download and use Zig for C compilation, but
 
 
 def makeResultPathFileSystemEncodable(env, result_exe):
-    deleteFile(result_exe, must_exist=False)
+    # Default builds always remove the previous binary so a stale result cannot
+    # linger when Scons falsely believes the link is up-to-date. With
+    # ``--keep-backend-objects`` the durable sconsign is the source of truth, so
+    # preserving the binary allows a true no-op backend when nothing changed.
+    keep_backend_objects = bool(getattr(env, "keep_backend_objects", False))
+
+    if not keep_backend_objects:
+        deleteFile(result_exe, must_exist=False)
 
     if os.name == "nt" and not isFilesystemEncodable(result_exe):
         result_exe = getNormalizedPathJoin(
@@ -1379,6 +1413,7 @@ def makeResultPathFileSystemEncodable(env, result_exe):
         if not isFilesystemEncodable(result_exe):
             result_exe = getNormalizedPath(os.path.relpath(result_exe))
 
+        if not keep_backend_objects:
             deleteFile(result_exe, must_exist=False)
 
     return result_exe

--- a/nuitka/build/SconsUtils.py
+++ b/nuitka/build/SconsUtils.py
@@ -50,18 +50,24 @@ def initScons(arguments):
     os.environ["LC_ALL"] = "C"
     os.environ["VSLANG"] = "1033"
 
-    def no_sync(self):
-        # That's a noop, pylint: disable=unused-argument
-        pass
+    # Historically Nuitka suppressed writing the SCons signature database:
+    # default builds wipe objects, so sconsign cannot help and only adds I/O.
+    # With ``--keep-backend-objects`` we deliberately keep C/objects and need a
+    # durable sconsign so the next process can mark targets up-to-date without
+    # re-spawning the compiler (and without relying only on spawn-time mtime
+    # heuristics). spell-checker: ignore dblite sconsign
+    if not getArgumentBool("keep_backend_objects", False):
 
-    # Avoid scons writing the scons database at all, we don't care for it,
-    # spell-checker: ignore dblite
-    import SCons.dblite  # pylint: disable=I0021,import-error
+        def no_sync(self):
+            # That's a noop, pylint: disable=unused-argument
+            pass
 
-    try:
-        SCons.dblite.dblite.sync = no_sync
-    except AttributeError:
-        SCons.dblite._Dblite.sync = no_sync  # pylint: disable=protected-access
+        import SCons.dblite  # pylint: disable=I0021,import-error
+
+        try:
+            SCons.dblite.dblite.sync = no_sync
+        except AttributeError:
+            SCons.dblite._Dblite.sync = no_sync  # pylint: disable=protected-access
 
     # We use threads during build, so keep locks if necessary for progress bar
     # updates.
@@ -95,6 +101,17 @@ def setupScons(env, source_dir):
     )
 
     env.SConsignFile(sconsign_filename)
+
+    # Keep-objects mode: use content-aware decisions backed by a real sconsign
+    # write (see 'initScons'). Prefer MD5-timestamp so unchanged files with
+    # preserved mtimes are cheap, while content changes still rebuild.
+    if getArgumentBool("keep_backend_objects", False):
+        for decider_name in ("MD5-timestamp", "content-timestamp", "MD5"):
+            try:
+                env.Decider(decider_name)
+                break
+            except Exception:  # pylint: disable=broad-except
+                continue
 
 
 def getArgumentRequired(name):
@@ -1186,23 +1203,33 @@ def createDefinitionsFile(source_dir, filename, definitions):
 
     build_definitions_filename = getNormalizedPathJoin(source_dir, filename)
 
-    with openTextFile(build_definitions_filename, "w", encoding="utf8") as f:
-        for key, value in sorted(definitions.items()):
-            if key == "_NUITKA_BUILD_DEFINITIONS_CATALOG":
-                continue
+    lines = []
+    for key, value in sorted(definitions.items()):
+        if key == "_NUITKA_BUILD_DEFINITIONS_CATALOG":
+            continue
 
-            if type(value) is int or key.endswith(("_BOOL", "_INT")):
-                if type(value) is bool:
-                    value = int(value)
-                f.write("#define %s %s\n" % (key, value))
-            elif key.endswith("_WIDE_STRING") or (
-                key.endswith("_FILENAME") and isWin32Windows()
-            ):
-                assert type(value) in (str, unicode), value
-                f.write("#define %s L%s\n" % (key, makeCLiteral(value)))
-            else:
-                assert type(value) in (str, unicode), value
-                f.write("#define %s %s\n" % (key, makeCLiteral(value)))
+        if type(value) is int or key.endswith(("_BOOL", "_INT")):
+            if type(value) is bool:
+                value = int(value)
+            lines.append("#define %s %s\n" % (key, value))
+        elif key.endswith("_WIDE_STRING") or (
+            key.endswith("_FILENAME") and isWin32Windows()
+        ):
+            assert type(value) in (str, unicode), value
+            lines.append("#define %s L%s\n" % (key, makeCLiteral(value)))
+        else:
+            assert type(value) in (str, unicode), value
+            lines.append("#define %s %s\n" % (key, makeCLiteral(value)))
+
+    contents = "".join(lines)
+
+    # Preserve mtime when definitions are unchanged so object-level incremental
+    # builds are not forced to recompile every translation unit.
+    from nuitka.utils.FileOperations import writeTextFileIfChanged
+
+    writeTextFileIfChanged(
+        filename=build_definitions_filename, contents=contents, encoding="utf8"
+    )
 
 
 def getMsvcVersionString(env):
@@ -1367,7 +1394,14 @@ c) Using "--zig" forces Nuitka download and use Zig for C compilation, but
 
 
 def makeResultPathFileSystemEncodable(env, result_exe):
-    deleteFile(result_exe, must_exist=False)
+    # Default builds always remove the previous binary so a stale result cannot
+    # linger when Scons falsely believes the link is up-to-date. With
+    # ``--keep-backend-objects`` the durable sconsign is the source of truth, so
+    # preserving the binary allows a true no-op backend when nothing changed.
+    keep_backend_objects = bool(getattr(env, "keep_backend_objects", False))
+
+    if not keep_backend_objects:
+        deleteFile(result_exe, must_exist=False)
 
     if os.name == "nt" and not isFilesystemEncodable(result_exe):
         result_exe = getNormalizedPathJoin(
@@ -1378,6 +1412,7 @@ def makeResultPathFileSystemEncodable(env, result_exe):
         if not isFilesystemEncodable(result_exe):
             result_exe = getNormalizedPath(os.path.relpath(result_exe))
 
+        if not keep_backend_objects:
             deleteFile(result_exe, must_exist=False)
 
     return result_exe

--- a/nuitka/build/inline_copy/bin/scons.py
+++ b/nuitka/build/inline_copy/bin/scons.py
@@ -22,8 +22,10 @@ if __name__ == "__main__":
     if sys.version_info < (2, 7):
         # Non-Windows, Python 2.6, mostly older RHEL
         scons_version = "scons-2.3.2"
-    elif os.name == "nt" and sys.version_info >= (3, 7):
-        # Windows can use latest, supported MSVC 2026 this way
+    elif sys.version_info >= (3, 7):
+        # Modern CPython needs modern Scons .sconsign support. Older
+        # scons-3.1.2 writes empty signature databases on current Python,
+        # which forces full rebuilds even when object files are kept.
         scons_version = "scons-4.10.1"
     elif os.name == "nt" and sys.version_info >= (3, 5):
         # Windows can use latest, supported MSVC 2022 this way
@@ -31,9 +33,10 @@ if __name__ == "__main__":
 
         # The caching of MSVC is not supported for the older Scons,
         # so remove that.
-        del os.environ["SCONS_CACHE_MSVC_CONFIG"]
+        if "SCONS_CACHE_MSVC_CONFIG" in os.environ:
+            del os.environ["SCONS_CACHE_MSVC_CONFIG"]
     else:
-        # Everything else 2.7 or higher works with this.
+        # Python 2.7 and early 3.x
         scons_version = "scons-3.1.2"
 
     sys.path.insert(

--- a/nuitka/build/inline_copy/lib/scons-4.10.1/SCons/Tool/__init__.py
+++ b/nuitka/build/inline_copy/lib/scons-4.10.1/SCons/Tool/__init__.py
@@ -775,8 +775,9 @@ def tool_list(platform, env):
         fortran_compilers = ['gfortran', 'g77', 'ifort', 'ifl', 'f95', 'f90', 'f77']
         ars = ['ar', ]
 
-    if not str(platform) == 'win32':
-        other_plat_tools += ['m4', 'rpm']
+    # Nuitka: Avoid unused tools (rpm/m4 are not shipped in the inline copy).
+    # if not str(platform) == 'win32':
+    #     other_plat_tools += ['m4', 'rpm']
 
     c_compiler = FindTool(c_compilers, env) or c_compilers[0]
 

--- a/nuitka/optimizations/Optimization.py
+++ b/nuitka/optimizations/Optimization.py
@@ -64,6 +64,7 @@ def signalChange(tags, source_ref, message):
 
 
 def optimizeCompiledPythonModule(module):
+    # Many details to deal with, pylint: disable=too-many-branches
     module_name = module.getFullName()
 
     optimization_logger.info_if_file(
@@ -85,7 +86,7 @@ def optimizeCompiledPythonModule(module):
     if isExperimental("module-frontend-skip-optimize") or isExperimental(
         "module-frontend-stub"
     ):
-        # L1: memoized probe — later optimization passes must not re-hash/
+        # L1: memoized probe - later optimization passes must not re-hash/
         # re-validate cache, but must still re-run dependency discovery.
         # startTraversal() resets done/active modules each pass, so skipping
         # considerUsedModules on pass 2+ collapses the inclusion set.
@@ -93,8 +94,6 @@ def optimizeCompiledPythonModule(module):
             if isModuleFrontendStub(module):
                 # Ensure optimize-skip stats/reconcile see stubs even when the
                 # probe path is not re-entered.
-                from nuitka.ModuleFrontendCaching import tryProbeAndPrepareOptimizeSkip
-
                 tryProbeAndPrepareOptimizeSkip(module)
 
             module.attemptRecursion()

--- a/nuitka/optimizations/Optimization.py
+++ b/nuitka/optimizations/Optimization.py
@@ -73,6 +73,39 @@ def optimizeCompiledPythonModule(module):
         other_logger=progress_logger,
     )
 
+    # Optional: skip local computeModule micro-passes when a validated frontend
+    # cache entry exists (or the module is an L3 no-AST stub). Dependency
+    # discovery still runs via considerUsedModules after replaying cached usage.
+    from nuitka.ModuleFrontendCaching import (
+        isModuleFrontendStub,
+        tryProbeAndPrepareOptimizeSkip,
+        wasModuleOptimizeSkipped,
+    )
+
+    if isExperimental("module-frontend-skip-optimize") or isExperimental(
+        "module-frontend-stub"
+    ):
+        # L1: memoized probe — later optimization passes must not re-hash/
+        # re-validate cache, but must still re-run dependency discovery.
+        # startTraversal() resets done/active modules each pass, so skipping
+        # considerUsedModules on pass 2+ collapses the inclusion set.
+        if wasModuleOptimizeSkipped(module) or isModuleFrontendStub(module):
+            if isModuleFrontendStub(module):
+                # Ensure optimize-skip stats/reconcile see stubs even when the
+                # probe path is not re-entered.
+                from nuitka.ModuleFrontendCaching import tryProbeAndPrepareOptimizeSkip
+
+                tryProbeAndPrepareOptimizeSkip(module)
+
+            module.attemptRecursion()
+            considerUsedModules(module=module, pass_count=pass_count)
+            return False, 0
+
+        if tryProbeAndPrepareOptimizeSkip(module):
+            module.attemptRecursion()
+            considerUsedModules(module=module, pass_count=pass_count)
+            return False, 0
+
     touched = False
 
     # TODO: Make this an option for the user to control instead.
@@ -344,6 +377,25 @@ def _makeOptimizationPass():
 
         if changed:
             unfinished_modules.add(current_module)
+
+    # When some modules skipped local optimize, ExpressionFunctionRef edges were
+    # never walked, so owner modules may not have marked helper functions as
+    # used. Reconcile those edges before pruning unused functions, or cross-module
+    # helpers (often on __main__) disappear and linking fails.
+    from nuitka.ModuleFrontendCaching import (
+        getModuleFrontendCacheStats,
+        getModuleFrontendOptimizeSkipStats,
+        reconcileCrossModuleFunctionUses,
+    )
+
+    skip_stats = getModuleFrontendOptimizeSkipStats()
+    cache_stats = getModuleFrontendCacheStats()
+    if (
+        skip_stats.get("skip", 0)
+        or skip_stats.get("stub", 0)
+        or cache_stats.get("stub", 0)
+    ):
+        reconcileCrossModuleFunctionUses()
 
     # Unregister collection traces from now unused code, dropping the trace
     # collections of functions no longer used. This must be done after global

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -983,6 +983,17 @@ Defaults to off.""",
 )
 
 output_group.add_option(
+    "--keep-backend-objects",
+    action="store_true",
+    dest="keep_backend_objects",
+    default=False,
+    help="""\
+Keep previous C object files in the build directory and only rewrite C/.const
+sources when their contents change. This allows Scons to skip recompiling
+unchanged modules (object-level incremental backend). Defaults to off.""",
+)
+
+output_group.add_option(
     "--no-pyi-file",
     action="store_false",
     dest="pyi_file",
@@ -1475,10 +1486,23 @@ del c_compiler_group
 
 caching_group = parser.add_option_group("Cache Control")
 
-_cache_names = ("all", "ccache", "bytecode", "compression")
+_cache_names = ("all", "ccache", "bytecode", "compression", "module-frontend")
 
 if isWin32Windows():
     _cache_names += ("dll-dependencies",)
+
+caching_group.add_option(
+    "--enable-module-frontend-cache",
+    action="store_true",
+    dest="enable_module_frontend_cache",
+    default=False,
+    help="""\
+Enable optional caching of generated C sources for compiled non-main modules.
+When enabled, unchanged modules can reuse previously generated module C and
+const payloads across compilations. Disabled by default so existing builds are
+unaffected. Can be combined with "--disable-cache=module-frontend" to turn the
+feature off again even if this flag is given.""",
+)
 
 caching_group.add_option(
     "--disable-cache",

--- a/nuitka/options/OptionParsing.py
+++ b/nuitka/options/OptionParsing.py
@@ -983,6 +983,17 @@ Defaults to off.""",
 )
 
 output_group.add_option(
+    "--keep-backend-objects",
+    action="store_true",
+    dest="keep_backend_objects",
+    default=False,
+    help="""\
+Keep previous C object files in the build directory and only rewrite C/.const
+sources when their contents change. This allows Scons to skip recompiling
+unchanged modules (object-level incremental backend). Defaults to off.""",
+)
+
+output_group.add_option(
     "--no-pyi-file",
     action="store_false",
     dest="pyi_file",
@@ -1446,10 +1457,23 @@ del c_compiler_group
 
 caching_group = parser.add_option_group("Cache Control")
 
-_cache_names = ("all", "ccache", "bytecode", "compression")
+_cache_names = ("all", "ccache", "bytecode", "compression", "module-frontend")
 
 if isWin32Windows():
     _cache_names += ("dll-dependencies",)
+
+caching_group.add_option(
+    "--enable-module-frontend-cache",
+    action="store_true",
+    dest="enable_module_frontend_cache",
+    default=False,
+    help="""\
+Enable optional caching of generated C sources for compiled non-main modules.
+When enabled, unchanged modules can reuse previously generated module C and
+const payloads across compilations. Disabled by default so existing builds are
+unaffected. Can be combined with "--disable-cache=module-frontend" to turn the
+feature off again even if this flag is given.""",
+)
 
 caching_group.add_option(
     "--disable-cache",

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -2238,6 +2238,19 @@ def shallDisableBytecodeCacheUsage():
     return shallDisableCacheUsage("bytecode")
 
 
+def shallUseModuleFrontendCache():
+    """:returns: bool derived from ``--enable-module-frontend-cache``.
+
+    Notes:
+        The feature is opt-in. Even when enabled, ``--disable-cache=module-frontend``
+        or ``--disable-cache=all`` still turns usage off.
+    """
+    if options is None:
+        return False
+
+    return bool(getattr(options, "enable_module_frontend_cache", False))
+
+
 def shallDisableCompressionCacheUsage():
     """:returns: bool derived from ``--disable-cache=compression``"""
     return shallDisableCacheUsage("compression")
@@ -2325,6 +2338,21 @@ def isShowPluginUsage():
 def isRemoveBuildDir():
     """:returns: bool derived from ``--remove-output``"""
     return options.remove_build and not options.generate_c_only
+
+
+def shallKeepBackendObjects():
+    """:returns: bool derived from ``--keep-backend-objects``.
+
+    Notes:
+        When enabled, Nuitka keeps previous ``.o``/``.obj`` files and only
+        rewrites generated C sources when contents differ, so Scons can reuse
+        objects for unchanged modules. Implies not fully wiping object files in
+        ``cleanSconsDirectory``.
+    """
+    if options is None:
+        return False
+
+    return bool(getattr(options, "keep_backend_objects", False))
 
 
 def isDeploymentMode():

--- a/nuitka/options/Options.py
+++ b/nuitka/options/Options.py
@@ -2124,6 +2124,19 @@ def shallDisableBytecodeCacheUsage():
     return shallDisableCacheUsage("bytecode")
 
 
+def shallUseModuleFrontendCache():
+    """:returns: bool derived from ``--enable-module-frontend-cache``.
+
+    Notes:
+        The feature is opt-in. Even when enabled, ``--disable-cache=module-frontend``
+        or ``--disable-cache=all`` still turns usage off.
+    """
+    if options is None:
+        return False
+
+    return bool(getattr(options, "enable_module_frontend_cache", False))
+
+
 def shallDisableCompressionCacheUsage():
     """:returns: bool derived from ``--disable-cache=compression``"""
     return shallDisableCacheUsage("compression")
@@ -2176,6 +2189,21 @@ def isShowPluginUsage():
 def isRemoveBuildDir():
     """:returns: bool derived from ``--remove-output``"""
     return options.remove_build and not options.generate_c_only
+
+
+def shallKeepBackendObjects():
+    """:returns: bool derived from ``--keep-backend-objects``.
+
+    Notes:
+        When enabled, Nuitka keeps previous ``.o``/``.obj`` files and only
+        rewrites generated C sources when contents differ, so Scons can reuse
+        objects for unchanged modules. Implies not fully wiping object files in
+        ``cleanSconsDirectory``.
+    """
+    if options is None:
+        return False
+
+    return bool(getattr(options, "keep_backend_objects", False))
 
 
 def isDeploymentMode():

--- a/nuitka/reports/Reports.py
+++ b/nuitka/reports/Reports.py
@@ -15,12 +15,6 @@ import traceback
 from nuitka.__past__ import unicode
 from nuitka.build.DataComposerInterface import getDataComposerReportValues
 from nuitka.build.SconsCaching import getCcacheModuleStats
-from nuitka.ModuleFrontendCaching import (
-    getModuleFrontendCacheModuleResults,
-    getModuleFrontendCacheStats,
-    getModuleFrontendOptimizeSkipModuleResults,
-    getModuleFrontendOptimizeSkipStats,
-)
 from nuitka.build.SconsUtils import (
     getSconsCompilerUsed,
     getSconsObjectSizes,
@@ -44,6 +38,12 @@ from nuitka.installer.Installer import (
     getInstallerOutputFilename,
     getInstallerToolVersion,
     wasInstallerCreated,
+)
+from nuitka.ModuleFrontendCaching import (
+    getModuleFrontendCacheModuleResults,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipModuleResults,
+    getModuleFrontendOptimizeSkipStats,
 )
 from nuitka.ModuleRegistry import (
     getDoneModules,

--- a/nuitka/reports/Reports.py
+++ b/nuitka/reports/Reports.py
@@ -15,6 +15,12 @@ import traceback
 from nuitka.__past__ import unicode
 from nuitka.build.DataComposerInterface import getDataComposerReportValues
 from nuitka.build.SconsCaching import getCcacheModuleStats
+from nuitka.ModuleFrontendCaching import (
+    getModuleFrontendCacheModuleResults,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipModuleResults,
+    getModuleFrontendOptimizeSkipStats,
+)
 from nuitka.build.SconsUtils import (
     getSconsCompilerUsed,
     getSconsObjectSizes,
@@ -326,10 +332,22 @@ def _getReportInputData(aborted):
             source_dir=getSourceDirectoryPath(onefile=False, create=False)
         )
         scons_ccache_stats = getCcacheModuleStats()
+        module_frontend_cache_stats = getModuleFrontendCacheStats()
+        module_frontend_cache_module_results = getModuleFrontendCacheModuleResults()
+        module_frontend_optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+        module_frontend_optimize_skip_module_results = (
+            getModuleFrontendOptimizeSkipModuleResults()
+        )
     else:
         scons_error_report_data = {}
         scons_resource_usage_data = {}
         scons_ccache_stats = {}
+        module_frontend_cache_stats = getModuleFrontendCacheStats()
+        module_frontend_cache_module_results = getModuleFrontendCacheModuleResults()
+        module_frontend_optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+        module_frontend_optimize_skip_module_results = (
+            getModuleFrontendOptimizeSkipModuleResults()
+        )
         output_run_filename = "failed too early"
         backend_executable = "failed too early"
         backend_executable_size = None
@@ -979,6 +997,54 @@ def writeCompilationReport(report_filename, report_input_data, diffable):
             memory_infos=report_input_data["memory_infos"],
             diffable=diffable,
         )
+
+    module_frontend_cache_stats = report_input_data.get("module_frontend_cache_stats")
+    if module_frontend_cache_stats and any(module_frontend_cache_stats.values()):
+        mfc_node = appendTreeElement(
+            root,
+            "module-frontend-cache",
+            hit=str(module_frontend_cache_stats.get("hit", 0)),
+            miss=str(module_frontend_cache_stats.get("miss", 0)),
+            store=str(module_frontend_cache_stats.get("store", 0)),
+            bypass=str(module_frontend_cache_stats.get("bypass", 0)),
+            invalid=str(module_frontend_cache_stats.get("invalid", 0)),
+            stub=str(module_frontend_cache_stats.get("stub", 0)),
+        )
+        for module_name, info in sorted(
+            report_input_data.get("module_frontend_cache_module_results", {}).items()
+        ):
+            appendTreeElement(
+                mfc_node,
+                "module",
+                name=module_name,
+                result=info.get("result", ""),
+                reason=info.get("reason", ""),
+            )
+
+    optimize_skip_stats = report_input_data.get("module_frontend_optimize_skip_stats")
+    if optimize_skip_stats and any(optimize_skip_stats.values()):
+        skip_node = appendTreeElement(
+            root,
+            "module-frontend-optimize-skip",
+            skip=str(optimize_skip_stats.get("skip", 0)),
+            stub=str(optimize_skip_stats.get("stub", 0)),
+            full=str(optimize_skip_stats.get("full", 0)),
+            probe_miss=str(optimize_skip_stats.get("probe_miss", 0)),
+            probe_invalid=str(optimize_skip_stats.get("probe_invalid", 0)),
+            probe_bypass=str(optimize_skip_stats.get("probe_bypass", 0)),
+        )
+        for module_name, info in sorted(
+            report_input_data.get(
+                "module_frontend_optimize_skip_module_results", {}
+            ).items()
+        ):
+            appendTreeElement(
+                skip_node,
+                "module",
+                name=module_name,
+                result=info.get("result", ""),
+                reason=info.get("reason", ""),
+            )
 
     for included_datafile in getIncludedDataFiles():
         if included_datafile.kind == "data_file":

--- a/nuitka/reports/Reports.py
+++ b/nuitka/reports/Reports.py
@@ -15,6 +15,12 @@ import traceback
 from nuitka.__past__ import unicode
 from nuitka.build.DataComposerInterface import getDataComposerReportValues
 from nuitka.build.SconsCaching import getCcacheModuleStats
+from nuitka.ModuleFrontendCaching import (
+    getModuleFrontendCacheModuleResults,
+    getModuleFrontendCacheStats,
+    getModuleFrontendOptimizeSkipModuleResults,
+    getModuleFrontendOptimizeSkipStats,
+)
 from nuitka.build.SconsUtils import (
     getSconsCompilerUsed,
     getSconsObjectSizes,
@@ -320,10 +326,22 @@ def _getReportInputData(aborted):
             source_dir=getSourceDirectoryPath(onefile=False, create=False)
         )
         scons_ccache_stats = getCcacheModuleStats()
+        module_frontend_cache_stats = getModuleFrontendCacheStats()
+        module_frontend_cache_module_results = getModuleFrontendCacheModuleResults()
+        module_frontend_optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+        module_frontend_optimize_skip_module_results = (
+            getModuleFrontendOptimizeSkipModuleResults()
+        )
     else:
         scons_error_report_data = {}
         scons_resource_usage_data = {}
         scons_ccache_stats = {}
+        module_frontend_cache_stats = getModuleFrontendCacheStats()
+        module_frontend_cache_module_results = getModuleFrontendCacheModuleResults()
+        module_frontend_optimize_skip_stats = getModuleFrontendOptimizeSkipStats()
+        module_frontend_optimize_skip_module_results = (
+            getModuleFrontendOptimizeSkipModuleResults()
+        )
         output_run_filename = "failed too early"
         backend_executable = "failed too early"
         backend_executable_size = None
@@ -966,6 +984,54 @@ def writeCompilationReport(report_filename, report_input_data, diffable):
             memory_infos=report_input_data["memory_infos"],
             diffable=diffable,
         )
+
+    module_frontend_cache_stats = report_input_data.get("module_frontend_cache_stats")
+    if module_frontend_cache_stats and any(module_frontend_cache_stats.values()):
+        mfc_node = appendTreeElement(
+            root,
+            "module-frontend-cache",
+            hit=str(module_frontend_cache_stats.get("hit", 0)),
+            miss=str(module_frontend_cache_stats.get("miss", 0)),
+            store=str(module_frontend_cache_stats.get("store", 0)),
+            bypass=str(module_frontend_cache_stats.get("bypass", 0)),
+            invalid=str(module_frontend_cache_stats.get("invalid", 0)),
+            stub=str(module_frontend_cache_stats.get("stub", 0)),
+        )
+        for module_name, info in sorted(
+            report_input_data.get("module_frontend_cache_module_results", {}).items()
+        ):
+            appendTreeElement(
+                mfc_node,
+                "module",
+                name=module_name,
+                result=info.get("result", ""),
+                reason=info.get("reason", ""),
+            )
+
+    optimize_skip_stats = report_input_data.get("module_frontend_optimize_skip_stats")
+    if optimize_skip_stats and any(optimize_skip_stats.values()):
+        skip_node = appendTreeElement(
+            root,
+            "module-frontend-optimize-skip",
+            skip=str(optimize_skip_stats.get("skip", 0)),
+            stub=str(optimize_skip_stats.get("stub", 0)),
+            full=str(optimize_skip_stats.get("full", 0)),
+            probe_miss=str(optimize_skip_stats.get("probe_miss", 0)),
+            probe_invalid=str(optimize_skip_stats.get("probe_invalid", 0)),
+            probe_bypass=str(optimize_skip_stats.get("probe_bypass", 0)),
+        )
+        for module_name, info in sorted(
+            report_input_data.get(
+                "module_frontend_optimize_skip_module_results", {}
+            ).items()
+        ):
+            appendTreeElement(
+                skip_node,
+                "module",
+                name=module_name,
+                result=info.get("result", ""),
+                reason=info.get("reason", ""),
+            )
 
     for included_datafile in getIncludedDataFiles():
         if included_datafile.kind == "data_file":

--- a/nuitka/tools/data_composer/DataComposer.py
+++ b/nuitka/tools/data_composer/DataComposer.py
@@ -28,7 +28,12 @@ from nuitka.Serialization import (
     ConstantStreamReader,
 )
 from nuitka.Tracing import data_composer_logger
-from nuitka.utils.FileOperations import getFileSize, listDir, syncFileOutput
+from nuitka.utils.FileOperations import (
+    getFileSize,
+    listDir,
+    syncFileOutput,
+    writeBinaryFileIfChanged,
+)
 from nuitka.utils.Json import writeJsonToFilename
 
 _max_uint64_t_value = 2**64 - 1
@@ -503,34 +508,43 @@ def _writeConstantStream(constants_reader, blob_spec):
 
 
 def _writeConstantsBlob(output_filename, desc):
-    with open(output_filename, "wb") as output:
-        for name, part in desc:
-            output.write(name + b"\0")
-            output.write(struct.pack("I", len(part)))
-            output.write(part)
+    # Build in memory so unchanged blobs keep their mtime (needed for durable
+    # sconsign / keep-backend-objects link skip).
+    chunks = []
+    for name, part in desc:
+        chunks.append(name + b"\0")
+        chunks.append(struct.pack("I", len(part)))
+        chunks.append(part)
 
-        data_size = output.tell()
+    contents = b"".join(chunks)
+    data_size = len(contents)
 
-        data_composer_logger.info("Total constants blob size %d." % data_size)
+    changed = writeBinaryFileIfChanged(output_filename, contents)
+    if changed:
+        # Ensure durable write when we actually replaced the blob.
+        with open(output_filename, "rb") as output:
+            syncFileOutput(output)
 
-        syncFileOutput(output)
+    data_composer_logger.info(
+        "Total constants blob size %d%s."
+        % (data_size, "" if changed else " (unchanged)")
+    )
 
 
 def _writeConstantBlob(output_filename, part):
-    with open(output_filename, "wb") as output:
-        output.write(part)
+    changed = writeBinaryFileIfChanged(output_filename, part)
+    if changed:
+        with open(output_filename, "rb") as output:
+            syncFileOutput(output)
 
-        data_size = output.tell()
-
-        data_composer_logger.info(
-            "Created constants blob '%s' size %d."
-            % (
-                os.path.basename(output_filename),
-                data_size,
-            )
+    data_composer_logger.info(
+        "Created constants blob '%s' size %d%s."
+        % (
+            os.path.basename(output_filename),
+            len(part),
+            "" if changed else " (unchanged)",
         )
-
-        syncFileOutput(output)
+    )
 
 
 def main():

--- a/nuitka/tree/Building.py
+++ b/nuitka/tree/Building.py
@@ -1441,6 +1441,31 @@ def buildModule(
                     module_filename=module_filename,
                 )
 
+        # L3 module-frontend stub: when a validated C cache entry exists, skip
+        # parse/AST/tree building entirely and only replay dependency edges.
+        if not is_main and not is_top and source_code is not None:
+            from nuitka.ModuleFrontendCaching import tryBuildCachedFrontendModule
+
+            stub_mode = decideCompilationMode(
+                is_top=is_top,
+                module_name=module_name,
+                module_filename=module_filename,
+                for_pgo=False,
+            )
+            stub_module = tryBuildCachedFrontendModule(
+                module_name=module_name,
+                module_filename=module_filename,
+                reason=reason,
+                source_code=source_code,
+                source_ref=source_ref,
+                is_package=is_package,
+                is_top=is_top,
+                is_main=is_main,
+                mode=stub_mode,
+            )
+            if stub_module is not None:
+                return stub_module
+
         try:
             with withNoSyntaxWarning():
                 ast_tree = parseSourceCodeToAst(

--- a/nuitka/tree/Building.py
+++ b/nuitka/tree/Building.py
@@ -1444,7 +1444,9 @@ def buildModule(
         # L3 module-frontend stub: when a validated C cache entry exists, skip
         # parse/AST/tree building entirely and only replay dependency edges.
         if not is_main and not is_top and source_code is not None:
-            from nuitka.ModuleFrontendCaching import tryBuildCachedFrontendModule
+            from nuitka.ModuleFrontendCaching import (
+                tryBuildCachedFrontendModule,
+            )
 
             stub_mode = decideCompilationMode(
                 is_top=is_top,

--- a/nuitka/tree/Building.py
+++ b/nuitka/tree/Building.py
@@ -1368,7 +1368,7 @@ def buildModule(
     hide_syntax_error,
 ):
     # Many details to deal with,
-    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements,too-many-statements
     (
         main_added,
         is_package,

--- a/nuitka/tree/Building.py
+++ b/nuitka/tree/Building.py
@@ -1385,6 +1385,31 @@ def buildModule(
                     module_filename=module_filename,
                 )
 
+        # L3 module-frontend stub: when a validated C cache entry exists, skip
+        # parse/AST/tree building entirely and only replay dependency edges.
+        if not is_main and not is_top and source_code is not None:
+            from nuitka.ModuleFrontendCaching import tryBuildCachedFrontendModule
+
+            stub_mode = decideCompilationMode(
+                is_top=is_top,
+                module_name=module_name,
+                module_filename=module_filename,
+                for_pgo=False,
+            )
+            stub_module = tryBuildCachedFrontendModule(
+                module_name=module_name,
+                module_filename=module_filename,
+                reason=reason,
+                source_code=source_code,
+                source_ref=source_ref,
+                is_package=is_package,
+                is_top=is_top,
+                is_main=is_main,
+                mode=stub_mode,
+            )
+            if stub_module is not None:
+                return stub_module
+
         try:
             with withNoSyntaxWarning():
                 ast_tree = parseSourceCodeToAst(

--- a/nuitka/tree/SourceHandling.py
+++ b/nuitka/tree/SourceHandling.py
@@ -351,9 +351,7 @@ def writeSourceCode(filename, source_code, logger, assume_yes_for_downloads):
         # detection or something else has failed.
         assert not os.path.isfile(filename), filename
 
-        putTextFileContents(
-            filename=filename, contents=source_code, encoding="latin1"
-        )
+        putTextFileContents(filename=filename, contents=source_code, encoding="latin1")
 
     if hasFilenameExtension(filename, (".c", ".h")) and shallGenerateReadableCode():
         formatC(

--- a/nuitka/tree/SourceHandling.py
+++ b/nuitka/tree/SourceHandling.py
@@ -17,6 +17,7 @@ from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.format.FileFormatting import formatC
 from nuitka.options.Options import (
     shallGenerateReadableCode,
+    shallKeepBackendObjects,
     shallShowSourceModifications,
 )
 from nuitka.plugins.Hooks import onModuleSourceCode
@@ -34,6 +35,7 @@ from nuitka.utils.FileOperations import (
     hasFilenameExtension,
     putTextFileContents,
     stripFileContentsBOM,
+    writeTextFileIfChanged,
 )
 from nuitka.utils.ModuleNames import ModuleName, checkModuleName
 from nuitka.utils.Shebang import getShebangFromSource, parseShebang
@@ -338,11 +340,20 @@ def readSourceLines(source_ref):
 
 
 def writeSourceCode(filename, source_code, logger, assume_yes_for_downloads):
-    # Prevent accidental overwriting. When this happens the collision detection
-    # or something else has failed.
-    assert not os.path.isfile(filename), filename
+    # With object-level incremental backend, existing files are expected and are
+    # only rewritten when contents change so mtime/Scons can skip recompiles.
+    if shallKeepBackendObjects() and os.path.isfile(filename):
+        writeTextFileIfChanged(
+            filename=filename, contents=source_code, encoding="latin1"
+        )
+    else:
+        # Prevent accidental overwriting. When this happens the collision
+        # detection or something else has failed.
+        assert not os.path.isfile(filename), filename
 
-    putTextFileContents(filename=filename, contents=source_code, encoding="latin1")
+        putTextFileContents(
+            filename=filename, contents=source_code, encoding="latin1"
+        )
 
     if hasFilenameExtension(filename, (".c", ".h")) and shallGenerateReadableCode():
         formatC(

--- a/nuitka/tree/SourceHandling.py
+++ b/nuitka/tree/SourceHandling.py
@@ -17,6 +17,7 @@ from nuitka.containers.OrderedSets import OrderedSet
 from nuitka.format.FileFormatting import formatC
 from nuitka.options.Options import (
     shallGenerateReadableCode,
+    shallKeepBackendObjects,
     shallShowSourceModifications,
 )
 from nuitka.plugins.Hooks import onModuleSourceCode
@@ -33,6 +34,7 @@ from nuitka.utils.FileOperations import (
     hasFilenameExtension,
     putTextFileContents,
     stripFileContentsBOM,
+    writeTextFileIfChanged,
 )
 from nuitka.utils.ModuleNames import ModuleName, checkModuleName
 from nuitka.utils.Shebang import getShebangFromSource, parseShebang
@@ -335,11 +337,20 @@ def readSourceLines(source_ref):
 
 
 def writeSourceCode(filename, source_code, logger, assume_yes_for_downloads):
-    # Prevent accidental overwriting. When this happens the collision detection
-    # or something else has failed.
-    assert not os.path.isfile(filename), filename
+    # With object-level incremental backend, existing files are expected and are
+    # only rewritten when contents change so mtime/Scons can skip recompiles.
+    if shallKeepBackendObjects() and os.path.isfile(filename):
+        writeTextFileIfChanged(
+            filename=filename, contents=source_code, encoding="latin1"
+        )
+    else:
+        # Prevent accidental overwriting. When this happens the collision
+        # detection or something else has failed.
+        assert not os.path.isfile(filename), filename
 
-    putTextFileContents(filename=filename, contents=source_code, encoding="latin1")
+        putTextFileContents(
+            filename=filename, contents=source_code, encoding="latin1"
+        )
 
     if hasFilenameExtension(filename, (".c", ".h")) and shallGenerateReadableCode():
         formatC(

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -1251,6 +1251,41 @@ def putTextFileContents(filename, contents, encoding=None):
             _writeContents(output_file)
 
 
+def writeTextFileIfChanged(filename, contents, encoding=None):
+    """Write text file only if missing or content differs.
+
+    Notes:
+        Preserves mtime when content is unchanged so build tools (Scons, ccache)
+        can skip recompilation of identical C sources.
+
+    Args:
+        filename: destination path
+        contents: full text contents to write
+        encoding: optional text encoding
+
+    Returns:
+        bool: True if the file was written/updated, False if left unchanged.
+    """
+    if isinstance(contents, basestring):
+        new_text = contents
+    else:
+        new_text = "".join(
+            line if line.endswith("\n") else (line + "\n") for line in contents
+        )
+
+    if os.path.isfile(filename):
+        try:
+            old_text = getFileContents(filename, encoding=encoding)
+        except (OSError, IOError, UnicodeError):
+            old_text = None
+
+        if old_text == new_text:
+            return False
+
+    putTextFileContents(filename=filename, contents=new_text, encoding=encoding)
+    return True
+
+
 def putBinaryFileContents(filename, contents):
     """Write a binary file from given contents.
 
@@ -1265,6 +1300,33 @@ def putBinaryFileContents(filename, contents):
     with withFileLock("writing file %s" % filename):
         with openTextFile(filename, "wb") as output_file:
             output_file.write(contents)
+
+
+def writeBinaryFileIfChanged(filename, contents):
+    """Write binary file only if missing or content differs.
+
+    Notes:
+        Preserves mtime when content is unchanged so Scons/sconsign can treat
+        constant blobs as up-to-date and skip re-link when nothing changed.
+
+    Args:
+        filename: destination path
+        contents: full binary contents to write
+
+    Returns:
+        bool: True if the file was written/updated, False if left unchanged.
+    """
+    if os.path.isfile(filename):
+        try:
+            if os.path.getsize(filename) == len(contents):
+                with open(filename, "rb") as existing_file:
+                    if existing_file.read() == contents:
+                        return False
+        except (OSError, IOError):
+            pass
+
+    putBinaryFileContents(filename=filename, contents=contents)
+    return True
 
 
 def changeTextFileContents(filename, contents, encoding=None, compare_only=False):
@@ -1494,6 +1556,32 @@ def copyFile(source_path, dest_path):
             raise
 
         break
+
+
+def copyFileIfChanged(source_path, dest_path):
+    """Copy file only when destination is missing or content differs.
+
+    Notes:
+        Used for module-frontend cache restore so unchanged C/.const keep their
+        mtime and object files can be reused by Scons.
+
+    Returns:
+        bool: True if destination was written, False if left unchanged.
+    """
+    if os.path.isfile(dest_path):
+        try:
+            if os.path.getsize(source_path) == os.path.getsize(dest_path):
+                with open(source_path, "rb") as source_file:
+                    source_data = source_file.read()
+                with open(dest_path, "rb") as dest_file:
+                    dest_data = dest_file.read()
+                if source_data == dest_data:
+                    return False
+        except (OSError, IOError):
+            pass
+
+    copyFile(source_path, dest_path)
+    return True
 
 
 def getWindowsDrive(path):

--- a/nuitka/utils/FileOperations.py
+++ b/nuitka/utils/FileOperations.py
@@ -1242,6 +1242,41 @@ def putTextFileContents(filename, contents, encoding=None):
             _writeContents(output_file)
 
 
+def writeTextFileIfChanged(filename, contents, encoding=None):
+    """Write text file only if missing or content differs.
+
+    Notes:
+        Preserves mtime when content is unchanged so build tools (Scons, ccache)
+        can skip recompilation of identical C sources.
+
+    Args:
+        filename: destination path
+        contents: full text contents to write
+        encoding: optional text encoding
+
+    Returns:
+        bool: True if the file was written/updated, False if left unchanged.
+    """
+    if isinstance(contents, basestring):
+        new_text = contents
+    else:
+        new_text = "".join(
+            line if line.endswith("\n") else (line + "\n") for line in contents
+        )
+
+    if os.path.isfile(filename):
+        try:
+            old_text = getFileContents(filename, encoding=encoding)
+        except (OSError, IOError, UnicodeError):
+            old_text = None
+
+        if old_text == new_text:
+            return False
+
+    putTextFileContents(filename=filename, contents=new_text, encoding=encoding)
+    return True
+
+
 def putBinaryFileContents(filename, contents):
     """Write a binary file from given contents.
 
@@ -1256,6 +1291,33 @@ def putBinaryFileContents(filename, contents):
     with withFileLock("writing file %s" % filename):
         with openTextFile(filename, "wb") as output_file:
             output_file.write(contents)
+
+
+def writeBinaryFileIfChanged(filename, contents):
+    """Write binary file only if missing or content differs.
+
+    Notes:
+        Preserves mtime when content is unchanged so Scons/sconsign can treat
+        constant blobs as up-to-date and skip re-link when nothing changed.
+
+    Args:
+        filename: destination path
+        contents: full binary contents to write
+
+    Returns:
+        bool: True if the file was written/updated, False if left unchanged.
+    """
+    if os.path.isfile(filename):
+        try:
+            if os.path.getsize(filename) == len(contents):
+                with open(filename, "rb") as existing_file:
+                    if existing_file.read() == contents:
+                        return False
+        except (OSError, IOError):
+            pass
+
+    putBinaryFileContents(filename=filename, contents=contents)
+    return True
 
 
 def changeTextFileContents(filename, contents, encoding=None, compare_only=False):
@@ -1485,6 +1547,32 @@ def copyFile(source_path, dest_path):
             raise
 
         break
+
+
+def copyFileIfChanged(source_path, dest_path):
+    """Copy file only when destination is missing or content differs.
+
+    Notes:
+        Used for module-frontend cache restore so unchanged C/.const keep their
+        mtime and object files can be reused by Scons.
+
+    Returns:
+        bool: True if destination was written, False if left unchanged.
+    """
+    if os.path.isfile(dest_path):
+        try:
+            if os.path.getsize(source_path) == os.path.getsize(dest_path):
+                with open(source_path, "rb") as source_file:
+                    source_data = source_file.read()
+                with open(dest_path, "rb") as dest_file:
+                    dest_data = dest_file.read()
+                if source_data == dest_data:
+                    return False
+        except (OSError, IOError):
+            pass
+
+    copyFile(source_path, dest_path)
+    return True
 
 
 def getWindowsDrive(path):


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

This PR adds an **opt-in, experimental incremental compile path** for repeated Nuitka builds where most dependency modules are unchanged:

### 1) Module Frontend Cache (MCC)
New module-level frontend artifact cache (`nuitka/ModuleFrontendCaching.py`) that stores generated `module.c` + `.const` for eligible non-main modules and restores them on later runs.

Levels (all gated; default Nuitka path unchanged):

- **L0** `--enable-module-frontend-cache`  
  Restore/store generated C/const (skip C source generation on hit).
- **L1/L2** `--experimental=module-frontend-skip-optimize`  
  Skip local `computeModule` micro-passes with used-modules replay, process memo/index, and import re-validation. Dependency closure still runs via `considerUsedModules` every optimize pass (required for correctness).
- **L3** `--experimental=module-frontend-stub`  
  No-AST stub modules + restore cached C. Materializes known root internal helpers; reconciles cross-module function uses; replays high-arity call-helper families into codegen (including POS_ARGS / KW_SPLIT / VECTORCALL). When meta already has complete helper families, warm restore skips re-scanning module C.

Cache keys are **source + compilation context**, not coarse `package==version`. Format/meta is versioned; feature is disabled unless explicitly enabled and still honors cache-disable switches.

### 2) Backend object reuse + durable sconsign
- New **`--keep-backend-objects`**: keep C/const/object artifacts across runs; content-stable rewrites where needed; avoid deleting the previous result binary at build start when reuse is requested.
- Under keep-objects only: allow real `.sconsign-*.dblite` sync (default path still uses Nuitka’s intentional `no_sync` empty-sconsign behavior).
- Prefer MD5-timestamp-style decide where available; Precious targets so SCons does not wipe objects before spawn; compile/link phase timing in scons logs.
- Spawn-level mtime object skip remains a **safety net**, not the primary correctness mechanism.

### 3) Onefile + keep-objects fix
When packing onefile with keep-objects, delete `blobs/__payload.bin` before compressor attach so payload is not **appended** onto a preserved previous blob (which previously doubled onefile size).

### Scope / non-goals
- **Default builds are unchanged** without the new flags.
- Not a business-specific pipeline; compiler-level caching only.
- Local scratch benches are **not** included in the PR tree (ignored); product code only.

Recommended experimental combo for incremental rebuilds:

```bash
--enable-module-frontend-cache \
--experimental=module-frontend-stub \
--keep-backend-objects
```

Do **not** combine `--keep-backend-objects` with `--remove-output` if object reuse is desired.

## 🧐 Why was it initiated? Any relevant Issues?

Repeated compiles of multi-module apps (e.g. FastAPI-style stacks) often rebuild the same third-party frontend/backend work even when only a small amount of business code changed. Existing ccache helps C compile, but:

1. Python→C frontend (tree/optimize/codegen) is still paid in full.
2. Clean backend dirs still re-spawn hundreds of compile jobs even on ccache hit.
3. Empty sconsign (`no_sync`) intentionally prevents SCons from treating backend as up-to-date.

Motivation: make **opt-in** incremental compilation practical for large dependency sets without changing default Nuitka behavior.

No upstream issue number yet (fork experimental work toward discussion / review).

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

Notes:
- Feature is **opt-in / experimental**; defaults preserve current behavior.
- Onefile payload truncate under keep-objects also fixes an incremental packaging correctness issue when that flag is used.

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
  - Local focused helper-meta unit checks and multi-module cold/warm stub runs were used during development; formal in-tree regression tests for MCC are intentionally **not** added in this first experimental PR (happy to follow up with an agreed test location/style).
- [ ] **Documentation**: Documentation updates are included for new or changed features.
  - User-facing docs not yet added; flags are experimental. Can add Developer Manual / option help polish in a follow-up if direction is accepted.

## 📈 Performance comparison (manual benches)

Hardware/software: local macOS, clang, Python 3.12, accelerated mode. Numbers are wall-clock for the full Nuitka process unless noted. **Opt-in flags only.**

### A) FastAPI-style multi-module app (~300 modules / ~306 C files)

Frontend ladder (hot ccache where applicable):

| Scenario | Wall | Optimize (Σ) | Codegen (Σ) | Notes |
| --- | --- | --- | --- | --- |
| Cold store (MCC on) | ~218s | ~30.8s | ~10.7s | seed cache |
| Warm skip-optimize | ~27s | ~12s | ~0.1s | L1/L2 |
| Warm L3 stub | ~14s | ~2–4s | ~0.1s | frontend largely restored |

Full stack A/B (baseline vs MCC clean vs keep-objects):

| Config | Wall | Compile jobs | Link jobs | Notes |
| --- | --- | --- | --- | --- |
| Baseline cold | ~229s | 306 | 1 | full work |
| Baseline warm + clean output | ~56s | 306 (often ccache hit) | 1 | still re-spawns compiles |
| MCC stub + clean (`--remove-output`) | can be worse (~180s in one run) | 306 ccache miss | 1 | frontend cache ≠ backend reuse |
| **MCC stub + `--keep-backend-objects` (stable warm)** | **~7.5–7.8s** | **0** | **0** | durable sconsign path |

Approx speedups on this stack:

- vs baseline warm clean: **~56s → ~7.5s (~7.5×)**
- vs cold: **~229s → ~7.5s (~30×)**

### B) Smaller “core” multi-module app

| Config | Wall | Compile jobs | Link jobs |
| --- | --- | --- | --- |
| Baseline cold | ~23s | 24 | 1 |
| Baseline warm clean | ~8.7s | 24 | 1 |
| **MCC stub + keep-objects stable warm** | **~2.4s** | **0** | **0** |

Approx speedups:

- vs baseline warm clean: **~8.7s → ~2.4s (~3.6×)**
- vs cold: **~23s → ~2.4s (~10×)**

### C) Residual floor (what is *not* claimed)

Even with L3 + keep-objects + 0 compile/0 link jobs, some wall remains:

- SCons decision / progress tax over many units (FastAPI ~3s, core ~0.8s)
- data-composer / process startup
- non-cached main/top and any changed modules

Also:

- MCC alone **does not** replace backend incremental; clean rebuilds can still force full C job spawn.
- First warm after incomplete old meta may still scan C once to upgrade helper meta; subsequent warms use meta-only helper replay.

### D) Correctness checks performed manually

- Core / FastAPI-style stdout identity across cold store, warm skip, warm stub paths (sample business outputs matched baseline).
- Warm link after helper-family replay: high-arity POS/KW/VECTORCALL helpers present in `__helpers`.
- Keep-objects onefile: payload no longer double-appends; size stays single-payload class.
- Helper materialization fails hard on unknown root helpers instead of silent undefined-link.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: Direction was fixed experimentally on a fork first (module-level frontend cache + keep-backend-objects), not as a blind one-shot patch. Happy to open/track an upstream issue for design review if preferred before wider adoption.
  - [x] **Documentation**: High-level prompts/goals used with the coding agent:
    - Design a **generic** Nuitka module frontend cache (not per-business scripts), correctness first, opt-in only.
    - Cache keys must not be coarse package-version only; reuse existing Nuitka cache infrastructure concepts.
    - Implement L0 codegen restore → skip-optimize → L3 stubs with graph-safe used-module handling.
    - Fix warm-link missing call helpers; skip C rescans when meta is complete.
    - Instrument backend compile vs link; add `--keep-backend-objects` and durable sconsign only when enabled.
    - Fix onefile payload append under keep-objects; keep default path behavior unchanged.
    - Align style with Developer Manual / autoformat; keep experimental benches out of the PR tree.
  - [x] **Verification**: AI-assisted code was manually reviewed and exercised with cold/warm builds, link checks, onefile size checks, and A/B timing runs.
  - [x] **Evidence**: Performance tables above; additional local phase logs (`Module frontend phase: …`, `Backend phase timing: compile … link …`).

## Summary by Sourcery

Enable experimental incremental builds by caching module frontend artifacts and reusing unchanged backend objects while preserving default build behavior.

New Features:
- Add an opt-in module frontend cache that reuses generated C and constant artifacts for unchanged modules, with experimental optimization-skipping and no-AST stub modes.
- Add opt-in backend object retention so unchanged C sources, objects, constants, and build outputs can be reused across compilations.

Bug Fixes:
- Prevent onefile payload data from being appended to a preserved previous payload when backend objects are retained.

Enhancements:
- Preserve timestamps for unchanged generated sources and data, use durable SCons signatures for retained backend artifacts, and report frontend and backend phase timings.
- Track cache outcomes and optimize-skip results in compilation reports, validate cached dependency metadata, and reconcile cached cross-module helper usage safely.

Build:
- Use newer bundled SCons versions on modern Python runtimes to support durable signature databases.

Chores:
- Extend cache cleanup to remove module frontend cache data and remove stale backend sources when retained build directories change module sets.