### PR TITLE
Implement lazy imports

### DIFF
--- a/nuitka/Builtins.py
+++ b/nuitka/Builtins.py
@@ -203,6 +203,12 @@ def _getAnonBuiltins():
         anon_names[union_name] = type(int | str)
         anon_codes[union_name] = "Nuitka_PyUnion_Type"
 
+    if python_version >= 0x3F0:
+        from types import LazyImportType
+
+        anon_codes["lazy_import"] = "&PyLazyImport_Type"
+        anon_names["lazy_import"] = LazyImportType
+
     return anon_names, anon_codes
 
 

--- a/nuitka/build/include/nuitka/importing.h
+++ b/nuitka/build/include/nuitka/importing.h
@@ -15,16 +15,17 @@
  * calls using default values, the _KW helper is used.
  *
  */
-extern PyObject *IMPORT_MODULE1(PyThreadState *tstate, PyObject *module_name);
-extern PyObject *IMPORT_MODULE2(PyThreadState *tstate, PyObject *module_name, PyObject *globals);
-extern PyObject *IMPORT_MODULE3(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals);
-extern PyObject *IMPORT_MODULE4(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
-                                PyObject *import_items);
-extern PyObject *IMPORT_MODULE5(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
-                                PyObject *import_items, PyObject *level);
+extern PyObject *IMPORT_MODULE2(PyThreadState *tstate, PyObject *module_name, int is_lazy);
+extern PyObject *IMPORT_MODULE3(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals);
+extern PyObject *IMPORT_MODULE4(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                                PyObject *locals);
+extern PyObject *IMPORT_MODULE5(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                                PyObject *locals, PyObject *import_items);
+extern PyObject *IMPORT_MODULE6(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                                PyObject *locals, PyObject *import_items, PyObject *level);
 
-extern PyObject *IMPORT_MODULE_KW(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
-                                  PyObject *import_items, PyObject *level);
+extern PyObject *IMPORT_MODULE_KW(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                                  PyObject *locals, PyObject *import_items, PyObject *level);
 
 extern bool IMPORT_MODULE_STAR(PyThreadState *tstate, PyObject *target, bool is_module, PyObject *module);
 

--- a/nuitka/build/include/nuitka/prelude.h
+++ b/nuitka/build/include/nuitka/prelude.h
@@ -255,6 +255,11 @@ NUITKA_MAY_BE_UNUSED static inline managed_static_type_state *Nuitka_PyStaticTyp
 #include <internal/pycore_unicodeobject.h>
 #endif
 
+#if PYTHON_VERSION >= 0x3f0
+#include <internal/pycore_import.h>
+#include <internal/pycore_lazyimportobject.h>
+#endif
+
 #undef Py_BUILD_CORE
 
 #endif

--- a/nuitka/build/static_src/HelpersImport.c
+++ b/nuitka/build/static_src/HelpersImport.c
@@ -15,9 +15,10 @@
 #endif
 
 NUITKA_DEFINE_BUILTIN(__import__);
+NUITKA_DEFINE_BUILTIN(__lazy_import__);
 
-PyObject *IMPORT_MODULE_KW(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
-                           PyObject *import_items, PyObject *level) {
+PyObject *IMPORT_MODULE_KW(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                           PyObject *locals, PyObject *import_items, PyObject *level) {
     CHECK_OBJECT_X(module_name);
     CHECK_OBJECT_X(globals);
     CHECK_OBJECT_X(locals);
@@ -29,26 +30,40 @@ PyObject *IMPORT_MODULE_KW(PyThreadState *tstate, PyObject *module_name, PyObjec
                                  const_str_plain_level,  level};
     PyObject *kw_args = MAKE_DICT_X(kw_pairs, 5);
 
-    NUITKA_ASSIGN_BUILTIN(__import__);
+    PyObject *import_function;
+    if (is_lazy) {
+        NUITKA_ASSIGN_BUILTIN(__lazy_import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__lazy_import__);
+    } else {
+        NUITKA_ASSIGN_BUILTIN(__import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    }
 
-    PyObject *import_result = CALL_FUNCTION_WITH_KW_ARGS(tstate, NUITKA_ACCESS_BUILTIN(__import__), kw_args);
+    PyObject *import_result = CALL_FUNCTION_WITH_KW_ARGS(tstate, import_function, kw_args);
 
     Py_DECREF(kw_args);
 
     return import_result;
 }
 
-PyObject *IMPORT_MODULE1(PyThreadState *tstate, PyObject *module_name) {
+PyObject *IMPORT_MODULE2(PyThreadState *tstate, PyObject *module_name, int is_lazy) {
     CHECK_OBJECT(module_name);
 
-    NUITKA_ASSIGN_BUILTIN(__import__);
+    PyObject *import_function;
+    if (is_lazy) {
+        NUITKA_ASSIGN_BUILTIN(__lazy_import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__lazy_import__);
+    } else {
+        NUITKA_ASSIGN_BUILTIN(__import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    }
 
-    PyObject *import_result = CALL_FUNCTION_WITH_SINGLE_ARG(tstate, NUITKA_ACCESS_BUILTIN(__import__), module_name);
+    PyObject *import_result = CALL_FUNCTION_WITH_SINGLE_ARG(tstate, import_function, module_name);
 
     return import_result;
 }
 
-PyObject *IMPORT_MODULE2(PyThreadState *tstate, PyObject *module_name, PyObject *globals) {
+PyObject *IMPORT_MODULE3(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals) {
     CHECK_OBJECT(module_name);
     CHECK_OBJECT(globals);
 
@@ -61,21 +76,29 @@ PyObject *IMPORT_MODULE2(PyThreadState *tstate, PyObject *module_name, PyObject 
     return import_result;
 }
 
-PyObject *IMPORT_MODULE3(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals) {
+PyObject *IMPORT_MODULE4(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals,
+                         PyObject *locals) {
     CHECK_OBJECT(module_name);
     CHECK_OBJECT(globals);
     CHECK_OBJECT(locals);
 
     PyObject *pos_args[] = {module_name, globals, locals};
 
-    NUITKA_ASSIGN_BUILTIN(__import__);
+    PyObject *import_function;
+    if (is_lazy) {
+        NUITKA_ASSIGN_BUILTIN(__lazy_import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__lazy_import__);
+    } else {
+        NUITKA_ASSIGN_BUILTIN(__import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    }
 
-    PyObject *import_result = CALL_FUNCTION_WITH_ARGS3(tstate, NUITKA_ACCESS_BUILTIN(__import__), pos_args);
+    PyObject *import_result = CALL_FUNCTION_WITH_ARGS3(tstate, import_function, pos_args);
 
     return import_result;
 }
 
-PyObject *IMPORT_MODULE4(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
+PyObject *IMPORT_MODULE5(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals, PyObject *locals,
                          PyObject *import_items) {
     CHECK_OBJECT(module_name);
     CHECK_OBJECT(globals);
@@ -84,14 +107,21 @@ PyObject *IMPORT_MODULE4(PyThreadState *tstate, PyObject *module_name, PyObject 
 
     PyObject *pos_args[] = {module_name, globals, locals, import_items};
 
-    NUITKA_ASSIGN_BUILTIN(__import__);
+    PyObject *import_function;
+    if (is_lazy) {
+        NUITKA_ASSIGN_BUILTIN(__lazy_import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__lazy_import__);
+    } else {
+        NUITKA_ASSIGN_BUILTIN(__import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    }
 
-    PyObject *import_result = CALL_FUNCTION_WITH_ARGS4(tstate, NUITKA_ACCESS_BUILTIN(__import__), pos_args);
+    PyObject *import_result = CALL_FUNCTION_WITH_ARGS4(tstate, import_function, pos_args);
 
     return import_result;
 }
 
-PyObject *IMPORT_MODULE5(PyThreadState *tstate, PyObject *module_name, PyObject *globals, PyObject *locals,
+PyObject *IMPORT_MODULE6(PyThreadState *tstate, PyObject *module_name, int is_lazy, PyObject *globals, PyObject *locals,
                          PyObject *import_items, PyObject *level) {
     CHECK_OBJECT(module_name);
     CHECK_OBJECT(globals);
@@ -101,8 +131,14 @@ PyObject *IMPORT_MODULE5(PyThreadState *tstate, PyObject *module_name, PyObject 
 
     PyObject *pos_args[] = {module_name, globals, locals, import_items, level};
 
-    NUITKA_ASSIGN_BUILTIN(__import__);
-    PyObject *import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    PyObject *import_function;
+    if (is_lazy) {
+        NUITKA_ASSIGN_BUILTIN(__lazy_import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__lazy_import__);
+    } else {
+        NUITKA_ASSIGN_BUILTIN(__import__);
+        import_function = NUITKA_ACCESS_BUILTIN(__import__);
+    }
 
 // TODO: This should be reserved for the import statements, but not for
 // the import built-in, we have to make a difference there with 3.10 to
@@ -427,12 +463,13 @@ PyObject *IMPORT_NAME_OR_MODULE(PyThreadState *tstate, PyObject *module, PyObjec
             if (level_int > 0) {
                 PyObject *fromlist = MAKE_TUPLE1(tstate, import_name);
 
-                result = IMPORT_MODULE5(tstate, const_str_empty, globals, globals, fromlist, level);
+                result =
+                    IMPORT_MODULE6(tstate, const_str_empty, /* TODO is_lazy=*/0, globals, globals, fromlist, level);
 
                 Py_DECREF(fromlist);
 
                 // Look up in "sys.modules", because we will have returned the
-                // package of it from IMPORT_MODULE5.
+                // package of it from IMPORT_MODULE6.
                 PyObject *name = PyUnicode_FromFormat("%s.%S", PyModule_GetName(result), import_name);
 
                 if (result != NULL) {
@@ -450,7 +487,7 @@ PyObject *IMPORT_NAME_OR_MODULE(PyThreadState *tstate, PyObject *module, PyObjec
                         return NULL;
                     }
                 } else {
-                    result = IMPORT_MODULE5(tstate, name, globals, globals, const_tuple_empty, level);
+                    result = IMPORT_MODULE6(tstate, name, /*is_lazy=*/0, globals, globals, const_tuple_empty, level);
 
                     if (result != NULL) {
                         Py_DECREF(result);
@@ -477,7 +514,7 @@ PyObject *IMPORT_NAME_OR_MODULE(PyThreadState *tstate, PyObject *module, PyObjec
 #endif
 
 PyObject *IMPORT_MODULE_FIXED(PyThreadState *tstate, PyObject *module_name, PyObject *value_name) {
-    PyObject *import_result = IMPORT_MODULE1(tstate, module_name);
+    PyObject *import_result = IMPORT_MODULE2(tstate, module_name, /*is_lazy=*/0);
 
     if (unlikely(import_result == NULL)) {
         return import_result;

--- a/nuitka/build/static_src/InspectPatcher.c
+++ b/nuitka/build/static_src/InspectPatcher.c
@@ -186,8 +186,8 @@ void patchInspectModule(PyThreadState *tstate) {
     // May need to import the "site" module, because otherwise the patching can
     // fail with it being unable to load it (yet)
     if (Py_NoSiteFlag == 0) {
-        PyObject *site_module =
-            IMPORT_MODULE5(tstate, const_str_plain_site, Py_None, Py_None, const_tuple_empty, const_int_0);
+        PyObject *site_module = IMPORT_MODULE6(tstate, const_str_plain_site, /*is_lazy=*/0, Py_None, Py_None,
+                                               const_tuple_empty, const_int_0);
 
         if (site_module == NULL) {
             // Ignore "ImportError", having a "site" module is not a must.
@@ -197,7 +197,8 @@ void patchInspectModule(PyThreadState *tstate) {
 #endif
 
     // TODO: Change this into an import hook that is executed after it is imported.
-    module_inspect = IMPORT_MODULE5(tstate, const_str_plain_inspect, Py_None, Py_None, const_tuple_empty, const_int_0);
+    module_inspect = IMPORT_MODULE6(tstate, const_str_plain_inspect, /*is_lazy=*/0, Py_None, Py_None, const_tuple_empty,
+                                    const_int_0);
 
     if (module_inspect == NULL) {
         PyErr_PrintEx(0);
@@ -228,7 +229,8 @@ void patchInspectModule(PyThreadState *tstate) {
         PyObject_SetAttrString(module_inspect, "getcoroutinestate", inspect_getcoroutinestate_replacement);
     }
 
-    module_types = IMPORT_MODULE5(tstate, const_str_plain_types, Py_None, Py_None, const_tuple_empty, const_int_0);
+    module_types =
+        IMPORT_MODULE6(tstate, const_str_plain_types, /*is_lazy=*/0, Py_None, Py_None, const_tuple_empty, const_int_0);
 
     if (module_types == NULL) {
         PyErr_PrintEx(0);

--- a/nuitka/code_generation/CodeGeneration.py
+++ b/nuitka/code_generation/CodeGeneration.py
@@ -202,6 +202,7 @@ from .ImportCodes import (
     generateImportModuleNameHardCode,
     generateImportNameCode,
     generateImportStarCode,
+    generateResolveLazyImportCode,
 )
 from .IntegerCodes import (
     generateBuiltinInt1Code,
@@ -781,6 +782,7 @@ addExpressionDispatchDict(
         "EXPRESSION_CONSTANT_TYPE_LIST_REF": generateConstantReferenceCode,
         "EXPRESSION_CONSTANT_TYPE_TUPLE_REF": generateConstantReferenceCode,
         "EXPRESSION_CONSTANT_TYPE_TYPE_REF": generateConstantReferenceCode,
+        "EXPRESSION_CONSTANT_TYPE_LAZY_IMPORT_REF": generateConstantReferenceCode,
         "EXPRESSION_CONSTANT_BYTEARRAY_REF": generateConstantReferenceCode,
         "EXPRESSION_CONSTANT_GENERIC_ALIAS": generateConstantGenericAliasCode,
         "EXPRESSION_CONSTANT_UNION_TYPE": generateConstantReferenceCode,
@@ -841,6 +843,7 @@ addExpressionDispatchDict(
         "EXPRESSION_IMPORTLIB_IMPORT_MODULE_REF": generateImportModuleNameHardCode,
         "EXPRESSION_IMPORTLIB_IMPORT_MODULE_CALL": generateImportlibImportCallCode,
         "EXPRESSION_IMPORT_NAME": generateImportNameCode,
+        "EXPRESSION_RESOLVE_LAZY_IMPORT": generateResolveLazyImportCode,
         "EXPRESSION_LIST_OPERATION_APPEND": generateListOperationAppendCode2,
         "EXPRESSION_LIST_OPERATION_EXTEND": generateListOperationExtendCode,
         "EXPRESSION_LIST_OPERATION_EXTEND_FOR_UNPACK": generateListOperationExtendCode,

--- a/nuitka/code_generation/ImportCodes.py
+++ b/nuitka/code_generation/ImportCodes.py
@@ -46,6 +46,7 @@ def generateBuiltinImportCode(to_name, expression, emit, context):
             import_list_name=import_list_name,
             level_name=level_name,
             needs_check=expression.mayRaiseException(BaseException),
+            is_lazy=expression.is_lazy,
             emit=emit,
             context=context,
         )
@@ -98,6 +99,7 @@ def _getBuiltinImportCode(
     import_list_name,
     level_name,
     needs_check,
+    is_lazy,
     emit,
     context,
 ):
@@ -108,8 +110,15 @@ def _getBuiltinImportCode(
     _getCountedArgumentsHelperCallCode(
         helper_prefix="IMPORT_MODULE",
         to_name=to_name,
-        args=(module_name, globals_name, locals_name, import_list_name, level_name),
-        min_args=1,
+        args=(
+            module_name,
+            is_lazy,
+            globals_name,
+            locals_name,
+            import_list_name,
+            level_name,
+        ),
+        min_args=2,
         needs_check=needs_check,
         emit=emit,
         context=context,
@@ -467,6 +476,32 @@ if (PyModule_Check(%(from_arg_name)s)) {
         )
 
         context.addCleanupTempName(value_name)
+
+
+def generateResolveLazyImportCode(to_name, expression, emit, context):
+    (lazy_import_value,) = generateChildExpressionsCode(
+        expression=expression, emit=emit, context=context
+    )
+
+    with withObjectCodeTemporaryAssignment(
+        to_name, "resolved", expression, emit, context
+    ) as resolved_name:
+        emit(
+            "%s = _PyImport_LoadLazyImportTstate(tstate, %s);"
+            % (
+                resolved_name,
+                lazy_import_value,
+            )
+        )
+
+        getErrorExitCode(
+            check_name=resolved_name,
+            release_name=lazy_import_value,
+            emit=emit,
+            context=context,
+        )
+
+        context.addCleanupTempName(resolved_name)
 
 
 #     Part of "Nuitka", an optimizing Python compiler that is compatible and

--- a/nuitka/nodes/ChildrenHavingMixins.py
+++ b/nuitka/nodes/ChildrenHavingMixins.py
@@ -10516,6 +10516,108 @@ class ChildrenHavingKeyValueMixin(object):
 ChildrenExpressionKeyValuePairNewMixin = ChildrenHavingKeyValueMixin
 
 
+class ChildHavingLazyImportMixin(object):
+    # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
+    __slots__ = ()
+
+    # This is generated for use in
+    #   ExpressionResolveLazyImport
+
+    def __init__(
+        self,
+        lazy_import,
+    ):
+        lazy_import.parent = self
+
+        self.subnode_lazy_import = lazy_import
+
+    def getVisitableNodes(self):
+        """The visitable nodes, with tuple values flattened."""
+
+        return (self.subnode_lazy_import,)
+
+    def getVisitableNodesNamed(self):
+        """Named children dictionary.
+
+        For use in cloning nodes, debugging and XML output.
+        """
+
+        return (("lazy_import", self.subnode_lazy_import),)
+
+    def replaceChild(self, old_node, new_node):
+        value = self.subnode_lazy_import
+        if old_node is value:
+            new_node.parent = self
+
+            self.subnode_lazy_import = new_node
+
+            return
+
+        raise AssertionError("Didn't find child", old_node, "in", self)
+
+    def getCloneArgs(self):
+        """Get clones of all children to pass for a new node.
+
+        Needs to make clones of child nodes too.
+        """
+
+        values = {
+            "lazy_import": self.subnode_lazy_import.makeClone(),
+        }
+
+        values.update(self.getDetails())
+
+        return values
+
+    def finalize(self):
+        del self.parent
+
+        self.subnode_lazy_import.finalize()
+        del self.subnode_lazy_import
+
+    def computeExpressionRaw(self, trace_collection):
+        """Compute an expression.
+
+        Default behavior is to just visit the child expressions first, and
+        then the node "computeExpression". For a few cases this needs to
+        be overloaded, e.g. conditional expressions.
+        """
+
+        # First apply the sub-expression, as they it's evaluated before.
+        expression = trace_collection.onExpression(self.subnode_lazy_import)
+
+        if expression.willRaiseAnyException():
+            return (
+                expression,
+                "new_raise",
+                lambda: "For '%s' the child expression '%s' will raise."
+                % (self.getChildNameNice(), expression.getChildNameNice()),
+            )
+
+        # Then ask ourselves to work on it.
+        return self.computeExpression(trace_collection)
+
+    def undoComputeExpressionRaw(self, trace_collection):
+        for child in self.getVisitableNodes():
+            child.undoComputeExpressionRaw(trace_collection)
+
+        self.undoComputeExpression()
+
+    # For overload only
+    @staticmethod
+    def undoComputeExpression():
+        pass
+
+    def collectVariableAccesses(self, emit_variable):
+        """Collect variable reads and writes of child nodes."""
+
+        self.subnode_lazy_import.collectVariableAccesses(emit_variable)
+
+
+# Assign the names that are easier to import with a stable name.
+ChildrenExpressionResolveLazyImportMixin = ChildHavingLazyImportMixin
+
+
 class ChildrenHavingLeftRightMixin(object):
     # Mixins are not allowed to specify slots, pylint: disable=assigning-non-slot
     __slots__ = ()

--- a/nuitka/nodes/ConstantRefNodes.py
+++ b/nuitka/nodes/ConstantRefNodes.py
@@ -1423,6 +1423,21 @@ class ExpressionConstantTypeTypeRef(
         ExpressionConstantTypeRef.__init__(self, constant=type, source_ref=source_ref)
 
 
+class ExpressionConstantTypeLazyImportRef(
+    ExpressionConstantConcreteTypeMixin,
+    ExpressionConstantTypeSubscriptableMixin,
+    ExpressionConstantTypeRef,
+):
+    kind = "EXPRESSION_CONSTANT_TYPE_LAZY_IMPORT_REF"
+
+    def __init__(self, source_ref):
+        from types import LazyImportType
+
+        ExpressionConstantTypeRef.__init__(
+            self, constant=LazyImportType, source_ref=source_ref
+        )
+
+
 def makeConstantRefNode(constant, source_ref, user_provided=False):
     # This is dispatching per constant value and types, every case
     # to be a return statement, pylint: disable=too-many-branches,too-many-return-statements,too-many-statements

--- a/nuitka/nodes/ImportNodes.py
+++ b/nuitka/nodes/ImportNodes.py
@@ -60,6 +60,7 @@ from nuitka.utils.ModuleNames import ModuleName
 from nuitka.utils.Utils import withNoDeprecationWarning, withWarningRemoved
 
 from .ChildrenHavingMixins import (
+    ChildHavingLazyImportMixin,
     ChildHavingModuleMixin,
     ChildrenExpressionBuiltinImportMixin,
     ChildrenExpressionImportlibImportModuleCallMixin,
@@ -852,11 +853,7 @@ def _makeParentImportModuleUsages(module_name, source_ref):
 
 
 class ExpressionBuiltinImport(ChildrenExpressionBuiltinImportMixin, ExpressionBase):
-    __slots__ = (
-        "follow_attempted",
-        "finding",
-        "used_modules",
-    )
+    __slots__ = ("follow_attempted", "finding", "used_modules", "is_lazy")
 
     kind = "EXPRESSION_BUILTIN_IMPORT"
 
@@ -868,7 +865,9 @@ class ExpressionBuiltinImport(ChildrenExpressionBuiltinImportMixin, ExpressionBa
         "level|optional",
     )
 
-    def __init__(self, name, globals_arg, locals_arg, fromlist, level, source_ref):
+    def __init__(
+        self, name, globals_arg, locals_arg, fromlist, level, is_lazy, source_ref
+    ):
         ChildrenExpressionBuiltinImportMixin.__init__(
             self,
             name=name,
@@ -887,6 +886,8 @@ class ExpressionBuiltinImport(ChildrenExpressionBuiltinImportMixin, ExpressionBa
         self.used_modules = []
 
         self.finding = None
+
+        self.is_lazy = is_lazy
 
     def _getLevelValue(self):
         parent_module = self.getParentModule()
@@ -1315,6 +1316,20 @@ class ExpressionImportName(ChildHavingModuleMixin, ExpressionBase):
         return self.subnode_module.mayRaiseExceptionImportName(
             exception_type=exception_type, import_name=self.import_name
         )
+
+
+class ExpressionResolveLazyImport(ChildHavingLazyImportMixin, ExpressionBase):
+    kind = "EXPRESSION_RESOLVE_LAZY_IMPORT"
+
+    named_children = ("lazy_import",)
+
+    def __init__(self, lazy_import, source_ref):
+        ChildHavingLazyImportMixin.__init__(self, lazy_import=lazy_import)
+
+        ExpressionBase.__init__(self, source_ref)
+
+    def computeExpression(self, trace_collection):
+        return self, None, None
 
 
 def makeExpressionImportModuleFixed(

--- a/nuitka/tree/Building.py
+++ b/nuitka/tree/Building.py
@@ -69,13 +69,16 @@ from nuitka.nodes.BuiltinTemplateNodes import (
     ExpressionTemplateString,
 )
 from nuitka.nodes.BuiltinTypeNodes import ExpressionBuiltinStrP3
+from nuitka.nodes.ComparisonNodes import ExpressionComparisonIs
 from nuitka.nodes.ConditionalNodes import (
     ExpressionConditional,
+    StatementConditional,
     makeStatementConditional,
 )
 from nuitka.nodes.ConstantRefNodes import (
     ExpressionConstantEllipsisRef,
     ExpressionConstantNoneRef,
+    ExpressionConstantTypeLazyImportRef,
     makeConstantRefNode,
 )
 from nuitka.nodes.ExceptionNodes import StatementRaiseException
@@ -85,6 +88,7 @@ from nuitka.nodes.GeneratorNodes import (
     StatementGeneratorReturnNone,
 )
 from nuitka.nodes.ImportNodes import (
+    ExpressionResolveLazyImport,
     isHardModuleWithoutSideEffect,
     makeExpressionImportModuleFixed,
 )
@@ -106,14 +110,18 @@ from nuitka.nodes.NodeMakingHelpers import (
 )
 from nuitka.nodes.OperatorNodes import makeBinaryOperationNode
 from nuitka.nodes.OperatorNodesUnary import makeExpressionOperationUnary
-from nuitka.nodes.ReturnNodes import makeStatementReturn
+from nuitka.nodes.OutlineNodes import ExpressionOutlineBody
+from nuitka.nodes.ReturnNodes import StatementReturn, makeStatementReturn
 from nuitka.nodes.SliceNodes import makeExpressionBuiltinSlice
 from nuitka.nodes.StatementNodes import StatementExpressionOnly
 from nuitka.nodes.StringConcatenationNodes import ExpressionStringConcatenation
+from nuitka.nodes.TypeNodes import ExpressionBuiltinType1
+from nuitka.nodes.VariableAssignNodes import makeStatementAssignmentVariable
 from nuitka.nodes.VariableNameNodes import (
     ExpressionVariableNameRef,
     StatementAssignmentVariableName,
 )
+from nuitka.nodes.VariableRefNodes import ExpressionTempVariableRef
 from nuitka.optimizations.BytecodeDemotion import demoteSourceCodeToBytecode
 from nuitka.options.Options import (
     getMainEntryPointFilenames,
@@ -218,6 +226,7 @@ from .TreeHelpers import (
     makeModuleFrame,
     makeReraiseExceptionStatement,
     makeStatementsSequenceFromStatement,
+    makeStatementsSequenceFromStatements,
     mangleName,
     parseSourceCodeToAst,
     setBuildingDispatchers,
@@ -226,6 +235,54 @@ from .VariableClosure import completeVariableClosures
 
 if str is not bytes:
 
+    def _makePotentiallyLazyNameRef(provider, node, source_ref):
+        outline = ExpressionOutlineBody(provider, "lookup_variable", source_ref)
+        tmp_variable = outline.allocateTempVariable(
+            temp_scope=None, name="variable", temp_type="object"
+        )
+        condition = ExpressionComparisonIs(
+            left=ExpressionBuiltinType1(
+                value=ExpressionTempVariableRef(tmp_variable, source_ref),
+                source_ref=source_ref,
+            ),
+            right=ExpressionConstantTypeLazyImportRef(source_ref),
+            source_ref=source_ref,
+        )
+        statements = [
+            makeStatementAssignmentVariable(
+                variable=tmp_variable,
+                source=ExpressionVariableNameRef(
+                    provider=provider,
+                    variable_name=mangleName(node.id, provider),
+                    source_ref=source_ref,
+                ),
+                source_ref=source_ref,
+            ),
+            StatementConditional(
+                condition=condition,
+                yes_branch=makeStatementsSequenceFromStatement(
+                    StatementReturn(
+                        expression=ExpressionResolveLazyImport(
+                            lazy_import=ExpressionTempVariableRef(
+                                tmp_variable, source_ref
+                            ),
+                            source_ref=source_ref,
+                        ),
+                        source_ref=source_ref,
+                    ),
+                ),
+                no_branch=makeStatementsSequenceFromStatement(
+                    StatementReturn(
+                        expression=ExpressionTempVariableRef(tmp_variable, source_ref),
+                        source_ref=source_ref,
+                    ),
+                ),
+                source_ref=source_ref,
+            ),
+        ]
+        outline.setChildBody(makeStatementsSequenceFromStatements(statements))
+        return outline
+
     def buildVariableReferenceNode(provider, node, source_ref):
         # Shortcut for Python3, which gives syntax errors for assigning these.
         if node.id in quick_names:
@@ -233,11 +290,14 @@ if str is not bytes:
                 constant=quick_names[node.id], source_ref=source_ref
             )
 
-        return ExpressionVariableNameRef(
-            provider=provider,
-            variable_name=mangleName(node.id, provider),
-            source_ref=source_ref,
-        )
+        if python_version >= 0x3F0:
+            return _makePotentiallyLazyNameRef(provider, node, source_ref)
+        else:
+            return ExpressionVariableNameRef(
+                provider=provider,
+                variable_name=mangleName(node.id, provider),
+                source_ref=source_ref,
+            )
 
 else:
 

--- a/nuitka/tree/ReformulationImportStatements.py
+++ b/nuitka/tree/ReformulationImportStatements.py
@@ -268,6 +268,11 @@ def buildImportModulesNode(provider, node, source_ref):
             else None
         )
 
+        if python_version >= 0x3F0:
+            is_lazy = node.is_lazy
+        else:
+            is_lazy = False
+
         module_name = _resolveImportModuleName(module_name)
 
         # TODO: Go to fixed node directly, avoiding the optimization for the
@@ -279,6 +284,7 @@ def buildImportModulesNode(provider, node, source_ref):
             locals_arg=makeConstantRefNode(None, source_ref, True),
             fromlist=makeConstantRefNode(None, source_ref, True),
             level=level,
+            is_lazy=is_lazy,
             source_ref=source_ref,
         )
 


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Implements Python 3.15's `lazy import` syntax ([PEP 810](https://peps.python.org/pep-0810/)).

## 🧐 Why was it initiated? Any relevant Issues?

- #3929

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [ ] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Add support for Python 3.15 lazy imports across the compiler and runtime.

New Features:
- Introduce a lazy-import-aware import helper path and node representation so that import statements can be compiled to use Python 3.15 lazy imports when requested.

Enhancements:
- Extend variable reference building and constant type handling to detect lazy-import proxy objects and resolve them transparently at use sites.
- Wire lazy import resolution into code generation and low-level C import helpers, including new helpers that can dispatch to either __import__ or __lazy_import__ as appropriate.