### PR TITLE
Fix: forkserver mode crash with nested processes (e.g. Manager()) due to __main__.__spec__ being non-None

### DIFF
--- a/nuitka/plugins/standard/MultiprocessingPlugin.py
+++ b/nuitka/plugins/standard/MultiprocessingPlugin.py
@@ -134,6 +134,7 @@ if str is not bytes:
 
             sys.modules["__main__"] = parents_main
             sys.modules["__mp_main__"] = parents_main
+            parents_main.__spec__ = None
 
         multiprocessing.spawn._fixup_main_from_path = _fixup_main_from_path_for_nuitka
 """,


### PR DESCRIPTION
The fix adds a single line `parents_main.__spec__ = None` to the monkey-patched `_fixup_main_from_path_for_nuitka` function.

Closes #3947 

## 🧐 Why was it initiated? Any relevant Issues?

### Root cause

In Nuitka, `__main__.__spec__` is set to `None` (matching CPython's behavior for script execution) and protected from being overwritten via a custom `tp_setattro` hook. This ensures `multiprocessing.spawn.get_preparation_data()` uses `init_main_from_path` (not `init_main_from_name`), avoiding `runpy.run_module()` which would fail on `nuitka_module_loader.get_code()`.

However, `__parents_main__` is a fake module whose name is not `__main__`, so Nuitka assigns it a real (non-None) `ModuleSpec`. When the patched `_fixup_main_from_path_for_nuitka` assigns `sys.modules["__main__"] = parents_main`, the `__main__.__spec__` silently becomes non-None.

This only matters when a **second** Process is started from within a worker (e.g., `Manager()`):

1. First worker: `_fixup_main_from_path()` replaces `__main__` with `parents_main` → `__main__.__spec__` becomes non-None
2. `Manager()` starts a second Process: `get_preparation_data()` sees non-None `__main__.__spec__` → sets `init_main_from_name`
3. Second worker: `_fixup_main_from_name()` → `runpy.run_module()` → `nuitka_module_loader.get_code()` → `AttributeError`

Without `Manager()` (or any nested Process), no second `get_preparation_data()` is called, so the bug never triggers — explaining why the crash is intermittent.

### Fix

Setting `parents_main.__spec__ = None` after the replacement restores the invariant that `__main__.__spec__` is `None`, consistent with Nuitka's code generation for `__main__` modules (`CodeTemplatesModules.py`, `is_dunder_main` branch) and its `tp_setattro` protection. This ensures `get_preparation_data()` always uses `init_main_from_path`, preventing the crash.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

I've thoroughly reviewed the code. I only used AI to dig into the problem and clarify my understanding.