### PR TITLE
Imports: Deduplicate scanned module candidates by basename with type priority

### DIFF
--- a/nuitka/importing/Recursion.py
+++ b/nuitka/importing/Recursion.py
@@ -39,11 +39,11 @@ from nuitka.plugins.Hooks import (
 )
 from nuitka.PythonVersions import python_version
 from nuitka.Tracing import recursion_logger
-from nuitka.utils.FileOperations import listDir
 from nuitka.utils.Importing import (
     getExtensionModuleSuffixes,
     getPackageDirFilename,
     hasPackageDirFilename,
+    listPackageDirFilename,
 )
 from nuitka.utils.ModuleNames import ModuleName
 
@@ -427,7 +427,7 @@ def _addIncludedModule(module, package_only):
             recursion_logger.info("Package directory '%s'." % package_dir)
 
         if not package_only:
-            for sub_path, sub_filename in listDir(package_dir):
+            for sub_path, sub_filename in listPackageDirFilename(package_dir):
                 if sub_filename == "__pycache__" or hasPackageDirFilename(sub_filename):
                     continue
 
@@ -546,7 +546,7 @@ def scanPluginPath(plugin_filename, module_package):
     # This effectively only covers files known to not be packages due to name
     # or older Python version.
     elif os.path.isdir(plugin_filename):
-        for sub_path, sub_filename in listDir(plugin_filename):
+        for sub_path, sub_filename in listPackageDirFilename(plugin_filename):
             assert sub_filename != "__init__.py"
 
             if isPackageDir(sub_path) or sub_path.endswith(".py"):

--- a/nuitka/utils/Importing.py
+++ b/nuitka/utils/Importing.py
@@ -11,9 +11,9 @@ import sys
 from contextlib import contextmanager
 
 from nuitka.__past__ import imp
+from nuitka.plugins.Hooks import decideRecompileExtensionModules
 from nuitka.PythonVersions import python_version
 from nuitka.Tracing import general
-from nuitka.plugins.Hooks import decideRecompileExtensionModules
 
 from .InlineCopies import getInlineCopyFolder
 from .ModuleNames import ModuleName

--- a/nuitka/utils/Importing.py
+++ b/nuitka/utils/Importing.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from nuitka.__past__ import imp
 from nuitka.PythonVersions import python_version
 from nuitka.Tracing import general
+from nuitka.plugins.Hooks import decideRecompileExtensionModules
 
 from .InlineCopies import getInlineCopyFolder
 from .ModuleNames import ModuleName
@@ -313,6 +314,44 @@ def getPackageDirFilename(path):
             return candidate
 
     return None
+
+
+def listPackageDirFilename(path):
+    assert os.path.isdir(path)
+
+    # Cyclic dependency here
+    from .FileOperations import listDir
+
+    candidates = []
+    # Higher values are lower priority.
+    priority_map = {
+        "PY_COMPILED": 3,
+        "PY_SOURCE": 2,
+        "C_EXTENSION": 1,
+    }
+
+    for filename_full, filename in listDir(path):
+        for suffix, module_type in getModuleFilenameSuffixes():
+            if filename.endswith(suffix):
+                module_name, _ = getModuleNameAndKindFromFilenameSuffix(filename)
+                candidates.append((module_name, module_type, (filename_full, filename)))
+                break
+
+    def prioritize(candidate):
+        decision, _reason = decideRecompileExtensionModules(candidate[0])
+        if candidate[1] == "PY_SOURCE" and decision:
+            return priority_map[candidate[1]] - 2
+        return priority_map[candidate[1]]
+
+    seen = set()
+    result = []
+
+    for candidate in sorted(candidates, key=prioritize):
+        if candidate[0] in seen:
+            continue
+        seen.add(candidate[0])
+        result.append(candidate[2])
+    return result
 
 
 @contextmanager


### PR DESCRIPTION
# Description

## ❓ What does this PR do?

When scanning a directory for modules (package recursion in `_addIncludedPackage` and plugin path scanning in `scanPluginPath`), a directory that contains both e.g. `foo.py` and `foo.pyd` previously produced two module entries for the same module name. This could lead to duplicate module registrations and assertion failures during timing checks.

This PR adds a new utility `listPackageDirFilename` in `nuitka/utils/Importing.py` which:

- Lists directory entries and groups them by module basename (derived from the filename suffix).
- Deduplicates candidates, retaining only the highest priority one per module name, ordered by `C_EXTENSION` > `PY_SOURCE` > `PY_COMPILED`, with adjustments from `decideRecompileExtensionModules` (e.g. when extension module recompilation is enabled, a `.py` source takes precedence over a `.pyd`).
- Keeps the returned `(full_path, filename)` tuples so callers are unaffected in shape.

The two call sites in `nuitka/importing/Recursion.py` now use `listPackageDirFilename` instead of the raw `listDir`, aligning plugin path scanning behavior with `locateModule`.

## 🧐 Why was it initiated? Any relevant Issues?

Scanning directories that contain both a `.py` and a compiled `.pyd` for the same module name caused the same module to be registered more than once, which surfaced as assertion failures in the module timing checks. Relevant issue: #4020.

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

## Summary by Sourcery

Deduplicate scanned module candidates by basename while honoring extension, source, and recompilation priorities.

Bug Fixes:
- Prevent duplicate module registrations when package or plugin directories contain multiple files for the same module basename by retaining the appropriate candidate according to module type priority.

Enhancements:
- Align package and plugin directory scanning with module resolution by centralizing filename filtering and candidate selection.