### PR TITLE
Fix: Allow str subclass keys in keyword argument unpacking

### DIFF
--- a/nuitka/tree/ComplexCallHelperFunctions.py
+++ b/nuitka/tree/ComplexCallHelperFunctions.py
@@ -2040,20 +2040,17 @@ def getFunctionCallHelperDictionaryUnpacking():
 
     update_body = (
         makeStatementConditional(
-            condition=ExpressionComparisonIsNot(
-                left=ExpressionBuiltinType1(
-                    value=ExpressionTempVariableRef(
-                        variable=tmp_key_variable, source_ref=internal_source_ref
-                    ),
-                    source_ref=internal_source_ref,
+            condition=ExpressionBuiltinIsinstance(
+                instance=ExpressionTempVariableRef(
+                    variable=tmp_key_variable, source_ref=internal_source_ref
                 ),
-                right=makeExpressionBuiltinTypeRef(
+                classes=makeExpressionBuiltinTypeRef(
                     builtin_name="str", source_ref=internal_source_ref
                 ),
                 source_ref=internal_source_ref,
             ),
-            yes_branch=_makeRaiseNoStringItem(called_variable=called_variable),
-            no_branch=None,
+            yes_branch=None,
+            no_branch=_makeRaiseNoStringItem(called_variable=called_variable),
             source_ref=internal_source_ref,
         ),
         makeStatementConditional(

--- a/tests/basics/UnpackingTest35.py
+++ b/tests/basics/UnpackingTest35.py
@@ -17,11 +17,15 @@ def dictUnpacking():
     return {"a": 1, **d}
 
 
+def keywordTarget(**kwargs):
+    return kwargs
+
+
 def keywordUnpacking():
     class _Str(str):
         pass
 
-    return dict(**d, **{_Str("b"): 2})
+    return keywordTarget(**d, **{_Str("b"): 2})
 
 
 a = range(3)
@@ -69,7 +73,7 @@ def dictUnpackingError():
 
 def keywordUnpackingError():
     try:
-        return dict(**d, **{2: 2})
+        return keywordTarget(**d, **{2: 2})
     except Exception as e:
         return e
 

--- a/tests/basics/UnpackingTest35.py
+++ b/tests/basics/UnpackingTest35.py
@@ -17,6 +17,13 @@ def dictUnpacking():
     return {"a": 1, **d}
 
 
+def keywordUnpacking():
+    class _Str(str):
+        pass
+
+    return dict(**d, **{_Str("b"): 2})
+
+
 a = range(3)
 b = 5
 c = range(8, 10)
@@ -26,6 +33,7 @@ print("Tuple unpacked", tupleUnpacking())
 print("List unpacked", listUnpacking())
 print("Set unpacked", setUnpacking())
 print("Dict unpacked", dictUnpacking())
+print("Keyword unpacked", keywordUnpacking())
 
 
 non_iterable = 2.0
@@ -59,10 +67,18 @@ def dictUnpackingError():
         return e
 
 
+def keywordUnpackingError():
+    try:
+        return dict(**d, **{2: 2})
+    except Exception as e:
+        return e
+
+
 print("Tuple unpacked error:", tupleUnpackingError())
 print("List unpacked error:", listUnpackingError())
 print("Set unpacked error:", setUnpackingError())
 print("Dict unpacked error:", dictUnpackingError())
+print("Keyword unpacked error:", keywordUnpackingError())
 
 #     Python tests originally created or extracted from other peoples work. The
 #     parts were too small to be protected.


### PR DESCRIPTION
# Description

<!--
Thank you for contributing to Nuitka!
Before submitting a PR, please review the guidelines:
https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md
-->

## ❓ What does this PR do?

1. Fixes an inconsistency with CPython where Nuitka rejected str subclasses as keyword names during **dict unpacking in complex calls.
2. Added BasicTests for keyword argument unpacking with both str subclass keys (accepted) and non-string int keys (rejected).

## 🧐 Why was it initiated? Any relevant Issues?

Closes #4034 

## 🧱 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] 🧹 Refactoring (no functional changes, no api changes)
- [ ] 🏗️ Build / CI System
- [ ] 📚 Documentation Update

## ✅ PR Checklist

- [x] **Correct base branch selected**: Should be `develop` branch.
- [x] **Formatting**: Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [x] **Tests**: All tests still pass. (See
  [Running the Tests](https://nuitka.net/doc/developer-manual.html#running-the-tests)).
  - CI actions cover the basics, but manual verification is encouraged.
- [x] **New Coverage**: New features or fixed regressions are covered via new tests.
- [ ] **Documentation**: Documentation updates are included for new or changed features.

## 🤖 AI Generated Code Policy

- [ ] **Detection**: This PR contains AI generated code.
  - **Model/Provider**: \<model name and provider, e.g. V4pro / DeepSeek>
  - [ ] **Issue First**: I have created an issue explaining the problem *before* using AI to
    generate a fix, ensuring the direction is correct.
  - [ ] **Documentation**: I have provided the prompts used to generate the code (non-optional).
  - [ ] **Verification**: I have **manually verified** the AI generated code.
    > **Note**: AI generated code is welcome, but it must be peer-reviewed and understood by the
    > submitter. Blindly copying AI output without understanding is not acceptable.
  - [ ] **Evidence**: I have included test evidence that the change is effective.

______________________________________________________________________

<!--
Note: The Nuitka team will review your PR. If you are unsure about something, ask in the comments!
-->

## Summary by Sourcery

Accept string subclass keys in unpacked keyword arguments while preserving errors for non-string keys.

Bug Fixes:
- Allow string subclasses as keyword names during dictionary unpacking in complex calls, matching CPython behavior.

Tests:
- Add coverage for accepting string subclass keys and rejecting non-string keys in unpacked keyword arguments.