### PR TITLE
perf: keep exact-float arithmetic intermediates native

### DIFF
--- a/nuitka/build/include/nuitka/helper/operations_binary_add.h
+++ b/nuitka/build/include/nuitka/helper/operations_binary_add.h
@@ -136,6 +136,24 @@ extern PyObject *BINARY_OPERATION_ADD_OBJECT_FLOAT_CFLOAT(PyObject *operand1, do
 /* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
 extern nuitka_bool BINARY_OPERATION_ADD_NBOOL_FLOAT_CFLOAT(PyObject *operand1, double operand2);
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+extern PyObject *BINARY_OPERATION_ADD_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern PyObject *BINARY_OPERATION_ADD_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_ADD_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_ADD_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_ADD_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_ADD_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2);
+
 #if PYTHON_VERSION < 0x300
 /* Code referring to "STR" corresponds to Python2 'str' and "STR" to Python2 'str'. */
 extern PyObject *BINARY_OPERATION_ADD_OBJECT_STR_STR(PyObject *operand1, PyObject *operand2);

--- a/nuitka/build/include/nuitka/helper/operations_binary_mult.h
+++ b/nuitka/build/include/nuitka/helper/operations_binary_mult.h
@@ -122,6 +122,24 @@ extern PyObject *BINARY_OPERATION_MULT_OBJECT_FLOAT_CFLOAT(PyObject *operand1, d
 /* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
 extern nuitka_bool BINARY_OPERATION_MULT_NBOOL_FLOAT_CFLOAT(PyObject *operand1, double operand2);
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+extern PyObject *BINARY_OPERATION_MULT_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern PyObject *BINARY_OPERATION_MULT_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_MULT_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_MULT_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_MULT_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_MULT_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2);
+
 #if PYTHON_VERSION < 0x300
 /* Code referring to "STR" corresponds to Python2 'str' and "INT" to Python2 'int'. */
 extern PyObject *BINARY_OPERATION_MULT_OBJECT_STR_INT(PyObject *operand1, PyObject *operand2);

--- a/nuitka/build/include/nuitka/helper/operations_binary_sub.h
+++ b/nuitka/build/include/nuitka/helper/operations_binary_sub.h
@@ -103,6 +103,21 @@ extern PyObject *BINARY_OPERATION_SUB_OBJECT_FLOAT_CFLOAT(PyObject *operand1, do
 /* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
 extern PyObject *BINARY_OPERATION_SUB_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern PyObject *BINARY_OPERATION_SUB_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_SUB_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2);
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_SUB_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+extern double BINARY_OPERATION_SUB_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2);
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+extern double BINARY_OPERATION_SUB_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2);
+
 /* Code referring to "OBJECT" corresponds to any Python object and "OBJECT" to any Python object. */
 extern PyObject *BINARY_OPERATION_SUB_OBJECT_OBJECT_OBJECT(PyObject *operand1, PyObject *operand2);
 

--- a/nuitka/build/static_src/HelpersOperationBinaryAdd.c
+++ b/nuitka/build/static_src/HelpersOperationBinaryAdd.c
@@ -3986,6 +3986,258 @@ nuitka_bool BINARY_OPERATION_ADD_NBOOL_FLOAT_CFLOAT(PyObject *operand1, double o
     return _BINARY_OPERATION_ADD_NBOOL_FLOAT_CFLOAT(operand1, operand2);
 }
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+static PyObject *_BINARY_OPERATION_ADD_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    PyObject *result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = operand1;
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = MAKE_FLOAT_FROM_DOUBLE(cfloat_result);
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+PyObject *BINARY_OPERATION_ADD_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_ADD_OBJECT_CFLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static PyObject *_BINARY_OPERATION_ADD_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    PyObject *result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = MAKE_FLOAT_FROM_DOUBLE(cfloat_result);
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+PyObject *BINARY_OPERATION_ADD_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_ADD_OBJECT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_ADD_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_ADD_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_ADD_CFLOAT_FLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_ADD_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_ADD_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    return _BINARY_OPERATION_ADD_CFLOAT_FLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_ADD_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = operand1;
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_ADD_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_ADD_CFLOAT_CFLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_ADD_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a + b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_ADD_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_ADD_CFLOAT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
 #if PYTHON_VERSION < 0x300
 /* Code referring to "STR" corresponds to Python2 'str' and "STR" to Python2 'str'. */
 static PyObject *_BINARY_OPERATION_ADD_OBJECT_STR_STR(PyObject *operand1, PyObject *operand2) {

--- a/nuitka/build/static_src/HelpersOperationBinaryMult.c
+++ b/nuitka/build/static_src/HelpersOperationBinaryMult.c
@@ -3644,6 +3644,258 @@ nuitka_bool BINARY_OPERATION_MULT_NBOOL_FLOAT_CFLOAT(PyObject *operand1, double 
     return _BINARY_OPERATION_MULT_NBOOL_FLOAT_CFLOAT(operand1, operand2);
 }
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+static PyObject *_BINARY_OPERATION_MULT_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    PyObject *result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = operand1;
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = MAKE_FLOAT_FROM_DOUBLE(cfloat_result);
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+PyObject *BINARY_OPERATION_MULT_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_MULT_OBJECT_CFLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static PyObject *_BINARY_OPERATION_MULT_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    PyObject *result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = MAKE_FLOAT_FROM_DOUBLE(cfloat_result);
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+PyObject *BINARY_OPERATION_MULT_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_MULT_OBJECT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_MULT_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_MULT_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_MULT_CFLOAT_FLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_MULT_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_MULT_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    return _BINARY_OPERATION_MULT_CFLOAT_FLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_MULT_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = operand1;
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_MULT_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_MULT_CFLOAT_CFLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_MULT_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a * b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_MULT_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_MULT_CFLOAT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
 #if PYTHON_VERSION < 0x300
 /* Code referring to "STR" corresponds to Python2 'str' and "INT" to Python2 'int'. */
 static PyObject *_BINARY_OPERATION_MULT_OBJECT_STR_INT(PyObject *operand1, PyObject *operand2) {

--- a/nuitka/build/static_src/HelpersOperationBinarySub.c
+++ b/nuitka/build/static_src/HelpersOperationBinarySub.c
@@ -2417,6 +2417,215 @@ PyObject *BINARY_OPERATION_SUB_OBJECT_CFLOAT_FLOAT(double operand1, PyObject *op
     return _BINARY_OPERATION_SUB_OBJECT_CFLOAT_FLOAT(operand1, operand2);
 }
 
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static PyObject *_BINARY_OPERATION_SUB_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    PyObject *result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    double r = a - b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = MAKE_FLOAT_FROM_DOUBLE(cfloat_result);
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+PyObject *BINARY_OPERATION_SUB_OBJECT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_SUB_OBJECT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_SUB_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a - b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_SUB_CFLOAT_FLOAT_FLOAT(PyObject *operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_SUB_CFLOAT_FLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "FLOAT" corresponds to Python 'float' and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_SUB_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand1);
+    assert(PyFloat_CheckExact(operand1));
+
+    const double a = PyFloat_AS_DOUBLE(operand1);
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a - b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_SUB_CFLOAT_FLOAT_CFLOAT(PyObject *operand1, double operand2) {
+    return _BINARY_OPERATION_SUB_CFLOAT_FLOAT_CFLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "FLOAT" to Python 'float'. */
+static double _BINARY_OPERATION_SUB_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    CHECK_OBJECT(operand2);
+    assert(PyFloat_CheckExact(operand2));
+
+    const double a = operand1;
+    const double b = PyFloat_AS_DOUBLE(operand2);
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a - b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_SUB_CFLOAT_CFLOAT_FLOAT(double operand1, PyObject *operand2) {
+    return _BINARY_OPERATION_SUB_CFLOAT_CFLOAT_FLOAT(operand1, operand2);
+}
+
+/* Code referring to "CFLOAT" corresponds to C platform float value and "CFLOAT" to C platform float value. */
+static double _BINARY_OPERATION_SUB_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+
+    double result;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#endif
+    // Not every code path will make use of all possible results.
+    NUITKA_MAY_BE_UNUSED PyObject *obj_result;
+    NUITKA_MAY_BE_UNUSED long clong_result;
+    NUITKA_MAY_BE_UNUSED double cfloat_result;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    const double a = operand1;
+    const double b = operand2;
+
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a - b;
+
+    cfloat_result = r;
+    goto exit_result_ok_cfloat;
+
+exit_result_ok_cfloat:
+    result = cfloat_result;
+    goto exit_result_ok;
+
+exit_result_ok:
+    return result;
+}
+
+double BINARY_OPERATION_SUB_CFLOAT_CFLOAT_CFLOAT(double operand1, double operand2) {
+    return _BINARY_OPERATION_SUB_CFLOAT_CFLOAT_CFLOAT(operand1, operand2);
+}
+
 /* Code referring to "OBJECT" corresponds to any Python object and "OBJECT" to any Python object. */
 static PyObject *_BINARY_OPERATION_SUB_OBJECT_OBJECT_OBJECT(PyObject *operand1, PyObject *operand2) {
     CHECK_OBJECT(operand1);

--- a/nuitka/code_generation/BinaryOperationHelperDefinitions.py
+++ b/nuitka/code_generation/BinaryOperationHelperDefinitions.py
@@ -181,6 +181,18 @@ def _makeNonContainerMathOps(op_code):
             yield value
 
 
+def _makeFloatIntermediateOps(op_code):
+    for result_type in ("OBJECT", "CFLOAT"):
+        for left_type in ("FLOAT", "CFLOAT"):
+            for right_type in ("FLOAT", "CFLOAT"):
+                yield "BINARY_OPERATION_%s_%s_%s_%s" % (
+                    op_code,
+                    result_type,
+                    left_type,
+                    right_type,
+                )
+
+
 def _makeNumberOps(op_code, result_types):
     return buildOrderedSet(
         _makeTypeOps(op_code=op_code, type_name="INT", result_types=result_types),
@@ -212,6 +224,11 @@ def _makeNumberOps(op_code, result_types):
         ),
         _makeFriendOps(
             op_code, friend_type_names=("FLOAT", "CFLOAT"), result_types=result_types
+        ),
+        (
+            _makeFloatIntermediateOps(op_code)
+            if op_code in ("ADD", "SUB", "MULT") and result_types is not None
+            else ()
         ),
         (
             _makeFriendOps(

--- a/nuitka/code_generation/ComparisonCodes.py
+++ b/nuitka/code_generation/ComparisonCodes.py
@@ -77,6 +77,7 @@ def getRichComparisonCode(
         left=left,
         right=right,
         may_swap_arguments="always",
+        allow_float_intermediates=False,
         context=context,
     )
 

--- a/nuitka/code_generation/ExpressionCTypeSelectionHelpers.py
+++ b/nuitka/code_generation/ExpressionCTypeSelectionHelpers.py
@@ -59,8 +59,23 @@ def _pickIntFamilyType(expression, context):
     return c_type
 
 
-def _pickFloatFamilyType(expression):
+def canUseCFloatIntermediate(expression):
+    """Check whether an arithmetic result can be passed as a native float."""
+    return (
+        expression.isExpressionOperationBinary()
+        and expression.getOperator() in ("Add", "Sub", "Mult")
+        and not expression.isInplaceSuspect()
+        and expression.getTypeShape() is tshape_float
+        and expression.subnode_left.getTypeShape() is tshape_float
+        and expression.subnode_right.getTypeShape() is tshape_float
+        and not expression.mayRaiseExceptionOperation()
+    )
+
+
+def _pickFloatFamilyType(expression, allow_float_intermediates):
     if expression.isCompileTimeConstant():
+        c_type = CTypeCFloat
+    elif allow_float_intermediates and canUseCFloatIntermediate(expression):
         c_type = CTypeCFloat
     else:
         c_type = CTypePyObjectPtr
@@ -110,7 +125,9 @@ _bytes_argument_normalization = {
 }
 
 
-def decideExpressionCTypes(left, right, may_swap_arguments, context):
+def decideExpressionCTypes(
+    left, right, may_swap_arguments, allow_float_intermediates, context
+):
     # Complex stuff with many cases, pylint: disable=too-many-branches
 
     left_shape = left.getTypeShape()
@@ -138,8 +155,8 @@ def decideExpressionCTypes(left, right, may_swap_arguments, context):
     elif left_shape in _float_types_family and right_shape in _float_types_family:
         may_swap_arguments = may_swap_arguments in ("number", "always")
 
-        left_c_type = _pickFloatFamilyType(left)
-        right_c_type = _pickFloatFamilyType(right)
+        left_c_type = _pickFloatFamilyType(left, allow_float_intermediates)
+        right_c_type = _pickFloatFamilyType(right, allow_float_intermediates)
 
         # Arguments might be swapped because of normalization.
         needs_argument_swap = (

--- a/nuitka/code_generation/OperationCodes.py
+++ b/nuitka/code_generation/OperationCodes.py
@@ -8,6 +8,7 @@ of course types could play into it. Then there is also the added difficulty of
 in-place assignments, which have other operation variants.
 """
 
+from nuitka.nodes.shapes.BuiltinTypeShapes import tshape_float
 from nuitka.nodes.shapes.StandardShapes import tshape_unknown
 
 from .BinaryOperationHelperDefinitions import (
@@ -16,6 +17,7 @@ from .BinaryOperationHelperDefinitions import (
     getSpecializedBinaryOperations,
 )
 from .c_types.CTypeBooleans import CTypeBool
+from .c_types.CTypeCFloats import CTypeCFloat
 from .c_types.CTypeNuitkaBooleans import CTypeNuitkaBoolEnum
 from .c_types.CTypeNuitkaVoids import CTypeNuitkaVoidEnum
 from .c_types.CTypePyObjectPointers import CTypePyObjectPtr
@@ -32,7 +34,10 @@ from .ErrorCodes import (
     getReleaseCodes,
     getTakeReferenceCode,
 )
-from .ExpressionCTypeSelectionHelpers import decideExpressionCTypes
+from .ExpressionCTypeSelectionHelpers import (
+    canUseCFloatIntermediate,
+    decideExpressionCTypes,
+)
 
 
 def generateOperationBinaryCode(to_name, expression, emit, context):
@@ -94,6 +99,20 @@ def _getBinaryOperationCode(
     # This is detail rich stuff, encoding the complexity of what helpers are
     # available, and can be used as a fallback.
     # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    allow_float_intermediates = (
+        operator in ("Add", "Sub", "Mult")
+        and not inplace
+        and not needs_check
+        and left.getTypeShape() is tshape_float
+        and right.getTypeShape() is tshape_float
+        and to_name.getCType() in (CTypePyObjectPtr, CTypeCFloat)
+        and (
+            to_name.getCType() is CTypeCFloat
+            or canUseCFloatIntermediate(left)
+            or canUseCFloatIntermediate(right)
+        )
+    )
+
     (
         _unknown_types,
         needs_argument_swap,
@@ -106,13 +125,14 @@ def _getBinaryOperationCode(
         right=right,
         may_swap_arguments=(
             "never"
-            if inplace
+            if inplace or allow_float_intermediates
             else (
                 "number"
                 if operator in ("Add", "Mult", "BitOr", "BitAnd", "BitXor")
                 else "never"
             )
         ),
+        allow_float_intermediates=allow_float_intermediates,
         context=context,
     )
 
@@ -187,6 +207,9 @@ def _getBinaryOperationCode(
         )
 
     if helper_function is None:
+        # Native targets require a complete helper matrix; no object conversion exists.
+        assert target_type is not CTypeCFloat, (prefix, left_c_type, right_c_type)
+
         # Give up and warn about it.
         left_c_type = CTypePyObjectPtr
         right_c_type = CTypePyObjectPtr

--- a/nuitka/code_generation/c_types/CTypeCFloats.py
+++ b/nuitka/code_generation/c_types/CTypeCFloats.py
@@ -14,6 +14,10 @@ class CTypeCFloat(CTypeBase):
     helper_code = "CFLOAT"
 
     @classmethod
+    def hasErrorIndicator(cls):
+        return False
+
+    @classmethod
     def emitAssignmentCodeFromConstant(
         cls, to_name, constant, may_escape, emit, context
     ):

--- a/nuitka/code_generation/templates_c/HelperSlotsFloat.c.j2
+++ b/nuitka/code_generation/templates_c/HelperSlotsFloat.c.j2
@@ -11,7 +11,12 @@
     const double a = {{ left.getAsDoubleValueExpression(operand1) }};
     const double b = {{ right.getAsDoubleValueExpression(operand2) }};
 
+{% if target and target.type_name == "cfloat" %}
+    // Round each unboxed result before another operation can contract it.
+    volatile double r = a {{operator}} b;
+{% else %}
     double r = a {{operator}} b;
+{% endif %}
 
     {{ goto_exit(props, exit_result_ok_cfloat, "r") }}
 {% elif operator == "//" %}

--- a/nuitka/tools/specialize/CTypeDescriptions.py
+++ b/nuitka/tools/specialize/CTypeDescriptions.py
@@ -1859,6 +1859,10 @@ class CFloatDesc(ConcreteCTypeBase):
     type_decl = "double"
 
     @classmethod
+    def getAssignFromFloatExpressionCode(cls, result, operand):
+        return "%s = %s;" % (result, operand)
+
+    @classmethod
     def getCheckValueCode(cls, operand):
         return ""
 

--- a/tests/basics/FloatArithmeticIntermediatesTest.py
+++ b/tests/basics/FloatArithmeticIntermediatesTest.py
@@ -1,0 +1,255 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+from __future__ import print_function
+
+import binascii
+import struct
+
+
+def floatBits(value):
+    return binascii.hexlify(struct.pack(">d", value)).decode("ascii")
+
+
+def arithmeticTrees(flag):
+    # Equal branch shapes prove exact floats without making their values constant.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    c = -0.5 if flag else 2.0
+
+    return (
+        (a + b) + c,
+        a + (b + c),
+        ((a + b) + (a + 2.0)) + ((3.0 + b) + (a + c)),
+        (a - b) - c,
+        a - (b - c),
+        ((a - b) - (a - 2.0)) - ((3.0 - b) - (a - c)),
+        (a * b) * c,
+        a * (b * c),
+        ((a * b) * (a * 2.0)) * ((3.0 * b) * (a * c)),
+        (a + b) * (a - c),
+        (a * b) + (a - c),
+        (a * b) - (a + c),
+        (a - b) + (a * c),
+        (a + b) - (a * c),
+        (a - b) * (a + c),
+    )
+
+
+def numericEdges(flag):
+    zero = -0.0 if flag else 0.0
+    other_zero = 0.0 if flag else -0.0
+    infinity = 1e400 if flag else -1e400
+    nan = (1e400 - 1e400) if flag else -(1e400 - 1e400)
+    smallest = 5e-324 if flag else 1e-323
+    largest = 1.7976931348623157e308 if flag else 1e308
+
+    return (
+        (zero + zero) * 1.0,
+        (zero - other_zero) * 1.0,
+        (zero * -1.0) + other_zero,
+        (smallest * 0.5) + smallest,
+        (largest * 2.0) - largest,
+        (infinity + 1.0) - infinity,
+        (nan + 1.0) * 2.0,
+        (1.0 + nan) * 2.0,
+        (nan - 1.0) + zero,
+        (1.0 - nan) + zero,
+        (nan * smallest) - other_zero,
+    )
+
+
+def boxedAdd(a, b):
+    return a + b
+
+
+def boxedSubtract(a, b):
+    return a - b
+
+
+def boxedMultiply(a, b):
+    return a * b
+
+
+def roundingCases(flag):
+    a = 1.0000000000000002 if flag else 1.0000000000000004
+    b = 0.9999999999999999 if flag else 0.9999999999999998
+    large = 9007199254740992.0 if flag else 18014398509481984.0
+
+    fused_sensitive = (a * b) - 1.0
+    separately_rounded = boxedSubtract(boxedMultiply(a, b), 1.0)
+    assert floatBits(fused_sensitive) == floatBits(separately_rounded)
+
+    cancellation = (large + 1.0) - large
+    separate_cancellation = boxedSubtract(boxedAdd(large, 1.0), large)
+    assert floatBits(cancellation) == floatBits(separate_cancellation)
+
+    return fused_sensitive, cancellation
+
+
+def recordCondition(events, label, failure):
+    events.append(label)
+    if label == failure:
+        raise ValueError(label)
+    return len(events) % 2
+
+
+def sideEffectOperands(flag, failure):
+    a = 1.25 if flag else -2.5
+    events = []
+
+    try:
+        result = (
+            (a + (1.0 if recordCondition(events, "left", failure) else 2.0))
+            * (3.0 if recordCondition(events, "right", failure) else 4.0)
+        ) - (5.0 if recordCondition(events, "last", failure) else 6.0)
+    except ValueError as exception:
+        return events, type(exception).__name__, str(exception)
+
+    return events, floatBits(result)
+
+
+def unknownValue(events, value):
+    events.append("call")
+    return value
+
+
+def unknownRight(flag, value):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    events = []
+    result = ((a + b) - a) * unknownValue(events, value)
+    return events, result
+
+
+def unknownLeft(flag, value):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    events = []
+    result = unknownValue(events, value) * ((a + b) - a)
+    return events, result
+
+
+class FloatSubclass(float):
+    def __mul__(self, other):
+        return "subclass multiply", floatBits(other)
+
+    def __rmul__(self, other):
+        return "subclass reflected multiply", floatBits(other)
+
+
+class FloatConvertible(object):
+    def __float__(self):
+        return 2.5
+
+
+def conversionBoundary(flag, value):
+    a = 1.25 if flag else -2.5
+    return (a + float(value)) * a
+
+
+def mixedIntegerBoundary(flag):
+    a = 1.25 if flag else -2.5
+    integer = 2 if flag else 2**54 + 1
+    return (a + integer) * a, (integer - a) * a
+
+
+def hugeIntegerBoundary(flag):
+    a = 1.25 if flag else -2.5
+    integer = 10**400 if flag else -(10**400)
+    return (a + a) * integer
+
+
+def divisionBoundary(flag):
+    a = 1.25 if flag else -2.5
+    divisor = -0.0 if flag else 2.0
+    return ((a + a) * a) / divisor
+
+
+def otherOperationBoundaries(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return (a + b) // b, (a + b) % a, (a + b) ** 2.0, -(a + b)
+
+
+def inplaceBoundary(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    a += (b + 1.0) * (b - 2.0)
+    a -= (b - 1.0) * (b + 2.0)
+    a *= (b + 1.0) - (b - 2.0)
+    return a
+
+
+def comparisonBoundary(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return (
+        (a + b) == (a * b),
+        (a + b) < (a * b),
+        ((a + b) * b) >= ((a - b) * b),
+        bool((a + b) * (a - b)),
+    )
+
+
+def identityBoundary(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    value = (a + b) * (a - b)
+    alias = value
+    container = [value]
+    local_values = locals()
+    return (
+        type(value) is float,
+        value is alias,
+        value is value,
+        value is container[0],
+        value is local_values["value"],
+        alias is local_values["alias"],
+    )
+
+
+def normalAssignmentLoop(flag):
+    value = 1.25 if flag else -2.5
+    for unused in range(5):
+        value = (value + 0.5) * 0.25
+    return value
+
+
+for test_flag in (False, True):
+    print("Flag:", test_flag)
+    print("Trees:", [floatBits(value) for value in arithmeticTrees(test_flag)])
+    print("Numeric edges:", [floatBits(value) for value in numericEdges(test_flag)])
+    print("Rounding:", [floatBits(value) for value in roundingCases(test_flag)])
+    for failure_at in (None, "left", "right", "last"):
+        print("Side effects:", failure_at, sideEffectOperands(test_flag, failure_at))
+    for unknown in (2.5, 2, True, FloatSubclass(2.5)):
+        print("Unknown right:", unknownRight(test_flag, unknown))
+        print("Unknown left:", unknownLeft(test_flag, unknown))
+    print("Conversion:", floatBits(conversionBoundary(test_flag, FloatConvertible())))
+    print("Mixed integers:", mixedIntegerBoundary(test_flag))
+    for exceptional_case in (hugeIntegerBoundary, divisionBoundary):
+        try:
+            print("Exceptional boundary:", exceptional_case(test_flag))
+        except (OverflowError, ZeroDivisionError) as error:
+            print("Exceptional boundary:", type(error).__name__)
+    print("Other operations:", otherOperationBoundaries(test_flag))
+    print("Inplace:", floatBits(inplaceBoundary(test_flag)))
+    print("Comparisons:", comparisonBoundary(test_flag))
+    print("Identity:", identityBoundary(test_flag))
+    print("Normal assignment loop:", floatBits(normalAssignmentLoop(test_flag)))
+
+#     Python tests originally created or extracted from other peoples work. The
+#     parts were too small to be protected.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/tests/benchmarks/constructs/OperationFloatChain.py
+++ b/tests/benchmarks/constructs/OperationFloatChain.py
@@ -1,0 +1,93 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+"""Float expression trees and controls with runtime-dependent inputs."""
+
+import itertools
+import sys
+
+
+def shortChain(seed, repetitions):
+    value = 1.5 if seed else 2.5
+
+    for _unused in itertools.repeat(None, repetitions):
+        value = (value + 1.25) * 0.5 - 0.125
+
+    return value
+
+
+def balancedTree(seed, repetitions):
+    result = 0.0
+
+    for _unused in itertools.repeat(None, repetitions):
+        value = 1.5 if seed else 2.5
+        factor = 0.625 if seed else 0.375
+        result = (value + 1.25) * (factor - 0.125)
+        seed = result < 1.0
+
+    return result
+
+
+def boxedRecurrence(seed, repetitions):
+    value = 1.5 if seed else 2.5
+
+    for _unused in itertools.repeat(None, repetitions):
+        value = value + 1.25
+        value = value * 0.5
+        value = value - 0.125
+
+    return value
+
+
+def singleOperation(seed, repetitions):
+    value = 1.5 if seed else 2.5
+
+    for _unused in itertools.repeat(None, repetitions):
+        value = value + 0.125
+
+    return value
+
+
+def unknownOperands(value, repetitions):
+    for _unused in itertools.repeat(None, repetitions):
+        value = (value + 1.25) * 0.5 - 0.125
+
+    return value
+
+
+operations = {
+    "short_chain": boxedRecurrence,
+    "balanced_tree": balancedTree,
+    "boxed_recurrence": boxedRecurrence,
+    "single_operation": singleOperation,
+    "unknown_operands": unknownOperands,
+}
+
+# construct_begin
+operations["short_chain"] = shortChain
+# construct_end
+
+operation_name = sys.argv[1] if len(sys.argv) > 1 else "short_chain"
+repetition_count = int(sys.argv[2]) if len(sys.argv) > 2 else 50000
+initial_value = float(sys.argv[3]) if len(sys.argv) > 3 else 1.5
+
+result = operations[operation_name](initial_value, repetition_count)
+
+print(repr(result))
+
+#     Python test originally created or extracted from other peoples work. The
+#     parts from me are licensed as below. It is at least Free Software where
+#     it's copied from other people. In these cases, that will normally be
+#     indicated.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/tests/codegen-analysis/float_intermediates_analysis.py
+++ b/tests/codegen-analysis/float_intermediates_analysis.py
@@ -1,0 +1,98 @@
+#     Copyright 2026, Kay Hayen, mailto:kay.hayen@gmail.com find license text at end of file
+
+
+from __future__ import print_function
+
+
+def add_tree(flag):
+    # Interior helpers cover FLOAT/FLOAT, FLOAT/CFLOAT, CFLOAT/FLOAT and CFLOAT/CFLOAT.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return ((a + b) + (a + 2.0)) + ((3.0 + b) + (a + b))
+
+
+def sub_tree(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return ((a - b) - (a - 2.0)) - ((3.0 - b) - (a - b))
+
+
+def mult_tree(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return ((a * b) * (a * 2.0)) * ((3.0 * b) * (a * b))
+
+
+def object_float_results(flag):
+    # These roots retain FLOAT/FLOAT operands and OBJECT results.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return a + b, a - b, a * b
+
+
+def left_native_results(flag):
+    # Each root has CFLOAT/FLOAT operands and an OBJECT result.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return (a + b) + a, (a - b) - a, (a * b) * a
+
+
+def right_native_results(flag):
+    # Each root has FLOAT/CFLOAT operands and an OBJECT result.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return a + (a + b), a - (a - b), a * (a * b)
+
+
+def unknown_boundary(flag, unknown):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return (a + b) * unknown
+
+
+def comparison_boundary(flag):
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return (a + b) < (a * b)
+
+
+def comparison_with_interior(flag):
+    # The comparison receives objects, but the addition remains an interior candidate.
+    a = 1.25 if flag else -2.5
+    b = 3.5 if flag else 4.25
+    return ((a + b) * b) < a
+
+
+def normal_assignment_loop(flag):
+    value = 1.25 if flag else -2.5
+    for unused in range(5):
+        value = (value + 0.5) * 0.25
+    return value
+
+
+for test_flag in (False, True):
+    print(add_tree(test_flag))
+    print(sub_tree(test_flag))
+    print(mult_tree(test_flag))
+    print(object_float_results(test_flag))
+    print(left_native_results(test_flag))
+    print(right_native_results(test_flag))
+    print(unknown_boundary(test_flag, 2.0))
+    print(comparison_boundary(test_flag))
+    print(comparison_with_interior(test_flag))
+    print(normal_assignment_loop(test_flag))
+
+#     Python tests originally created or extracted from other peoples work. The
+#     parts were too small to be protected.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.


### PR DESCRIPTION
Keep intermediate results in exact-float addition, subtraction, and multiplication expressions as C doubles. Materialize Python float objects at assignments, returns, and other object boundaries, reducing temporary allocations and reference-count operations.

Extend the specialized helper generator with ordered FLOAT/CFLOAT operand combinations and native result variants. Preserve operand evaluation order and round each native result before subsequent operations.

Include regression tests for arithmetic trees, numeric edge cases, and object boundaries, plus benchmark fixtures for calculation chains and controls.

## Summary by Sourcery

Optimize exact-float arithmetic by retaining eligible intermediate results natively and boxing them only when required.

Enhancements:
- Keep exact-float addition, subtraction, and multiplication intermediates as native doubles while materializing Python floats at object boundaries.
- Expand specialized float arithmetic helpers to cover ordered Python/native operand combinations and native or object results while preserving evaluation order and floating-point rounding semantics.

Tests:
- Add regression coverage for arithmetic trees, rounding and numeric edge cases, evaluation order, exception behavior, and object boundaries.
- Add code-generation analysis cases and benchmark fixtures for float expression chains and comparison controls.