### PR TITLE
Standalone: Fix, include GdkPixbuf GI override to avoid new_from_data use-after-free

### DIFF
--- a/nuitka/plugins/standard/GiPlugin.py
+++ b/nuitka/plugins/standard/GiPlugin.py
@@ -66,6 +66,7 @@ if not os.getenv("GI_TYPELIB_PATH"):
         if full_name == "gi.overrides":
             yield "gi.overrides.Gtk"
             yield "gi.overrides.Gdk"
+            yield "gi.overrides.GdkPixbuf"
             yield "gi.overrides.GLib"
             yield "gi.overrides.GObject"
 


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

Include `gi.overrides.GdkPixbuf` as a standalone implicit import so PyGObject’s `Pixbuf.new_from_data` override is packaged. Without it, GI calls `gdk_pixbuf_new_from_data` directly and the pixel buffer is a use-after-free.

See https://github.com/GNOME/pygobject/commit/898bbe50005223f5f04994764b3e95f13dffe2d2 for details

## 🧐 Why was it initiated? Any relevant Issues?

Closes #897

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

