### PR TITLE
Cleanup, deduplicate statements sequence optimization and COFF dependency helpers

### DIFF
--- a/nuitka/nodes/FrameNodes.py
+++ b/nuitka/nodes/FrameNodes.py
@@ -170,41 +170,9 @@ class StatementsFrameBase(StatementsSequenceMixin, StatementsSequenceBase):
         return self.code_object
 
     def computeStatementsSequence(self, trace_collection):
-        # The extraction of parts of the frame that can be moved before or after
-        # the frame scope, takes it toll to complexity, pylint: disable=too-many-branches
-        new_statements = []
-
         statements = self.subnode_statements
 
-        for count, statement in enumerate(statements):
-            # May be frames embedded.
-            if statement.isStatementsFrame():
-                new_statement = statement.computeStatementsSequence(
-                    trace_collection=trace_collection
-                )
-            else:
-                new_statement = trace_collection.onStatement(statement=statement)
-
-            if new_statement is not None:
-                if new_statement.isStatementsSequenceButNotFrame():
-                    new_statements.extend(new_statement.subnode_statements)
-                else:
-                    new_statements.append(new_statement)
-
-                if (
-                    statement is not statements[-1]
-                    and new_statement.isStatementAborting()
-                ):
-                    trace_collection.signalChange(
-                        "new_statements",
-                        statements[count + 1].getSourceReference(),
-                        "Removed dead statements.",
-                    )
-
-                    for s in statements[count + 1 :]:
-                        s.finalize()
-
-                    break
+        new_statements = self._computeStatementsSequenceCore(trace_collection)
 
         if not new_statements:
             trace_collection.signalChange(

--- a/nuitka/nodes/StatementNodes.py
+++ b/nuitka/nodes/StatementNodes.py
@@ -115,21 +115,14 @@ class StatementsSequenceMixin(object):
     def willRaiseAnyException(self):
         return self.subnode_statements[-1].willRaiseAnyException()
 
+    def _computeStatementsSequenceCore(self, trace_collection):
+        """Optimize the child statements and drop the ones after an aborting one.
 
-class StatementsSequence(StatementsSequenceMixin, StatementsSequenceBase):
-    kind = "STATEMENTS_SEQUENCE"
-
-    named_children = ("statements|tuple+setter",)
-
-    @staticmethod
-    def isStatementsSequenceButNotFrame():
-        return True
-
-    def computeStatementsSequence(self, trace_collection):
+        Returns a mutable list, the caller decides what to make of it.
+        """
         new_statements = []
 
         statements = self.subnode_statements
-        assert statements, self
 
         for count, statement in enumerate(statements):
             # May be frames embedded.
@@ -159,7 +152,24 @@ class StatementsSequence(StatementsSequenceMixin, StatementsSequenceBase):
 
                     break
 
-        new_statements = tuple(new_statements)
+        return new_statements
+
+
+class StatementsSequence(StatementsSequenceMixin, StatementsSequenceBase):
+    kind = "STATEMENTS_SEQUENCE"
+
+    named_children = ("statements|tuple+setter",)
+
+    @staticmethod
+    def isStatementsSequenceButNotFrame():
+        return True
+
+    def computeStatementsSequence(self, trace_collection):
+        statements = self.subnode_statements
+        assert statements, self
+
+        new_statements = tuple(self._computeStatementsSequenceCore(trace_collection))
+
         if statements != new_statements:
             if new_statements:
                 self.setChildStatements(new_statements)

--- a/nuitka/utils/SharedLibraries.py
+++ b/nuitka/utils/SharedLibraries.py
@@ -522,7 +522,7 @@ def _coffDependencyError(
         )
 
 
-def _detectBinaryPathDLLsCoff2(filename, package_name, imported_by):
+def detectBinaryPathDLLsCoff(filename, package_name, imported_by=None):
     """Detect the shared libraries needed by a COFF (AIX) binary.
 
     Uses 'dump -H' to determine which shared libraries are imported, and
@@ -557,47 +557,36 @@ def _detectBinaryPathDLLsCoff2(filename, package_name, imported_by):
 
         found_path = _resolveCoffLibraryPath(base, member, search_paths)
 
-        if not found_path:
+        if (
+            not found_path
+            or not os.path.isabs(found_path)
+            or not os.path.isfile(found_path)
+        ):
             return _coffDependencyError(
                 filename=filename,
                 imported_libraries=imported_libraries,
                 search_paths=search_paths,
                 base=base,
-                found_path=None,
+                # Not resolved at all is reported differently from resolved
+                # to something unusable.
+                found_path=found_path or None,
                 imported_by=imported_by,
             )
-        elif not os.path.isabs(found_path):
-            return _coffDependencyError(
-                filename=filename,
-                imported_libraries=imported_libraries,
-                search_paths=search_paths,
-                base=base,
-                found_path=found_path,
-                imported_by=imported_by,
+
+        if imported_by:
+            postprocessing_logger.info(
+                "Resolved dependency of '%s': '%s' -> '%s'"
+                % (imported_by, filename, found_path)
             )
-        elif not os.path.isfile(found_path):
-            return _coffDependencyError(
-                filename=filename,
-                imported_libraries=imported_libraries,
-                search_paths=search_paths,
-                base=base,
-                found_path=found_path,
-                imported_by=imported_by,
-            )
-        else:
-            if imported_by:
-                postprocessing_logger.info(
-                    "Resolved dependency of '%s': '%s' -> '%s'"
-                    % (imported_by, filename, found_path)
-                )
-            result_set.add(found_path)
+
+        result_set.add(found_path)
 
     _coff_dependency_cache[filename] = result_set
 
     complete_result = OrderedSet(result_set)
     for sub_dll_filename in result_set:
         complete_result.update(
-            _detectBinaryPathDLLsCoff2(
+            detectBinaryPathDLLsCoff(
                 filename=sub_dll_filename,
                 package_name=package_name,
                 imported_by=filename,
@@ -605,32 +594,6 @@ def _detectBinaryPathDLLsCoff2(filename, package_name, imported_by):
         )
 
     return complete_result
-
-
-def detectBinaryPathDLLsCoff(filename, package_name):
-    """Detect the shared libraries needed by a COFF (AIX) binary.
-
-    Uses 'dump -H' to determine which shared libraries are imported, and
-    'dump -Tv' to resolve symbol-level dependencies.
-
-    Args:
-        filename: Path to the COFF binary or shared object.
-        package_name: Name of the package being processed.
-
-    Returns:
-        OrderedSet of absolute paths to required shared libraries.
-
-    Notes:
-        This is the COFF/XCOFF equivalent of 'detectBinaryPathDLLsPosix'
-        which uses 'ldd' on ELF platforms. AIX does not have ldd, so we
-        use the 'dump' command instead to inspect the loader section and
-        symbol table.
-    """
-    return _detectBinaryPathDLLsCoff2(
-        filename=filename,
-        package_name=package_name,
-        imported_by=None,
-    )
 
 
 _otool_output_cache = {}


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

Three behavior preserving cleanups to code that currently exists only on `factory`.

**1. Share the statements sequence optimization with frames**
(`nuitka/nodes/StatementNodes.py`, `nuitka/nodes/FrameNodes.py`)

After 8f43a98b6 and 86d980ce8, the loop that optimizes child statements and drops the ones
following an aborting statement was identical in `StatementsSequence.computeStatementsSequence`
and `StatementsFrameBase.computeStatementsSequence`, down to the token, except that one passed
`trace_collection` positionally and the other by keyword. It now lives once in
`StatementsSequenceMixin._computeStatementsSequenceCore`, which both classes already inherit.

Details that are deliberate:

- The helper returns a `list`, not a tuple, because the frame variant mutates it in place with
  `del new_statements[0]` and `del new_statements[-1]` while determining the statements that
  need not be in the frame. The plain sequence variant makes a tuple of it exactly as before.
- `assert statements, self` stays in `StatementsSequence` only. Frames legitimately tolerate an
  empty statement list, `checkFrameStatements` says so, and they rely on the following
  `if not new_statements: ... return None`.
- `statements = self.subnode_statements` is still read *before* the helper call in both callers.
  In the frame variant it is the pre optimization snapshot that the later
  `if statements != new_statements_tuple:` comparison depends on, so moving that read after the
  loop would have been wrong.
- With the loop gone, the frame variant drops to nine branches, so the
  `pylint: disable=too-many-branches` there became a useless suppression. Since
  `nuitka/tools/quality/pylint/PyLint.py` runs with `--enable=useless-suppression`, keeping it
  fails the check, so it is removed.

**2. Simplify the COFF dependency resolution failure handling**
(`nuitka/utils/SharedLibraries.py`)

The `if / elif / elif` chain added in 415ffc8fa called `_coffDependencyError` from all three
branches with identical arguments except `found_path`, and `_coffDependencyError` then repeated
the same three checks itself to select its message. One condition does it now. The call passes
`found_path or None` so that a falsy value still selects the "not found in search paths" message,
which keeps the merged form independent of whether `_resolveCoffLibraryPath` can return an empty
string.

**3. Fold away the `detectBinaryPathDLLsCoff` pass through wrapper**
(`nuitka/utils/SharedLibraries.py`)

`_detectBinaryPathDLLsCoff2` and `detectBinaryPathDLLsCoff` carried the same seventeen line
docstring, and the public one only forwarded with `imported_by=None`. The recursion argument now
simply defaults to `None`. The parameter order of the public function is unchanged and the new
parameter is appended, so positional and keyword callers are both unaffected. The only caller,
`nuitka/freezer/Standalone.py:175`, uses keyword arguments.

## 🧐 Why was it initiated? Any relevant Issues?

No issue. This is duplication that appeared as a side effect of recent `factory` commits rather
than a reported problem, so there was nothing to file first. See the AI policy section below,
where this is the one checklist item I cannot honestly tick.

**On the base branch.** The checklist asks for `develop`, and this PR does not use it. The code
being cleaned up does not exist there:

- `develop`'s `FrameNodes.computeStatementsSequence` has no
  `for s in statements[count + 1:]: s.finalize()` loop, that came with 8f43a98b6. On `develop`
  the two loops are therefore not identical, and merging them would silently add those
  `finalize()` calls to frames, which is a behavior change rather than a refactoring.
- `develop`'s `nuitka/utils/SharedLibraries.py` has no `_coffDependencyError`, no `imported_by`
  and no `_detectBinaryPathDLLsCoff2`, those came with 415ffc8fa and 64e0b3b38. Changes 2 and 3
  have nothing to attach to there.

So `factory` is the only base on which this stays a pure refactoring. Happy to rebase onto
`develop` once those commits arrive there, or to have this cherry picked instead, whichever suits
the workflow better.

## 🧱 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [ ] **Correct base branch selected**: Should be `develop` branch.
  - Deliberately `factory`, see the explanation above.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
  - `bin/autoformat-nuitka-source` reports no files needed formatting changes, and
    `bin/check-nuitka-with-pylint` is clean on all three files with PyLint 4.0.5.
- [x] **Tests**: All tests still pass.
  - See the evidence section below.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
  - Not applicable, no behavior changes, so there is nothing new to cover.
- [ ] **Documentation**: Documentation updates are included for new or changed features.
  - Not applicable.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
    - Not done, and I am flagging it rather than glossing over it. There was no reported problem
      to file, this came out of reading the `factory` diff for duplication. Say the word and I
      will open an issue first and resubmit.
  - [x] **Documentation**: I have provided the prompts used to generate the code (non-optional).
    - The whole task ran under a "prosecute" workflow: propose cleanups, then have two
      adversarial reviewers try to prove each one wrong before anything is applied. The prompts
      were:
      1. `/prosecute we should focus on the factory branch. Any proposed changes should first be
         met by 2 adversarial subagents who assume you are wrong. Anything you remove or simplify
         should not inherently mean we lose edge case coverage, so you must prove that you are
         right before doing anything.`
      2. Two reviewer prompts, run before any edit was made, over a written proposal document.
         One reviewed runtime behavior: "Assume every proposal changes what the code does at
         runtime. Find the concrete input, state or ordering where the proposed code differs:
         edge cases, side effect order, mutability, short circuit evaluation, error paths,
         Python 2.6 compatibility, and the `--enable=useless-suppression` pylint gate. Default to
         guilty when unsure." The other reviewed deletions: "Assume nothing is truly dead and
         nothing is truly duplicate. Find the caller that still reaches the removed code,
         including dynamic reach through node kinds, plugins, YAML, templates, tests and the
         separate Nuitka Commercial repository. Diff the supposedly identical blocks character by
         character and find the difference the merge would erase. Default to guilty when unsure."
      3. The same two reviewer prompts again after the edits were applied, this time against the
         real diff, with the note that their earlier finding had been acted on.
  - [x] **Verification**: I have **manually verified** the AI generated code.
    - The first review round rejected the original version of change 1: it had moved
      `statements = self.subnode_statements` in `FrameNodes` to *after* the loop, which would
      have turned the pre optimization snapshot into the post optimization value and defeated the
      `if statements != new_statements_tuple:` guard documented at that spot. That was corrected
      before anything was applied. The second round, against the applied diff, raised no further
      objections beyond one note, which is why the merged condition in change 2 passes
      `found_path or None` rather than `found_path`.
  - [x] **Evidence**: I have included test evidence that the change is effective.

## Test evidence

Generated C compared before and after, with `--module --generate-c-only` and `diff -r` over the
whole build directory:

| Case | Result |
| --- | --- |
| Sample with dead statements after `return`, `raise` and `continue`, a generator with `try/finally`, a `with` statement and a class body | byte identical |
| stdlib `argparse.py` | byte identical |
| stdlib `ast.py` | byte identical |

`--xml` optimizer dumps over `tests/basics/*.py`, before against after: 73 modules, 73 identical,
0 differing. A separate run with `--verbose` confirmed the touched paths are actually exercised,
21 "Removed dead statements" and 3 "Removed useless frame object" signals, all matching.

For the COFF changes, which cannot run outside AIX, the old and new modules were loaded side by
side with `_resolveCoffLibraryPath` stubbed, and driven with `found_path` values of `None`, `""`,
a relative path, an absolute but missing path and an absolute existing path. The selected
`sysexit` message, the `postprocessing_logger.info` sequence, the `isabs`/`isfile` call log and
the resulting set matched in every case. A fake dependency graph containing both a diamond and a
cycle produced identical results, identical log order and identical `_coff_dependency_cache`
contents.

## Noticed while working, not changed here

`_coff_dependency_cache[filename]` stores `result_set`, the direct dependencies, while the
function returns `complete_result`, the transitive ones, so a cache hit returns strictly less
than a cache miss. This reproduces on `develop` as well, so it predates the `factory` work. It is
a behavior change to fix and this PR is deliberately behavior preserving, so it is left alone.
Happy to file it separately.

## Summary by Sourcery

Deduplicate statement-sequence optimization logic between frames and regular statement sequences and simplify COFF shared library dependency handling for AIX.

Enhancements:
- Share a single statement-sequence optimization helper between frame nodes and generic statement sequences while preserving existing behavior and frame-specific handling.
- Streamline COFF dependency resolution error handling by collapsing redundant path validation branches and keeping logging behavior intact.
- Remove the private COFF DLL detection wrapper by inlining its behavior into the public function and adding an optional recursion parameter without changing the public call pattern.