### PR TITLE
Standalone: Fix, "glfw" and "imgui_bundle" must share one GLFW library

### DIFF
--- a/nuitka/plugins/standard/GlfwPlugin.py
+++ b/nuitka/plugins/standard/GlfwPlugin.py
@@ -108,11 +108,12 @@ class NuitkaPluginGlfw(NuitkaPluginBase):
 
             code = r"""
 import os
-os.environ["PYGLFW_LIBRARY"] = os.path.join(__nuitka_binary_dir, "glfw", "%s")
+if not os.getenv("PYGLFW_LIBRARY"):
+    os.environ["PYGLFW_LIBRARY"] = os.path.join(__nuitka_binary_dir, "glfw", "%s")
 """ % os.path.basename(dll_filename)
             return (
                 code,
-                "Setting 'PYGLFW_LIBRARY' environment variable for glfw to find platform DLL.",
+                "Setting 'PYGLFW_LIBRARY' environment variable for glfw to find platform DLL unless already provided.",
             )
 
 

--- a/nuitka/plugins/standard/standard.nuitka-package.config.yml
+++ b/nuitka/plugins/standard/standard.nuitka-package.config.yml
@@ -2241,6 +2241,14 @@
       replacements:
         'sj.get_version("pyimagej")': 'repr(version("pyimagej"))'
 
+- module-name: 'imgui_bundle' # checksum: bddcce39
+  # Vendored GLFW must sit next to the package; pyglfw loads it via PYGLFW_LIBRARY.
+  dlls:
+    - from_filenames:
+        prefixes:
+          - 'glfw3'
+          - 'libglfw'
+
 - module-name: 'imgui_bundle.immapp.immapp_notebook' # checksum: 7d07a2d1
   anti-bloat:
     - description: 'remove IPython reference'


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

Standalone currently forces `PYGLFW_LIBRARY` to the `glfw` package DLL. `imgui_bundle` vendors its own GLFW and points pyglfw at it, so the C++ backend and `glfw.create_window()` can load two different GLFW copies. On Windows that makes `glfwGetWin32Window()` return a null HWND and asserts in `imgui_impl_glfw.cpp`.
This PR:
* Leaves an existing `PYGLFW_LIBRARY` value alone in the glfw plugin.
* Includes the vendored GLFW of `imgui_bundle` (`glfw3` / `libglfw*`) next to the package.

## 🧐 Why was it initiated? Any relevant Issues?

Closes #2812

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [ ] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [x] **Detection**: This PR contains AI generated code.
  - [x] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [x] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [x] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Bug Fixes:
- Ensure standalone builds using imgui_bundle and pyglfw load a single shared GLFW library, preventing invalid native window handles on Windows.