### PR TITLE
Python3.14: Make deferred annotations work on hard coded import names

### DIFF
--- a/nuitka/code_generation/PythonSourceCodeGeneration.py
+++ b/nuitka/code_generation/PythonSourceCodeGeneration.py
@@ -571,6 +571,13 @@ def _generateImportModuleHardSource(expression):
     return "__import__(%r)" % target
 
 
+def _generateImportModuleNameHardSource(expression):
+    return "%s.%s" % (
+        _generateImportModuleHardSource(expression),
+        expression.getImportName(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dispatch table
 
@@ -639,6 +646,8 @@ _expression_source_dispatch = {
     "EXPRESSION_IMPORT_MODULE_HARD": _generateImportModuleHardSource,
     "EXPRESSION_IMPORT_MODULE_FIXED": _generateImportModuleHardSource,
     "EXPRESSION_IMPORT_MODULE_BUILTIN": _generateImportModuleHardSource,
+    "EXPRESSION_IMPORT_MODULE_NAME_HARD_MAYBE_EXISTS": _generateImportModuleNameHardSource,
+    "EXPRESSION_IMPORT_MODULE_NAME_HARD_EXISTS": _generateImportModuleNameHardSource,
 }
 
 _statement_source_dispatch = {

--- a/nuitka/code_generation/PythonSourceCodeGeneration.py
+++ b/nuitka/code_generation/PythonSourceCodeGeneration.py
@@ -118,9 +118,11 @@ def _generateDictConstantSource(expression):
 
 
 def _findAliasForModule(module, target):
-    """Find `import X as Y` alias for `target` via trace collection.
+    """Find the module variable name for `target` via trace collection.
 
-    Returns alias string if found and differs from target, else None.
+    Returns the variable name (the alias, or the module name itself when it
+    was imported without a rename) if a module variable for `target` exists,
+    else None.
     """
     trace_collection = module.getTraceCollection()
 
@@ -145,12 +147,7 @@ def _findAliasForModule(module, target):
                 module_name = node.getModuleName()
 
                 if module_name.asString() == target:
-                    alias = variable.getName()
-
-                    if alias != target:
-                        return alias
-
-                    return None
+                    return variable.getName()
             elif node.isExpressionBuiltinImport():
                 # General import `import mymod as mm` -> `__import__('mymod')`
                 name_node = node.subnode_name
@@ -163,12 +160,7 @@ def _findAliasForModule(module, target):
                 if module_name_str != target:
                     continue
 
-                alias = variable.getName()
-
-                if alias != target:
-                    return alias
-
-                return None
+                return variable.getName()
 
     return None
 

--- a/tests/basics/FunctionAnnotateTest314.py
+++ b/tests/basics/FunctionAnnotateTest314.py
@@ -3,6 +3,8 @@
 
 """Test Python 3.14 function '__annotate__' behavior."""
 
+import io
+from annotationlib import Format, call_annotate_function
 from functools import singledispatch
 
 
@@ -58,6 +60,7 @@ print(
 class TestClassAnnotations:
     x: int = 1
     y: str
+    z: io.BytesIO
 
     def method(self, a: int) -> str:
         return str(a)
@@ -71,6 +74,14 @@ print("Class annotation attribute x:", TestClassAnnotations.x)
 print(
     "Class annotation method result:",
     TestClassAnnotations().method(42),
+)
+print(
+    "Class annotations by calling the function:",
+    displayDict(
+        call_annotate_function(
+            TestClassAnnotations.__annotate__, format=Format.FORWARDREF
+        )
+    ),
 )
 
 


### PR DESCRIPTION
Closes #4008 

## ❓ What does this PR do?

Add source-code generation support for hard-module attribute references
(`EXPRESSION_IMPORT_MODULE_NAME_HARD_MAYBE_EXISTS` and
`EXPRESSION_IMPORT_MODULE_NAME_HARD_EXISTS`) in
`nuitka/code_generation/PythonSourceCodeGeneration.py`.

These two node kinds were missing from `_expression_source_dispatch`, so any
`__annotate__` function (Python 3.14+ PEP 649 deferred annotations) that
referenced an attribute of a hard module (`io.BytesIO`) could not be emitted as Python source and was forced
into C compilation.

A new helper `_generateImportModuleNameHardSource` reuses the existing
module-alias resolution in `_generateImportModuleHardSource` (which tries
`_findAliasForModule` via trace collection and falls back to
`__import__(%r)`) and appends `.getImportName()` for the attribute lookup,
yielding source such as `__import__('io').BytesIO` (or the recovered alias
`io.BytesIO` when an `import X as Y` alias is still alive).

`tests/basics/FunctionAnnotateTest314.py` is extended with a class-level
annotation `z: io.BytesIO` and a verification call
`call_annotate_function(TestClassAnnotations.__annotate__, format=Format.FORWARDREF)`
to exercise the new path end-to-end.

## 🧐 Why was it initiated? Any relevant Issues?

On Python 3.14, PEP 649 makes annotations lazy by synthesizing an
`__annotate__` function per class/function. Nuitka emits the source of these
functions through `generateFunctionSourceFromBody`; when an unsupported
expression node is encountered, `PythonSourceGenerationError` is raised and
`CodeGeneration.py` sets the `force_c` flag on the function body, falling
back to C compilation.

For a C-compiled `__annotate__` function, the deferred/forwardref
stringification path inside `annotationlib.call_annotate_function` cannot
inspect the code object's source to produce a forward-reference string, so
invoking it with `format=Format.FORWARDREF` raised:

    TypeError: exceptions must derive from BaseException

By teaching the source generator how to emit
`EXPRESSION_IMPORT_MODULE_NAME_HARD_{MAYBE_,}EXISTS`, the `__annotate__`
function is preserved as Python source, allowing `annotationlib` to
stringify it in `FORWARDREF`/`STRING` formats and eliminating the
`TypeError`.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [ ] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See `https://nuitka.net/doc/developer-manual.html#running-the-tests`).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

I've thoroughly reviewed the code. I only used AI to dig into the problem and clarify my understanding.

## Summary by Sourcery

Enable Python 3.14 deferred annotations to resolve hard-coded module attributes without falling back to C compilation.

Bug Fixes:
- Fix Python 3.14 deferred annotation handling for class annotations that reference attributes of hard-coded modules.

Enhancements:
- Preserve generated __annotate__ functions as Python source so forward-reference annotation formats can be produced correctly.

Tests:
- Extend Python 3.14 annotation coverage with a hard-module attribute reference and forward-reference verification.